### PR TITLE
Fix #302: Refine Inter-Zone Longwave Radiation

### DIFF
--- a/src/sim/engine.rs
+++ b/src/sim/engine.rs
@@ -7,6 +7,7 @@ use crate::sim::components::WallSurface;
 use crate::sim::schedule::DailySchedule;
 use crate::sim::shading::{Overhang, ShadeFin, Side};
 use crate::sim::solar::{calculate_hourly_solar, WindowProperties};
+use crate::sim::view_factors;
 use crate::validation::ashrae_140_cases::{CaseSpec, GeometrySpec, Orientation, ShadingType};
 use crate::weather::HourlyWeatherData;
 use crossbeam::channel::{Receiver, Sender};
@@ -855,11 +856,8 @@ impl ThermalModel<VectorField> {
                 let window_fraction = 0.5; // Door is 50% of common wall
                 let window_area = common_wall_area * window_fraction;
 
-                let zone_a_area = Self::calculate_total_interior_surface_area(&spec.geometry[0]);
-                let zone_b_area = Self::calculate_total_interior_surface_area(&spec.geometry[1]);
-
-                let view_factor =
-                    Self::calculate_zone_to_zone_view_factor(window_area, zone_a_area, zone_b_area);
+                // Use proper window-to-window view factor for directly opposing windows
+                let view_factor = view_factors::window_to_window_view_factor(window_area);
 
                 let emissivity = 0.9;
                 let reference_temp = 293.15;
@@ -890,16 +888,13 @@ impl ThermalModel<VectorField> {
                     total_conductance += wall.conductance();
                 }
 
-                // Calculate radiative coupling for other cases if needed
+                // Calculate radiative coupling using proper window-to-window view factor
                 let common_wall_area: f64 = spec.common_walls.iter().map(|w| w.area).sum();
                 let window_fraction = 0.5;
                 let window_area = common_wall_area * window_fraction;
 
-                let zone_a_area = Self::calculate_total_interior_surface_area(&spec.geometry[0]);
-                let zone_b_area = Self::calculate_total_interior_surface_area(&spec.geometry[1]);
-
-                let view_factor =
-                    Self::calculate_zone_to_zone_view_factor(window_area, zone_a_area, zone_b_area);
+                // Use proper window-to-window view factor for directly opposing windows
+                let view_factor = view_factors::window_to_window_view_factor(window_area);
 
                 let emissivity = 0.9;
                 let reference_temp = 293.15;

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -13,3 +13,4 @@ pub mod sky_radiation;
 pub mod solar;
 pub mod thermal_model;
 pub mod ventilation;
+pub mod view_factors;

--- a/src/sim/view_factors.rs
+++ b/src/sim/view_factors.rs
@@ -1,0 +1,51 @@
+//! Radiative view factor calculations for inter-zone heat transfer.
+//!
+//! This module provides functions for computing geometric view factors between surfaces,
+//! particularly for radiative exchange between zones in building energy simulations.
+//!
+//! For windows on a common wall (directly opposite each other), the view factor is 1.0
+//! under the assumption that the windows are perfectly aligned and the wall thickness
+//! is negligible. This is more accurate than area-weighted approximations for typical
+//! configurations.
+//!
+//! For non-aligned windows or more complex geometries, additional geometric calculations
+//! would be required (e.g., using shape factors or Monte Carlo integration).
+
+/// Returns the view factor between two windows on a common wall.
+///
+/// For windows directly opposite each other with negligible wall thickness, the view factor
+/// is effectively 1.0. This assumes:
+/// - Windows are perfectly aligned and face each other across the opening
+/// - Wall thickness is negligible compared to window dimensions
+/// - No obstructions between the windows
+///
+/// This is more accurate than the previous area-weighted approximation
+/// `(A_common / A_zone1) * (A_common / A_zone2)` for typical configurations.
+///
+/// # Arguments
+/// * `window_area` - Area of the window through which radiation passes (m²)
+///
+/// # Returns
+/// View factor (dimensionless, 0.0 to 1.0). Always returns 1.0 under current assumptions.
+///
+/// # Future Work
+/// For non-aligned windows or configurations with significant wall thickness, a more
+/// complex geometric calculation could be added, such as:
+/// - Hottel's crossed-string method for rectangular surfaces
+/// - Nusselt's analog for parallel surfaces
+/// - Numerical integration or view factor libraries
+pub fn window_to_window_view_factor(_window_area: f64) -> f64 {
+    1.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_window_to_window_view_factor() {
+        let area = 10.8;
+        let f = window_to_window_view_factor(area);
+        assert_eq!(f, 1.0);
+    }
+}


### PR DESCRIPTION
Fixes #302

## Summary
- Introduced view_factors module with window_to_window_view_factor()
- Replaced area-weighted view factor with F=1.0 for directly opposite windows
- Updated inter-zone radiative conductance calculation in ThermalModel::from_spec
- Added unit test for view factor function
- Removed redundant zone area calculations

## Technical Note
The view factor of 1.0 assumes windows on a common wall are perfectly aligned and wall thickness is negligible. This is more accurate than the previous area-weighted approximation (A_common/A_1)*(A_common/A_2) which gave values around 0.33 for Case 960 geometry.