### PR TITLE
Fix performance_example.rs compilation errors

### DIFF
--- a/examples/performance_example.rs
+++ b/examples/performance_example.rs
@@ -1,0 +1,43 @@
+use fluxion::validation::performance::reports::PerformanceMetrics;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("Fluxion Performance Validation Examples");
+    println!("======================================\n");
+
+    example_performance_metrics_demo()?;
+
+    Ok(())
+}
+
+fn example_performance_metrics_demo() -> Result<(), Box<dyn std::error::Error>> {
+    println!("Example: Performance Metrics Structure");
+    println!("---------------------------------");
+
+    let metrics = PerformanceMetrics {
+        timestep_duration_ms: 45.2,
+        memory_usage_bytes: 8_500_000,
+        iterations_per_timestep: 15,
+        cpu_utilization: 0.0,
+        throughput_tps: 0.0,
+        zone_coupling_time_ms: 0.0,
+    };
+
+    println!("Performance Metrics:");
+    println!(
+        "  Timestep Duration: {:.3} ms",
+        metrics.timestep_duration_ms
+    );
+    println!("  Memory Usage: {} bytes", metrics.memory_usage_bytes);
+    println!("  Solver Iterations: {}", metrics.iterations_per_timestep);
+    println!(
+        "  Status: {}",
+        if metrics.timestep_duration_ms < 50.0 {
+            "PASS"
+        } else {
+            "WARN"
+        }
+    );
+    println!();
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes 6 compilation errors in the Cross-Validation CI:

- examples/performance_example.rs: Uses incorrect import path `fluxion::validation::performance::PerformanceMetrics` instead of `fluxion::validation::performance::reports::PerformanceMetrics`
- Field type mismatches: uses Duration instead of f64 for timestep_duration_ms and zone_coupling_time_ms
- Field name mismatch: uses memory_usage instead of memory_usage_bytes

This example was causing the Cross-Validation Tests check to fail.

## Summary by Sourcery

New Features:
- Introduce a performance example binary demonstrating construction and printing of PerformanceMetrics values.