### PR TITLE
Feat #360: Add beam vs diffuse radiation separation in solar module

### DIFF
--- a/src/sim/engine.rs
+++ b/src/sim/engine.rs
@@ -1809,7 +1809,7 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]>> ThermalModel<T
         let mut total_solar_gain = 0.0;
         for &orientation in orientations {
             // Use solar module to calculate gain for this orientation
-            let (_sun_pos, _irradiance, solar_gain_watts) = calculate_hourly_solar(
+            let (_sun_pos, _irradiance, solar_gain) = calculate_hourly_solar(
                 self.latitude_deg,
                 self.longitude_deg,
                 year,
@@ -1825,8 +1825,7 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]>> ThermalModel<T
                 orientation,
                 Some(0.2), // Ground reflectance
             );
-
-            total_solar_gain += solar_gain_watts;
+            total_solar_gain += solar_gain.total_gain_w;
         }
 
         total_solar_gain

--- a/src/validation/ashrae_140/case_600.rs
+++ b/src/validation/ashrae_140/case_600.rs
@@ -204,7 +204,7 @@ impl Case600Model {
             let dhi = weather_data.dhi;
 
             // Calculate solar gain through south window
-            let (_, _, solar_gain_watts) = calculate_hourly_solar(
+            let (_, _, solar_gain) = calculate_hourly_solar(
                 39.7392,                       // Denver latitude (°N)
                 -104.9903,                     // Denver longitude (°W)
                 2024,                          // Year
@@ -224,10 +224,10 @@ impl Case600Model {
             // Calculate total internal loads (W)
             // Internal gains: 200W continuous (60% radiative, 40% convective)
             let internal_gains = 200.0;
-            let total_loads = internal_gains + solar_gain_watts;
+            let total_loads = internal_gains + solar_gain.total_gain_w;
 
             // Store solar gain for analysis
-            hourly_solar.push(solar_gain_watts);
+            hourly_solar.push(solar_gain.total_gain_w);
 
             // Set loads for this timestep (W/m²)
             let load_per_area = total_loads / 48.0; // 48 m² floor area

--- a/src/validation/ashrae_140_validator.rs
+++ b/src/validation/ashrae_140_validator.rs
@@ -496,7 +496,7 @@ impl ASHRAE140Validator {
                         win_area.orientation,
                         Some(0.2),
                     );
-                    total_solar_gain_per_zone[zone_idx] += gain;
+                    total_solar_gain_per_zone[zone_idx] += gain.total_gain_w;
                 }
 
                 // Opaque solar gains
@@ -963,7 +963,7 @@ impl ASHRAE140Validator {
                         win_area.orientation,
                         Some(0.2),
                     );
-                    total_solar_gain_per_zone[zone_idx] += gain;
+                    total_solar_gain_per_zone[zone_idx] += gain.total_gain_w;
                 }
 
                 // --- Opaque Solar Gains (Walls + Roof) ---
@@ -1231,7 +1231,7 @@ impl ASHRAE140Validator {
                         win_area.orientation,
                         Some(0.2),
                     );
-                    total_solar_gain_per_zone[zone_idx] += gain;
+                    total_solar_gain_per_zone[zone_idx] += gain.total_gain_w;
                 }
 
                 // Opaque Solar Gains
@@ -1536,7 +1536,7 @@ impl ASHRAE140Validator {
                         win_area.orientation,
                         Some(0.2),
                     );
-                    total_solar_gain_per_zone[zone_idx] += gain;
+                    total_solar_gain_per_zone[zone_idx] += gain.total_gain_w;
                 }
 
                 // Opaque solar gains


### PR DESCRIPTION
Closes #360

## Changes
- Added new  structure to separate beam, diffuse, and ground-reflected solar gain components
- Modified  to return  instead of a single f64 value
- Updated  to return 
- Updated all callers to use  for total solar gain

## Implementation Details
- Beam gain: Direct solar radiation through window, affected by shading and incidence angle
- Diffuse gain: Scattered radiation from sky, uses constant diffuse SHGC
- Ground-reflected gain: Radiation reflected from ground, uses constant diffuse SHGC

## ASHRAE 140 Impact
This is the foundation for Issue #297 (Geometric Solar Distribution - Beam-to-Floor Logic). ASHRAE 140 Case 960 reference data shows that beam radiation primarily affects floor mass, while diffuse radiation is more evenly distributed.

## Testing
- All existing tests pass
- Verified compatibility with existing code by using  property for backward compatibility