### PR TITLE
fix(ci): Add --pull=never to docker run commands in smoke tests

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -70,7 +70,7 @@ jobs:
         if: github.event_name != 'pull_request'
         run: |
           # Start container in background
-          docker run -d --name fluxion-test ${{ steps.meta.outputs.tags }} sleep 30
+          docker run -d --name fluxion-test --pull=never ${{ steps.meta.outputs.tags }} sleep 30
           
           # Wait for container to start
           sleep 5
@@ -85,7 +85,7 @@ jobs:
       - name: Run integration tests
         if: github.event_name != 'pull_request'
         run: |
-          docker run --rm ${{ steps.meta.outputs.tags }} python -c "import fluxion; print('Fluxion import successful')"
+          docker run --rm --pull=never ${{ steps.meta.outputs.tags }} python -c "import fluxion; print('Fluxion import successful')"
 
   # Multi-platform build
   multi-platform:


### PR DESCRIPTION
The build-and-test job builds the Docker image with push: false, so the image
only exists locally. However, the smoke test steps try to run the container
using tags that include the registry path (e.g., ghcr.io/repo:sha-xxxx), which
causes Docker to attempt pulling from the registry, resulting in 'manifest
unknown' error.

This fix adds --pull=never to both docker run commands in the smoke test and
integration test steps, instructing Docker to use the locally-built image
without attempting to pull from the registry.

Fixes #438