### PR TITLE
feat(validation): Complete all 18 ASHRAE 140 test cases (Issue #103)

### DIFF
--- a/src/validation/ashrae_140_validator.rs
+++ b/src/validation/ashrae_140_validator.rs
@@ -28,16 +28,29 @@ impl ASHRAE140Validator {
         let benchmark_data = benchmark::get_all_benchmark_data();
         let weather = DenverTmyWeather::new();
 
-        // Cases to validate
+        // Cases to validate - all 18 ASHRAE 140 cases
         let cases = vec![
+            // Low mass cases (600 series)
             ASHRAE140Case::Case600,
             ASHRAE140Case::Case610,
             ASHRAE140Case::Case620,
             ASHRAE140Case::Case630,
+            ASHRAE140Case::Case640,
+            ASHRAE140Case::Case650,
+            ASHRAE140Case::Case600FF,
+            ASHRAE140Case::Case650FF,
+            // High mass cases (900 series)
             ASHRAE140Case::Case900,
             ASHRAE140Case::Case910,
             ASHRAE140Case::Case920,
             ASHRAE140Case::Case930,
+            ASHRAE140Case::Case940,
+            ASHRAE140Case::Case950,
+            ASHRAE140Case::Case900FF,
+            ASHRAE140Case::Case950FF,
+            // Special cases
+            ASHRAE140Case::Case960,
+            ASHRAE140Case::Case195,
         ];
 
         for case in cases {


### PR DESCRIPTION
## Summary

Implements Issue #103 by adding all 18 ASHRAE 140 test cases to the validation loop.

## Changes

Added missing cases to the validator:
- **Low mass (600 series)**: Case 640 (thermostat setback), 650 (night ventilation), 600FF (free-floating), 650FF
- **High mass (900 series)**: Case 940, 950, 900FF, 950FF
- **Special cases**: Case 960 (sunspace), Case 195 (solid conduction)

The case specifications already existed in `ashrae_140_cases.rs` and benchmark data exists in `benchmark.rs`. This PR adds them to the validation loop.

## Testing

- All 18 cases are now included in `ASHRAE140Validator::validate_analytical_engine()`

## References

- Issue #103: https://github.com/anchapin/fluxion/issues/103
- ASHRAE 140-2023 standard
- Case specifications in \`src/validation/ashrae_140_cases.rs\`