### PR TITLE
fix(ci): Add missing tags configuration to multi-platform Docker job (Issue #438)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -117,6 +117,11 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=sha
 
       - name: Build and push multi-platform image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## Summary

The Docker Build & Push GitHub Actions workflow was failing with a 'manifest unknown' error. 

## Root Cause

The  job in  was missing the  configuration in the  step. While the  job had proper tag configuration:

```yaml
tags: |
  type=ref,event=branch
  type=ref,event=pr
  type=semver,pattern={{version}}
  type=sha
```

The  job only had:

```yaml
images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
```

This caused the metadata action to not generate proper tags (SHA, branch, semver) for multi-platform images, leading to 'manifest unknown' errors when pushing or pulling the images.

## Fix

Added the same tags configuration to the multi-platform job:



This ensures consistent tag generation across both jobs and should resolve the manifest unknown error.

## Testing

This fix needs to be merged and the Docker workflow triggered to verify the fix works correctly.

## Summary by Sourcery

CI:
- Add missing tag configuration to the multi-platform Docker metadata step so images receive branch, PR, semver, and SHA tags consistently.