### PR TITLE
⚡ Bolt: [performance improvement] Optimize VectorField multiplications in step_physics_6r2c

### DIFF
--- a/src/sim/engine.rs
+++ b/src/sim/engine.rs
@@ -4788,8 +4788,11 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
         };
 
         // Use envelope mass temperature instead of single mass temperature
-        let num_tm = self.derived_h_ms_is_prod.clone() * self.envelope_mass_temperatures.clone();
-        let num_phi_st = self.h_tr_is.clone() * phi_st.clone();
+        // Optimized: use zip_with to avoid double clones
+        let num_tm = self
+            .derived_h_ms_is_prod
+            .zip_with(&self.envelope_mass_temperatures, |a, b| a * b);
+        let num_phi_st = self.h_tr_is.zip_with(&phi_st, |a, b| a * b);
 
         // Inter-zone heat transfer (with radiative component - Issue #302)
         let num_zones = self.num_zones;
@@ -6181,7 +6184,10 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
         };
 
         // Use envelope_mass_temperatures to match step_physics_6r2c
-        let num_tm = self.derived_h_ms_is_prod.clone() * self.envelope_mass_temperatures.clone();
+        // Optimized: use zip_with to avoid double clones
+        let num_tm = self
+            .derived_h_ms_is_prod
+            .zip_with(&self.envelope_mass_temperatures, |a, b| a * b);
         let num_phi_st = self.h_tr_is.zip_with(&phi_st, |a, b| a * b);
 
         // Inter-zone heat transfer (with radiative component - Issue #302)


### PR DESCRIPTION
💡 What: Replaced computationally expensive `.clone() * .clone()` operations on tensors/arrays with `.zip_with(..., |a, b| a * b)` in `step_physics_6r2c` and `calculate_free_float_temperature`.
🎯 Why: Avoiding double heap-allocations and deep copies of `VectorField` instances in the hot simulation loops reduces memory allocations significantly.
📊 Impact: Expected to reduce memory overhead during core execution in simulation engines like the `solve_timesteps_1year_10zones` case.
🔬 Measurement: Verify with `cargo bench --bench engine_bench` and review Dhat heap outputs.

---
*PR created automatically by Jules for task [1796272496612273513](https://jules.google.com/task/1796272496612273513) started by @anchapin*

## Summary by Sourcery

Enhancements:
- Replace clone-based VectorField multiplications with zip_with-based elementwise products in step_physics_6r2c and related temperature calculations to avoid unnecessary allocations.