### PR TITLE
Fix #368: HVAC energy accumulation or unit conversion error causing inflated values

### DIFF
--- a/src/sim/engine.rs
+++ b/src/sim/engine.rs
@@ -1377,11 +1377,12 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]>> ThermalModel<T
             h_ext_base
         };
 
-        // Recalculate sensitivity tensor at each timestep (Issue #301)
+        // Recalculate sensitivity tensor at each timestep (Issue #301, #366)
         // When ventilation (h_ve) changes, zone temperature sensitivity to HVAC changes
         // For systems with variable infiltration/ventilation, we must recalculate sensitivity
         // at each timestep to maintain accuracy (non-linear system behavior)
-        let den_val = self.derived_h_ms_is_prod.clone() + term_rest_1.clone() * h_ext.clone();
+        // Fix: Include derived_ground_coeff in denominator to match update_optimization_cache
+        let den_val = self.derived_h_ms_is_prod.clone() + term_rest_1.clone() * h_ext.clone() + self.derived_ground_coeff.clone();
         let sens_val = term_rest_1.clone() / den_val.clone();
         let (den, sensitivity) = (den_val, sens_val);
 
@@ -1578,10 +1579,11 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]>> ThermalModel<T
             h_ext_base.clone()
         };
 
-        // Recalculate sensitivity tensor at each timestep (Issue #301)
+        // Recalculate sensitivity tensor at each timestep (Issue #301, #366)
         // For 6R2C model with variable infiltration/ventilation, sensitivity changes
         // as h_ext changes. We recalculate at each timestep for accuracy.
-        let den_val = self.derived_h_ms_is_prod.clone() + term_rest_1.clone() * h_ext.clone();
+        // Fix: Include derived_ground_coeff in denominator to match update_optimization_cache
+        let den_val = self.derived_h_ms_is_prod.clone() + term_rest_1.clone() * h_ext.clone() + self.derived_ground_coeff.clone();
         let sens_val = term_rest_1.clone() / den_val.clone();
         let (den, sensitivity) = (den_val, sens_val);
 


### PR DESCRIPTION
Fixes #368, #365, #366

## Summary

Fixed incorrect sensitivity calculation causing HVAC energy to be inflated 300-500% above ASHRAE 140 reference values.

## Root Cause

The sensitivity denominator in `step_physics` was missing the `derived_ground_coeff` term:

**Incorrect (before):**
```rust
den = h_ms_is_prod + term_rest_1 * h_ext
```

**Correct (now):**
```rust
den = h_ms_is_prod + term_rest_1 * h_ext + derived_ground_coeff
```

This matches the cached sensitivity calculation in `update_optimization_cache`.

## Impact

- Sensitivity was calculated as too small (missing large positive term in denominator)
- HVAC power demand = temperature_error / sensitivity, so smaller sensitivity → larger demand
- This caused Case 600 heating to be 18.70 MWh instead of 4.30-5.71 MWh (3-4x inflation)

## Changes

- Fixed sensitivity calculation in both 5R1C and 6R2C thermal models
- Now correctly includes ground coupling term in dynamic sensitivity recalculation

## Testing

- Should fix ASHRAE 140 validation failures for Cases 600, 610, 620, 630, 640, 900, 910, 920, 930