### PR TITLE
⚡ Bolt: [performance improvement] Optimize hvac_power_demand loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -11,3 +11,6 @@
 ## 2024-11-13 - [Optimize Hot Loop Memory Allocations]
 **Learning:** In hot loops, chaining operations on tensors (like `VectorField * scalar * scalar`) creates redundant intermediate vector allocations and causes a measurable slowdown. Calculating combined scalar terms before multiplying the `VectorField` minimizes the allocations needed per iteration.
 **Action:** When working with math routines in `ThermalModel::step_physics`, algebraically group scalars out of vector operations beforehand to minimize the number of `VectorField` instantiations in inner loops.
+## 2024-11-14 - [Optimize HVAC Power Demand Loop]
+**Learning:** Found that `hvac_power_demand` in `src/sim/engine.rs` was iterating over `demand_vec` twice: once to calculate the power demand and push to the vector, and a second time to multiply by `hvac_enabled`. It was also performing calculations even when the HVAC system was disabled.
+**Action:** Merged the loops to apply the `hvac_enabled` multiplier during the initial calculation. Added a fast-path to immediately push 0.0 and `continue` if the HVAC system is disabled for the current zone, avoiding unnecessary floating point divisions and clamp operations.

--- a/src/sim/engine.rs
+++ b/src/sim/engine.rs
@@ -3025,7 +3025,7 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
     ///
     /// # Returns
     /// A tensor representing the HVAC power (heating is positive, cooling is negative).
-    fn hvac_power_demand(&self, hour: usize, t_i_free: &T, sensitivity: &T) -> T {
+    fn hvac_power_demand(&self, _hour: usize, t_i_free: &T, sensitivity: &T) -> T {
         // Use direct setpoints for HVAC control (updated by validation loop each hour)
         // This ensures per-hour setpoint changes from validation loop are respected
         let heating_setpoint = self.heating_setpoint;
@@ -3035,40 +3035,34 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
         let t_vec = t_i_free.as_ref();
         let sens_vec = sensitivity.as_ref();
 
+        let enabled_vec = self.hvac_enabled.as_ref();
+
         // Compute HVAC demand per zone
         let mut demand_vec = Vec::with_capacity(self.num_zones);
         for i in 0..self.num_zones {
+            let enabled = enabled_vec[i];
+
+            // Fast path: if HVAC is disabled, zero power
+            if enabled == 0.0 {
+                demand_vec.push(0.0);
+                continue;
+            }
+
             let t = t_vec[i];
 
             // Determine HVAC mode based on time-varying setpoints
             let power = if t < heating_setpoint {
                 // Heating mode
                 // Use the full HVAC capacity for heating (no artificial limit)
-                ((heating_setpoint - t) / sens_vec[i]).clamp(0.0, self.hvac_heating_capacity)
+                ((heating_setpoint - t) / sens_vec[i]).clamp(0.0, self.hvac_heating_capacity) * enabled
             } else if t >= cooling_setpoint {
                 // Cooling mode (provide cooling when at or above setpoint)
-                ((cooling_setpoint - t) / sens_vec[i]).clamp(-self.hvac_cooling_capacity, 0.0)
+                ((cooling_setpoint - t) / sens_vec[i]).clamp(-self.hvac_cooling_capacity, 0.0) * enabled
             } else {
                 // Off/deadband
                 0.0
             };
             demand_vec.push(power);
-        }
-
-        // Convert back to T and apply per-zone HVAC enable flag
-        // Multiply in place to avoid an extra VectorField allocation
-        let enabled_vec = self.hvac_enabled.as_ref();
-        for (power, &enabled) in demand_vec.iter_mut().zip(enabled_vec.iter()) {
-            *power *= enabled;
-        }
-
-        // Debug: Print HVAC demand for Case 600
-        if self.case_id == "600" && hour == 12 {
-            let temp_diff = cooling_setpoint - t_vec[0];
-            let raw_power = temp_diff / sens_vec[0];
-            let clamped_power = raw_power.clamp(-self.hvac_cooling_capacity, 0.0);
-            println!("DEBUG HVAC Case 600 hour {}: t={:.2}°C, cooling_sp={:.1}°C, sens={:.6} K/W, cap={:.2}W, diff={:.2}K, raw={:.2}W, clamped={:.2}W, enabled={}, final={:.2}W",
-                hour, t_vec[0], cooling_setpoint, sens_vec[0], self.hvac_cooling_capacity, temp_diff, raw_power, clamped_power, enabled_vec[0], demand_vec[0]);
         }
 
         T::from(VectorField::new(demand_vec))


### PR DESCRIPTION
💡 What: Merged the two loops in `hvac_power_demand` that calculated heating/cooling power and then multiplied by the `hvac_enabled` flag respectively. Also added a fast path where an inactive HVAC skips division and calculation operations.
🎯 Why: Iterating over intermediate vectors in hot loops creates CPU overhead. Also performing complex conditional logic when `enabled == 0.0` creates unnecessary CPU pressure. 
📊 Impact: Less overhead in calculation loops per step (saves an O(n) pass).
🔬 Measurement: Verify via `benches/engine_bench.rs` and the codebase's normal behavior tests.

---
*PR created automatically by Jules for task [11020034738110327641](https://jules.google.com/task/11020034738110327641) started by @anchapin*

## Summary by Sourcery

Optimize HVAC power demand computation to reduce per-step overhead in the simulation engine.

Enhancements:
- Combine HVAC power demand computation and enable-flag application into a single loop with a fast path when HVAC is disabled for a zone.
- Remove now-unnecessary debug logging tied to specific case and hour in the HVAC power demand calculation.
- Mark the hour parameter as unused in the HVAC power demand helper to reflect current behavior.

Documentation:
- Extend internal Bolt notes with guidance on optimizing the HVAC power demand loop to avoid redundant iterations and unnecessary calculations.