### PR TITLE
Fix cooling load calculation to use actual zone properties (Vibe Kanban)

### DIFF
--- a/src/sim/engine.rs
+++ b/src/sim/engine.rs
@@ -12,7 +12,7 @@ use crate::sim::components::WallSurface;
 use crate::sim::equipment::Equipment;
 use crate::sim::holiday;
 use crate::sim::hvac::{
-    AnyEquipment, CyclingTracker, EconomizerMode, HVACMode as EquipmentHVACMode,
+    AnyEquipment, CyclingTracker, EconomizerMode, HVACMode as EquipmentHVACMode, IdealLoadsSystem,
     PredictiveController, VariableCapacityEquipment,
 };
 use crate::sim::interzone::{calculate_stack_effect_ach, calculate_ventilation_heat_transfer};
@@ -500,6 +500,12 @@ pub struct ThermalModel<T: ContinuousTensor<f64>> {
     /// - No curve fitting or artificial delays
     pub ideal_air_loads_mode: bool,
 
+    /// IdealLoadsSystem for calculating HVAC loads using proper thermodynamic formulas.
+    /// Uses mass_flow * cp * delta_t instead of sensitivity-based calculation.
+    /// Initialized with zone volume and infiltration rate from geometry.
+    /// One per zone for multi-zone support.
+    pub ideal_loads_system: Vec<Option<IdealLoadsSystem>>,
+
     // CTF (Conduction Transfer Function) solver for high-mass walls (Phase 28)
     /// CTF coefficients for each wall construction (precomputed during initialization)
     pub ctf_coefficients: Option<CTFCoefficients>,
@@ -804,6 +810,9 @@ impl<T: ContinuousTensor<f64> + Clone> Clone for ThermalModel<T> {
 
             // Variable capacity HVAC equipment (Plan 15-06)
             hvac_equipment: self.hvac_equipment.clone(),
+
+            // IdealLoadsSystem for thermodynamic HVAC load calculation (Issue #521)
+            ideal_loads_system: self.ideal_loads_system.clone(),
 
             // Door geometry for temperature-dependent inter-zone air exchange
             door_geometry: self.door_geometry,
@@ -2318,6 +2327,14 @@ impl ThermalModel<VectorField> {
         // This is required for Cases 800-810 (HVAC equipment cases)
         model.hvac_equipment = spec.hvac_equipment.clone();
 
+        // Initialize IdealLoadsSystem with zone properties from geometry (Issue #521)
+        // Create one IdealLoadsSystem per zone with that zone's volume
+        let zone_vols = model.zone_volume.as_ref();
+        model.ideal_loads_system = zone_vols
+            .iter()
+            .map(|&vol| Some(IdealLoadsSystem::new(vol, spec.infiltration_ach)))
+            .collect();
+
         model
     }
 
@@ -2791,6 +2808,10 @@ impl ThermalModel<VectorField> {
 
             // Variable capacity HVAC equipment (Plan 15-06)
             hvac_equipment: None, // Default to no equipment (uses IdealHVACController)
+
+            // IdealLoadsSystem for proper thermodynamic HVAC load calculation (Issue #521)
+            // Initialized with zone properties from geometry when setting up from spec
+            ideal_loads_system: vec![], // Will be populated by from_spec() with one per zone
 
             // Door geometry for temperature-dependent inter-zone air exchange (stack effect)
             door_geometry: DoorGeometry::default(),

--- a/src/sim/engine.rs
+++ b/src/sim/engine.rs
@@ -3434,6 +3434,51 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
         T::from(VectorField::new(demand_vec))
     }
 
+    /// Calculate HVAC power demand using IdealLoadsSystem thermodynamic formulas.
+    ///
+    /// This replaces the sensitivity-based `(setpoint - temp) / sensitivity` formula
+    /// with proper ideal loads physics: `mass_flow * cp * delta_t`.
+    ///
+    /// Returns a VectorField of power values:
+    /// - Positive = heating demand (W)
+    /// - Negative = cooling demand (W)
+    ///
+    /// # Arguments
+    /// * `zone_temps` - Current zone temperatures (°C)
+    /// * `heating_setpoint` - Single heating setpoint (°C) applied to all zones
+    /// * `cooling_setpoint` - Single cooling setpoint (°C) applied to all zones
+    fn hvac_demand_from_ideal_loads(
+        &self,
+        zone_temps: &[f64],
+        heating_setpoint: f64,
+        cooling_setpoint: f64,
+    ) -> T {
+        let enabled_vec = self.hvac_enabled.as_ref();
+
+        let heating_vec = vec![heating_setpoint; self.num_zones];
+        let cooling_vec = vec![cooling_setpoint; self.num_zones];
+
+        let mut combined_demand = vec![0.0; self.num_zones];
+        for (zone_idx, opt_system) in self.ideal_loads_system.iter().enumerate() {
+            if let Some(ref system) = opt_system {
+                let zone_temps_slice = &zone_temps[zone_idx..zone_idx + 1];
+                let heating_slice = &heating_vec[zone_idx..zone_idx + 1];
+                let cooling_slice = &cooling_vec[zone_idx..zone_idx + 1];
+                let enabled_slice = &enabled_vec[zone_idx..zone_idx + 1];
+
+                let demands = system.calculate_power_demand_vector(
+                    zone_temps_slice,
+                    heating_slice,
+                    cooling_slice,
+                    enabled_slice,
+                );
+                combined_demand[zone_idx] = demands[0];
+            }
+        }
+
+        T::from(VectorField::new(combined_demand))
+    }
+
     /// Core physics simulation loop for annual building energy performance.
     ///
     /// Simulates hourly thermal dynamics using batched inference with a coordinator.
@@ -4231,9 +4276,13 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
 
             // FIX: For multi-zone buildings (e.g., Case 960), use per-zone HVAC demand
             // instead of broadcasting a single scalar value to all zones.
-            // Use hvac_power_demand which calculates per-zone values based on each zone's
-            // free-floating temperature and setpoint.
-            let hvac_output = self.hvac_power_demand(hour_of_day_idx, &t_i_free, &sensitivity_val);
+            // Use IdealLoadsSystem thermodynamic formulas (mass_flow * cp * delta_t)
+            // instead of sensitivity-based (setpoint - temp) / sensitivity
+            let hvac_output = self.hvac_demand_from_ideal_loads(
+                t_i_free.as_ref(),
+                heating_setpoint,
+                cooling_setpoint,
+            );
 
             // Track peak heating/cooling based on per-zone HVAC demand (Plan 18-08)
             // TASK 2: Apply direct calibration factor for high-mass cases

--- a/src/sim/engine.rs
+++ b/src/sim/engine.rs
@@ -4341,9 +4341,19 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
             // so it needs to be returned for both branches
             hvac_output
         } else {
-            // Fallback to IdealHVACController when no equipment attached
-            let hvac_output_raw =
-                self.hvac_power_demand(hour_of_day_idx, &t_i_free, &sensitivity_val);
+            // Fallback: Use IdealLoadsSystem thermodynamic formulas if available,
+            // otherwise use sensitivity-based hvac_power_demand
+            let hvac_output_raw = if self.ideal_loads_system.iter().any(|opt| opt.is_some()) {
+                // ideal_loads_system is initialized - use thermodynamic formulas
+                self.hvac_demand_from_ideal_loads(
+                    t_i_free.as_ref(),
+                    self.heating_setpoint,
+                    self.cooling_setpoint,
+                )
+            } else {
+                // ideal_loads_system not initialized - fall back to sensitivity-based
+                self.hvac_power_demand(hour_of_day_idx, &t_i_free, &sensitivity_val)
+            };
 
             // Track peak heating/cooling based on actual HVAC demand (only if not already tracked above)
             if self.hvac_equipment.is_none() {

--- a/src/sim/hvac/ideal_loads.rs
+++ b/src/sim/hvac/ideal_loads.rs
@@ -448,10 +448,14 @@ impl IdealLoadsSystem {
                 self.air_changes_per_hour,
             );
 
-            let thermal_load = if cooling_load > heating_load {
-                cooling_load
-            } else {
+            let thermal_load = if cooling_load > 0.0 && cooling_load >= heating_load {
+                // Cooling mode: return negative to indicate heat removal
+                -cooling_load
+            } else if heating_load > 0.0 {
+                // Heating mode: return positive
                 heating_load
+            } else {
+                0.0
             };
             demand_vec.push(thermal_load)
         }

--- a/src/sim/hvac/ideal_loads.rs
+++ b/src/sim/hvac/ideal_loads.rs
@@ -253,7 +253,7 @@ impl SimpleHVACEquipment {
     pub fn with_custom_cop(cop: f64, efficiency: f64) -> Self {
         Self {
             cooling_cop: cop,
-            heating_efficiency: efficiency.max(0.1).min(1.0), // Clamp to reasonable range
+            heating_efficiency: efficiency.clamp(0.1, 1.0), // Clamp to reasonable range
             equipment_name: "Custom".to_string(),
         }
     }
@@ -422,26 +422,24 @@ impl IdealLoadsSystem {
         let n = zone_temps.len();
         let mut demand_vec = Vec::with_capacity(n);
 
-        for i in 0..n {
+        for (i, zone_temp) in zone_temps.iter().enumerate().take(n) {
             let enabled = hvac_enabled.get(i).copied().unwrap_or(1.0);
             if enabled < 0.5 {
                 demand_vec.push(0.0);
                 continue;
             }
-
-            let zone_temp = zone_temps[i];
             let heating_sp = heating_setpoints.get(i).copied().unwrap_or(20.0);
             let cooling_sp = cooling_setpoints.get(i).copied().unwrap_or(24.0);
 
             let cooling_load = ZoneIdealLoads::calculate_sensible_cooling_load(
-                zone_temp,
+                *zone_temp,
                 cooling_sp,
                 self.supply_cooling_temp,
                 self.zone_volume,
                 self.air_changes_per_hour,
             );
             let heating_load = ZoneIdealLoads::calculate_sensible_heating_load(
-                zone_temp,
+                *zone_temp,
                 heating_sp,
                 self.supply_heating_temp,
                 self.zone_volume,

--- a/src/sim/hvac/ideal_loads.rs
+++ b/src/sim/hvac/ideal_loads.rs
@@ -95,6 +95,8 @@ impl ZoneIdealLoads {
     /// * `zone_temp` - Current zone air temperature (°C)
     /// * `cooling_setpoint` - Cooling setpoint temperature (°C)
     /// * `supply_air_temp` - Supply air temperature from HVAC (°C), typically 13°C for cooling
+    /// * `zone_volume` - Zone volume in cubic meters (m³)
+    /// * `air_changes_per_hour` - Ventilation air changes per hour (ACH)
     ///
     /// # Returns
     /// Sensible cooling load in watts (positive when zone needs cooling)
@@ -102,28 +104,22 @@ impl ZoneIdealLoads {
         zone_temp: f64,
         cooling_setpoint: f64,
         supply_air_temp: f64,
+        zone_volume: f64,
+        air_changes_per_hour: f64,
     ) -> f64 {
-        // Only calculate if zone temperature is above cooling setpoint
         if zone_temp <= cooling_setpoint {
             return 0.0;
         }
 
-        // Assume supply air is at cooling setpoint temperature (for ideal loads)
-        // In reality, supply might be 12-15°C, but ideal loads assumes perfect control
         let effective_supply = supply_air_temp.max(cooling_setpoint);
 
-        // Simple calculation: heat to remove = mass_flow * cp * delta_T
-        // Assume default air changes: 6 ACH (air changes per hour) for typical building
-        // Volume = 3m height * 100m² = 300 m³, ACH = 6 => 1800 m³/hr = 0.5 m³/s
-        let air_changes_per_hour = 6.0;
-        let zone_volume = 300.0; // m³ (assumed 100m² floor, 3m ceiling)
-        let airflow_m3s = zone_volume * air_changes_per_hour / 3600.0; // m³/s
+        let airflow_m3s = zone_volume * air_changes_per_hour / 3600.0;
 
-        let rho = 1.2; // kg/m³ (air density at sea level)
-        let cp = 1005.0; // J/kg·K (specific heat of air)
+        let rho = 1.2;
+        let cp = 1005.0;
 
-        let mass_flow = airflow_m3s * rho; // kg/s
-        let delta_t = (zone_temp - effective_supply).max(0.0); // K
+        let mass_flow = airflow_m3s * rho;
+        let delta_t = (zone_temp - effective_supply).max(0.0);
 
         mass_flow * cp * delta_t
     }
@@ -137,6 +133,8 @@ impl ZoneIdealLoads {
     /// * `zone_temp` - Current zone air temperature (°C)
     /// * `heating_setpoint` - Heating setpoint temperature (°C)
     /// * `supply_air_temp` - Supply air temperature from HVAC (°C), typically 40-50°C for heating
+    /// * `zone_volume` - Zone volume in cubic meters (m³)
+    /// * `air_changes_per_hour` - Ventilation air changes per hour (ACH)
     ///
     /// # Returns
     /// Sensible heating load in watts (positive when zone needs heating)
@@ -144,18 +142,15 @@ impl ZoneIdealLoads {
         zone_temp: f64,
         heating_setpoint: f64,
         supply_air_temp: f64,
+        zone_volume: f64,
+        air_changes_per_hour: f64,
     ) -> f64 {
-        // Only calculate if zone temperature is below heating setpoint
         if zone_temp >= heating_setpoint {
             return 0.0;
         }
 
-        // Assume supply air is at heating setpoint temperature (for ideal loads)
         let effective_supply = supply_air_temp.min(heating_setpoint);
 
-        // Same assumptions as cooling
-        let air_changes_per_hour = 6.0;
-        let zone_volume = 300.0;
         let airflow_m3s = zone_volume * air_changes_per_hour / 3600.0;
 
         let rho = 1.2;
@@ -303,6 +298,10 @@ pub struct IdealLoadsSystem {
     pub supply_cooling_temp: f64,
     /// Supply air temperature for heating (°C), typically 40°C
     pub supply_heating_temp: f64,
+    /// Zone volume in cubic meters (m³)
+    pub zone_volume: f64,
+    /// Ventilation air changes per hour (ACH)
+    pub air_changes_per_hour: f64,
 }
 
 impl Default for IdealLoadsSystem {
@@ -310,8 +309,10 @@ impl Default for IdealLoadsSystem {
         Self {
             zone_loads: ZoneIdealLoads::new(),
             equipment: SimpleHVACEquipment::new(),
-            supply_cooling_temp: 13.0, // Typical cooling supply
-            supply_heating_temp: 40.0, // Typical heating supply
+            supply_cooling_temp: 13.0,
+            supply_heating_temp: 40.0,
+            zone_volume: 129.6, // ASHRAE 140 standard zone volume (8m × 6m × 2.7m)
+            air_changes_per_hour: 0.5, // ASHRAE 140 standard infiltration rate
         }
     }
 }
@@ -329,6 +330,36 @@ impl IdealLoadsSystem {
             equipment,
             supply_cooling_temp: 13.0,
             supply_heating_temp: 40.0,
+            zone_volume: 129.6,
+            air_changes_per_hour: 0.5,
+        }
+    }
+
+    /// Create IdealLoadsSystem with zone properties
+    pub fn with_zone_properties(zone_volume: f64, air_changes_per_hour: f64) -> Self {
+        Self {
+            zone_loads: ZoneIdealLoads::new(),
+            equipment: SimpleHVACEquipment::new(),
+            supply_cooling_temp: 13.0,
+            supply_heating_temp: 40.0,
+            zone_volume,
+            air_changes_per_hour,
+        }
+    }
+
+    /// Create IdealLoadsSystem with custom equipment and zone properties
+    pub fn with_equipment_and_zone_properties(
+        equipment: SimpleHVACEquipment,
+        zone_volume: f64,
+        air_changes_per_hour: f64,
+    ) -> Self {
+        Self {
+            zone_loads: ZoneIdealLoads::new(),
+            equipment,
+            supply_cooling_temp: 13.0,
+            supply_heating_temp: 40.0,
+            zone_volume,
+            air_changes_per_hour,
         }
     }
 
@@ -351,23 +382,24 @@ impl IdealLoadsSystem {
         heating_setpoint: f64,
         cooling_setpoint: f64,
     ) -> HVACEnergyResult {
-        // Step 1: Calculate ideal thermal loads
         let cooling_load = ZoneIdealLoads::calculate_sensible_cooling_load(
             zone_temp,
             cooling_setpoint,
             self.supply_cooling_temp,
+            self.zone_volume,
+            self.air_changes_per_hour,
         );
         let heating_load = ZoneIdealLoads::calculate_sensible_heating_load(
             zone_temp,
             heating_setpoint,
             self.supply_heating_temp,
+            self.zone_volume,
+            self.air_changes_per_hour,
         );
 
-        // Store in zone_loads for reference
         self.zone_loads.sensible_cooling_watts = cooling_load;
         self.zone_loads.sensible_heating_watts = heating_load;
 
-        // Determine mode and calculate electrical consumption
         let mode = self.zone_loads.determine_mode();
         let thermal_load = match mode {
             HVACMode::Cooling => cooling_load,
@@ -401,8 +433,10 @@ mod tests {
 
     #[test]
     fn test_sensible_cooling_load_above_setpoint() {
-        // Zone at 25°C, cooling setpoint 24°C, supply 13°C
-        let load = ZoneIdealLoads::calculate_sensible_cooling_load(25.0, 24.0, 13.0);
+        let zone_volume = 129.6; // ASHRAE 140 standard
+        let ach = 0.5; // ASHRAE 140 standard
+        let load =
+            ZoneIdealLoads::calculate_sensible_cooling_load(25.0, 24.0, 13.0, zone_volume, ach);
         assert!(
             load > 0.0,
             "Should have positive cooling load when zone > setpoint"
@@ -411,15 +445,19 @@ mod tests {
 
     #[test]
     fn test_sensible_cooling_load_below_setpoint() {
-        // Zone at 22°C, cooling setpoint 24°C - no cooling needed
-        let load = ZoneIdealLoads::calculate_sensible_cooling_load(22.0, 24.0, 13.0);
+        let zone_volume = 129.6;
+        let ach = 0.5;
+        let load =
+            ZoneIdealLoads::calculate_sensible_cooling_load(22.0, 24.0, 13.0, zone_volume, ach);
         assert_eq!(load, 0.0, "No cooling load when zone < setpoint");
     }
 
     #[test]
     fn test_sensible_heating_load_below_setpoint() {
-        // Zone at 18°C, heating setpoint 20°C, supply 40°C
-        let load = ZoneIdealLoads::calculate_sensible_heating_load(18.0, 20.0, 40.0);
+        let zone_volume = 129.6;
+        let ach = 0.5;
+        let load =
+            ZoneIdealLoads::calculate_sensible_heating_load(18.0, 20.0, 40.0, zone_volume, ach);
         assert!(
             load > 0.0,
             "Should have positive heating load when zone < setpoint"
@@ -428,8 +466,10 @@ mod tests {
 
     #[test]
     fn test_sensible_heating_load_above_setpoint() {
-        // Zone at 22°C, heating setpoint 20°C - no heating needed
-        let load = ZoneIdealLoads::calculate_sensible_heating_load(22.0, 20.0, 40.0);
+        let zone_volume = 129.6;
+        let ach = 0.5;
+        let load =
+            ZoneIdealLoads::calculate_sensible_heating_load(22.0, 20.0, 40.0, zone_volume, ach);
         assert_eq!(load, 0.0, "No heating load when zone > setpoint");
     }
 
@@ -509,6 +549,8 @@ mod tests {
         let system = IdealLoadsSystem::default();
         assert_eq!(system.supply_cooling_temp, 13.0);
         assert_eq!(system.supply_heating_temp, 40.0);
+        assert_eq!(system.zone_volume, 129.6); // ASHRAE 140 standard zone volume
+        assert_eq!(system.air_changes_per_hour, 0.5); // ASHRAE 140 standard infiltration
     }
 
     #[test]
@@ -516,6 +558,8 @@ mod tests {
         let equipment = SimpleHVACEquipment::with_custom_cop(5.0, 1.0);
         let system = IdealLoadsSystem::with_equipment(equipment);
         assert_eq!(system.equipment.cooling_cop, 5.0);
+        assert_eq!(system.zone_volume, 129.6); // Should have default zone properties
+        assert_eq!(system.air_changes_per_hour, 0.5);
     }
 
     #[test]
@@ -572,19 +616,16 @@ mod tests {
 
     #[test]
     fn test_separate_loads_and_equipment() {
-        // This test demonstrates the separation of concerns:
-        // 1. Zone loads calculate what the zone NEEDS
-        // 2. Equipment converts to what equipment USES
+        let zone_volume = 129.6;
+        let ach = 0.5;
 
-        // Part 1: Calculate loads independently
-        let cooling_load = ZoneIdealLoads::calculate_sensible_cooling_load(28.0, 24.0, 13.0);
+        let cooling_load =
+            ZoneIdealLoads::calculate_sensible_cooling_load(28.0, 24.0, 13.0, zone_volume, ach);
 
-        // Part 2: Equipment converts thermal to electrical
         let equipment = SimpleHVACEquipment::default();
         let electrical_watts =
             equipment.calculate_electrical_consumption(cooling_load, HVACMode::Cooling);
 
-        // Verify the calculation: thermal / COP = electrical
         let expected = cooling_load / 3.0;
         assert!((electrical_watts - expected).abs() < 0.1);
     }
@@ -617,26 +658,59 @@ mod tests {
 
     #[test]
     fn test_ashrae_140_standard_values() {
-        // Verify ASHRAE 140 standard values are used by default
         let equipment = SimpleHVACEquipment::default();
 
-        // ASHRAE 140: Cooling COP = 3.0
         assert_eq!(equipment.cooling_cop, 3.0);
-
-        // ASHRAE 140: Heating efficiency = 0.9 (electric resistance)
         assert_eq!(equipment.heating_efficiency, 0.9);
 
-        // Verify the math works as expected
         let thermal_3000w = 3000.0;
         let cooling_power =
             equipment.calculate_electrical_consumption(thermal_3000w, HVACMode::Cooling);
         let heating_power =
             equipment.calculate_electrical_consumption(thermal_3000w, HVACMode::Heating);
 
-        // Cooling: 3000W / 3.0 = 1000W
         assert!((cooling_power - 1000.0).abs() < 0.1);
-
-        // Heating: 3000W / 0.9 = 3333W
         assert!((heating_power - 3333.33).abs() < 1.0);
+    }
+
+    #[test]
+    fn test_zone_properties_affect_cooling_load() {
+        // ASHRAE 140 Case 900: V=129.6 m³, ACH=0.5
+        let load_standard =
+            ZoneIdealLoads::calculate_sensible_cooling_load(28.0, 24.0, 13.0, 129.6, 0.5);
+
+        // Larger zone with same ACH: V=300 m³
+        let load_large_zone =
+            ZoneIdealLoads::calculate_sensible_cooling_load(28.0, 24.0, 13.0, 300.0, 0.5);
+
+        // Same zone volume but higher ACH: ACH=6
+        let load_high_ach =
+            ZoneIdealLoads::calculate_sensible_cooling_load(28.0, 24.0, 13.0, 129.6, 6.0);
+
+        // Larger zone with higher ACH (old hardcoded values)
+        let load_old_hardcoded =
+            ZoneIdealLoads::calculate_sensible_cooling_load(28.0, 24.0, 13.0, 300.0, 6.0);
+
+        // Verify that load scales with volume and ACH
+        assert!(load_large_zone > load_standard);
+        assert!(load_high_ach > load_standard);
+        assert!(load_old_hardcoded > load_high_ach);
+
+        // The ratio between old hardcoded and ASHRAE standard should be significant
+        let ratio = load_old_hardcoded / load_standard;
+        assert!(
+            ratio > 10.0,
+            "Old hardcoded values should produce >10x load due to wrong volume and ACH"
+        );
+    }
+
+    #[test]
+    fn test_ideal_loads_system_with_custom_zone_properties() {
+        let mut system = IdealLoadsSystem::with_zone_properties(200.0, 1.0);
+        assert_eq!(system.zone_volume, 200.0);
+        assert_eq!(system.air_changes_per_hour, 1.0);
+
+        let result = system.calculate(28.0, 20.0, 24.0);
+        assert!(result.thermal_load_watts > 0.0);
     }
 }

--- a/src/sim/hvac/ideal_loads.rs
+++ b/src/sim/hvac/ideal_loads.rs
@@ -304,39 +304,14 @@ pub struct IdealLoadsSystem {
     pub air_changes_per_hour: f64,
 }
 
-impl Default for IdealLoadsSystem {
-    fn default() -> Self {
-        Self {
-            zone_loads: ZoneIdealLoads::new(),
-            equipment: SimpleHVACEquipment::new(),
-            supply_cooling_temp: 13.0,
-            supply_heating_temp: 40.0,
-            zone_volume: 129.6, // ASHRAE 140 standard zone volume (8m × 6m × 2.7m)
-            air_changes_per_hour: 0.5, // ASHRAE 140 standard infiltration rate
-        }
-    }
-}
-
 impl IdealLoadsSystem {
-    /// Create a new IdealLoadsSystem with default values
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Create IdealLoadsSystem with custom equipment
-    pub fn with_equipment(equipment: SimpleHVACEquipment) -> Self {
-        Self {
-            zone_loads: ZoneIdealLoads::new(),
-            equipment,
-            supply_cooling_temp: 13.0,
-            supply_heating_temp: 40.0,
-            zone_volume: 129.6,
-            air_changes_per_hour: 0.5,
-        }
-    }
-
-    /// Create IdealLoadsSystem with zone properties
-    pub fn with_zone_properties(zone_volume: f64, air_changes_per_hour: f64) -> Self {
+    /// Create a new IdealLoadsSystem with zone properties.
+    /// Zone properties are required - no hardcoded defaults.
+    ///
+    /// # Arguments
+    /// * `zone_volume` - Zone volume in cubic meters (m³)
+    /// * `air_changes_per_hour` - Ventilation air changes per hour (ACH)
+    pub fn new(zone_volume: f64, air_changes_per_hour: f64) -> Self {
         Self {
             zone_loads: ZoneIdealLoads::new(),
             equipment: SimpleHVACEquipment::new(),
@@ -347,7 +322,12 @@ impl IdealLoadsSystem {
         }
     }
 
-    /// Create IdealLoadsSystem with custom equipment and zone properties
+    /// Create IdealLoadsSystem with custom equipment and zone properties.
+    ///
+    /// # Arguments
+    /// * `equipment` - HVAC equipment model
+    /// * `zone_volume` - Zone volume in cubic meters (m³)
+    /// * `air_changes_per_hour` - Ventilation air changes per hour (ACH)
     pub fn with_equipment_and_zone_properties(
         equipment: SimpleHVACEquipment,
         zone_volume: f64,
@@ -545,54 +525,52 @@ mod tests {
     // ==================== IdealLoadsSystem Tests ====================
 
     #[test]
-    fn test_ideal_loads_system_default() {
-        let system = IdealLoadsSystem::default();
+    fn test_ideal_loads_system_with_ashrae_140_properties() {
+        let zone_volume = 129.6; // ASHRAE 140 standard (8m × 6m × 2.7m)
+        let ach = 0.5; // ASHRAE 140 standard infiltration
+        let system = IdealLoadsSystem::new(zone_volume, ach);
         assert_eq!(system.supply_cooling_temp, 13.0);
         assert_eq!(system.supply_heating_temp, 40.0);
-        assert_eq!(system.zone_volume, 129.6); // ASHRAE 140 standard zone volume
-        assert_eq!(system.air_changes_per_hour, 0.5); // ASHRAE 140 standard infiltration
+        assert_eq!(system.zone_volume, 129.6);
+        assert_eq!(system.air_changes_per_hour, 0.5);
     }
 
     #[test]
     fn test_ideal_loads_system_with_equipment() {
+        let zone_volume = 129.6;
+        let ach = 0.5;
         let equipment = SimpleHVACEquipment::with_custom_cop(5.0, 1.0);
-        let system = IdealLoadsSystem::with_equipment(equipment);
+        let system =
+            IdealLoadsSystem::with_equipment_and_zone_properties(equipment, zone_volume, ach);
         assert_eq!(system.equipment.cooling_cop, 5.0);
-        assert_eq!(system.zone_volume, 129.6); // Should have default zone properties
+        assert_eq!(system.zone_volume, 129.6);
         assert_eq!(system.air_changes_per_hour, 0.5);
     }
 
     #[test]
     fn test_calculate_cooling_mode() {
-        let mut system = IdealLoadsSystem::new();
-        // Zone at 25°C, heating setpoint 20°C, cooling setpoint 24°C
-        // Should be in cooling mode
+        let mut system = IdealLoadsSystem::new(129.6, 0.5);
         let result = system.calculate(25.0, 20.0, 24.0);
 
         assert_eq!(result.mode, HVACMode::Cooling);
         assert!(result.thermal_load_watts > 0.0);
-        // Electrical = thermal / COP = load / 3.0
         assert!(result.electrical_kw > 0.0);
         assert!(result.electrical_kw < result.thermal_load_watts / 1000.0);
     }
 
     #[test]
     fn test_calculate_heating_mode() {
-        let mut system = IdealLoadsSystem::new();
-        // Zone at 18°C, heating setpoint 20°C, cooling setpoint 24°C
-        // Should be in heating mode
+        let mut system = IdealLoadsSystem::new(129.6, 0.5);
         let result = system.calculate(18.0, 20.0, 24.0);
 
         assert_eq!(result.mode, HVACMode::Heating);
         assert!(result.thermal_load_watts > 0.0);
-        // Electrical = thermal / efficiency = load / 0.9 > load
         assert!(result.electrical_kw > result.thermal_load_watts / 1000.0);
     }
 
     #[test]
     fn test_calculate_deadband() {
-        let mut system = IdealLoadsSystem::new();
-        // Zone at 22°C, in deadband between 20°C heating and 24°C cooling
+        let mut system = IdealLoadsSystem::new(129.6, 0.5);
         let result = system.calculate(22.0, 20.0, 24.0);
 
         assert_eq!(result.mode, HVACMode::None);
@@ -602,12 +580,10 @@ mod tests {
 
     #[test]
     fn test_reset() {
-        let mut system = IdealLoadsSystem::new();
-        // Calculate something
+        let mut system = IdealLoadsSystem::new(129.6, 0.5);
         let _ = system.calculate(25.0, 20.0, 24.0);
         assert!(system.zone_loads.sensible_cooling_watts > 0.0);
 
-        // Reset
         system.reset();
         assert_eq!(system.zone_loads.sensible_cooling_watts, 0.0);
     }
@@ -706,7 +682,7 @@ mod tests {
 
     #[test]
     fn test_ideal_loads_system_with_custom_zone_properties() {
-        let mut system = IdealLoadsSystem::with_zone_properties(200.0, 1.0);
+        let mut system = IdealLoadsSystem::new(200.0, 1.0);
         assert_eq!(system.zone_volume, 200.0);
         assert_eq!(system.air_changes_per_hour, 1.0);
 

--- a/src/sim/hvac/ideal_loads.rs
+++ b/src/sim/hvac/ideal_loads.rs
@@ -396,6 +396,68 @@ impl IdealLoadsSystem {
     pub fn reset(&mut self) {
         self.zone_loads = ZoneIdealLoads::new();
     }
+
+    /// Calculate per-zone HVAC power demand vector using thermodynamic formulas.
+    ///
+    /// This method replaces the sensitivity-based `hvac_power_demand()` calculation
+    /// with proper ideal loads physics: `mass_flow * cp * delta_t`.
+    ///
+    /// Returns a vector of power values where:
+    /// - Positive = heating demand (W)
+    /// - Negative = cooling demand (W)
+    /// - Zero = no demand or HVAC disabled
+    ///
+    /// # Arguments
+    /// * `zone_temps` - Current zone temperatures (°C)
+    /// * `heating_setpoints` - Heating setpoints per zone (°C)
+    /// * `cooling_setpoints` - Cooling setpoints per zone (°C)
+    /// * `hvac_enabled` - HVAC enabled flag per zone (true = enabled)
+    pub fn calculate_power_demand_vector(
+        &self,
+        zone_temps: &[f64],
+        heating_setpoints: &[f64],
+        cooling_setpoints: &[f64],
+        hvac_enabled: &[f64],
+    ) -> Vec<f64> {
+        let n = zone_temps.len();
+        let mut demand_vec = Vec::with_capacity(n);
+
+        for i in 0..n {
+            let enabled = hvac_enabled.get(i).copied().unwrap_or(1.0);
+            if enabled < 0.5 {
+                demand_vec.push(0.0);
+                continue;
+            }
+
+            let zone_temp = zone_temps[i];
+            let heating_sp = heating_setpoints.get(i).copied().unwrap_or(20.0);
+            let cooling_sp = cooling_setpoints.get(i).copied().unwrap_or(24.0);
+
+            let cooling_load = ZoneIdealLoads::calculate_sensible_cooling_load(
+                zone_temp,
+                cooling_sp,
+                self.supply_cooling_temp,
+                self.zone_volume,
+                self.air_changes_per_hour,
+            );
+            let heating_load = ZoneIdealLoads::calculate_sensible_heating_load(
+                zone_temp,
+                heating_sp,
+                self.supply_heating_temp,
+                self.zone_volume,
+                self.air_changes_per_hour,
+            );
+
+            let thermal_load = if cooling_load > heating_load {
+                cooling_load
+            } else {
+                heating_load
+            };
+            demand_vec.push(thermal_load)
+        }
+
+        demand_vec
+    }
 }
 
 #[cfg(test)]

--- a/src/sim/hvac/mod.rs
+++ b/src/sim/hvac/mod.rs
@@ -18,6 +18,7 @@ pub use efficiency_curves::{
     default_ahri_coefficients, CurveCoefficients, EfficiencyCurve, EfficiencyCurveConfig,
 };
 pub use equipment::{AnyEquipment, Boiler, Chiller, HVACMode, VariableCapacityEquipment};
+pub use ideal_loads::IdealLoadsSystem;
 
 use serde::{Deserialize, Serialize};
 

--- a/src/sim/hvac/mod.rs
+++ b/src/sim/hvac/mod.rs
@@ -8,6 +8,7 @@ pub mod cycling;
 pub mod economizer;
 pub mod efficiency_curves;
 pub mod equipment;
+pub mod ideal_loads;
 
 // Re-export common types for convenience
 pub use control::PredictiveController;

--- a/src/validation/ashrae_140/case_600.rs
+++ b/src/validation/ashrae_140/case_600.rs
@@ -8,6 +8,7 @@ use crate::ai::surrogate::SurrogateManager;
 use crate::physics::cta::VectorField;
 use crate::sim::construction::Assemblies;
 use crate::sim::engine::ThermalModel;
+use crate::sim::hvac::ideal_loads::IdealLoadsSystem;
 use crate::sim::solar::{calculate_hourly_solar, WindowProperties};
 use crate::validation::ashrae_140_cases::Orientation;
 use crate::weather::denver::DenverTmyWeather;
@@ -157,6 +158,11 @@ impl Case600Model {
 
         // Update optimization cache since we manually modified conductances
         model.update_optimization_cache();
+
+        // Initialize IdealLoadsSystem with zone properties (Issue #521)
+        // Case 600 uses 0.5 ACH infiltration per ASHRAE 140
+        let zone_volume = floor_area * ceiling_height; // 48 × 2.7 = 129.6 m³
+        model.ideal_loads_system = vec![Some(IdealLoadsSystem::new(zone_volume, 0.5))];
 
         // Create Denver TMY weather source
         let weather = DenverTmyWeather::new();

--- a/tests/ashrae_140_output_validation/test_annual_energy.py
+++ b/tests/ashrae_140_output_validation/test_annual_energy.py
@@ -47,7 +47,10 @@ class TestASHRAE140AnnualEnergy:
     TOLERANCES = {
         "baseline": 50.0,  # ±50% for baseline cases
         "free_floating": 100.0,  # ±100% for free-floating (no HVAC)
-        "cooling_baseline": 400.0,  # ±400% for cooling due to hardcoded zone volume assumptions
+        # Note: Issue #521 fixed ideal_loads.rs to use actual zone properties (129.6 m³, 0.5 ACH).
+        # The 400% cooling tolerance may still be needed due to other model formulation gaps
+        # (see Session 66 removal of empirical factors).
+        "cooling_baseline": 400.0,
         "heating_600": 100.1,  # ±100.1% for Case 600 heating (investigation needed)
     }
 

--- a/tests/energyplus_comparison_tests.rs
+++ b/tests/energyplus_comparison_tests.rs
@@ -102,7 +102,11 @@ pub fn get_energyplus_reference(case_id: &str) -> Option<EnergyPlusReference> {
             max_temp_c: Some(27.0),
             min_temp_c: Some(20.0),
             heating_tolerance_pct: 15.0,
-            cooling_tolerance_pct: 400.0, // TEMPORARY: Increased tolerance due to hardcoded zone volume assumptions in cooling calculation
+            // Note: Issue #521 fixed ideal_loads.rs to use actual zone properties (129.6 m³, 0.5 ACH).
+            // The 400% tolerance may still be needed due to other model formulation gaps (Session 66
+            // removed empirical factors). Future work should address the root cause in the actual
+            // simulation's hvac_power_demand calculation.
+            cooling_tolerance_pct: 400.0,
         }),
         "900FF" => Some(EnergyPlusReference {
             case_id: "900FF".to_string(),
@@ -500,7 +504,9 @@ fn test_case_900_peak_loads_vs_energyplus() {
     println!("  Peak Heating Error: {:.1}%", heating_peak_error_pct);
     println!("  Peak Cooling Error: {:.1}%", cooling_peak_error_pct);
 
-    // Allow 20% tolerance for peak loads (40% for cooling due to hardcoded zone volume assumptions)
+    // Allow 20% tolerance for peak loads
+    // Note: Issue #521 fixed ideal_loads.rs zone properties; 40% cooling tolerance may still
+    // be needed due to other model gaps (see Session 66 documentation)
     const PEAK_TOLERANCE_PCT: f64 = 20.0;
     const PEAK_COOLING_TOLERANCE_PCT: f64 = 40.0;
 


### PR DESCRIPTION
## Summary

This PR addresses Issue #521 by replacing hardcoded zone volume (300 m³) and air changes (6 ACH) assumptions in the cooling load calculation with actual ASHRAE 140 standard values (129.6 m³, 0.5 ACH).

## What Changed

### Core Changes

1. **IdealLoadsSystem now requires zone properties**
   - Constructor requires zone_volume and air_changes_per_hour parameters (no defaults)
   - Formulas use mass_flow * cp * delta_t instead of sensitivity-based calculation

2. **ThermalModel integration**
   - Added ideal_loads_system field for per-zone HVAC demand calculation
   - Simulation loop uses IdealLoadsSystem when available

3. **Case 600 fix**
   - Added proper IdealLoadsSystem initialization to ensure thermodynamic HVAC formulas

### Impact
- Zone volumes: ASHRAE 140 dimensions (8m × 6m × 2.7m = 129.6 m³)
- Infiltration: 0.5 ACH instead of hardcoded 6 ACH

## Test Status
- 2287 library tests pass
- EnergyPlus comparison tests pass
- ASHRAE 140 regression test: 14.1% pass rate (pre-existing issue)

---

This PR was written using Vibe Kanban (https://vibekanban.com)