### PR TITLE
feat(physics): Add explicit solver selection config for Issue #502 (Vibe Kanban)

### DIFF
--- a/src/physics/method_selector.rs
+++ b/src/physics/method_selector.rs
@@ -50,6 +50,88 @@ impl ThermalMethod {
     }
 }
 
+/// Configuration for solver selection mode.
+///
+/// This allows explicit control over solver selection instead of relying
+/// on implicit automatic selection based on thermal mass time constant.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SolverSelectionConfig {
+    /// Automatic selection based on thermal mass time constant (τ)
+    Automatic,
+    /// Force a specific method for all surfaces
+    ForceMethod(ThermalMethod),
+    /// Per-surface explicit solver selection
+    PerSurface(Vec<SurfaceSolverConfig>),
+}
+
+/// Configuration for a specific surface's solver selection.
+///
+/// This allows intentional selection of solver method per surface rather than
+/// relying on automatic selection based on thermal mass characteristics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SurfaceSolverConfig {
+    /// Surface identifier (e.g., "Wall", "Roof", "Floor", or surface index)
+    pub surface_id: String,
+    /// Explicit solver method to use for this surface
+    pub method: ThermalMethod,
+}
+
+impl SurfaceSolverConfig {
+    /// Create a new surface solver config.
+    pub fn new(surface_id: impl Into<String>, method: ThermalMethod) -> Self {
+        Self {
+            surface_id: surface_id.into(),
+            method,
+        }
+    }
+
+    /// Create config for a wall surface.
+    pub fn wall(method: ThermalMethod) -> Self {
+        Self::new("Wall", method)
+    }
+
+    /// Create config for a roof surface.
+    pub fn roof(method: ThermalMethod) -> Self {
+        Self::new("Roof", method)
+    }
+
+    /// Create config for a floor surface.
+    pub fn floor(method: ThermalMethod) -> Self {
+        Self::new("Floor", method)
+    }
+}
+
+/// Solver selection result with method and reason for selection.
+///
+/// This provides transparency into why a particular solver was selected,
+/// supporting the requirement for "intentional, not implicit" selection.
+#[derive(Debug, Clone)]
+pub struct SolverSelectionResult {
+    /// The selected thermal method
+    pub method: ThermalMethod,
+    /// Human-readable reason for the selection
+    pub reason: String,
+    /// Time constant τ in hours (if calculated)
+    pub time_constant_hours: Option<f64>,
+}
+
+impl SolverSelectionResult {
+    /// Create a new selection result.
+    pub fn new(method: ThermalMethod, reason: impl Into<String>) -> Self {
+        Self {
+            method,
+            reason: reason.into(),
+            time_constant_hours: None,
+        }
+    }
+
+    /// Create with time constant.
+    pub fn with_time_constant(mut self, tau: f64) -> Self {
+        self.time_constant_hours = Some(tau);
+        self
+    }
+}
+
 /// Automatic method selection based on building thermal mass.
 ///
 /// # Selection Strategy
@@ -90,6 +172,8 @@ pub struct ThermalMethodSelector {
     pub h_interior: f64,
     /// Exterior convective coefficient [W/m²·K]
     pub h_exterior: f64,
+    /// Explicit solver selection configuration
+    pub selection_config: SolverSelectionConfig,
 }
 
 impl ThermalMethodSelector {
@@ -240,6 +324,97 @@ impl ThermalMethodSelector {
         }
     }
 
+    /// Select method with explicit configuration and return selection result.
+    ///
+    /// This method provides transparency into the solver selection process by returning
+    /// both the selected method and the reason for selection.
+    ///
+    /// # Arguments
+    ///
+    /// * `wall` - Wall assembly to analyze
+    /// * `surface_id` - Surface identifier (e.g., "Wall", "Roof") for per-surface config
+    ///
+    /// # Returns
+    ///
+    /// Selection result with method and reason
+    pub fn select_with_result(
+        &self,
+        wall: &BuildingAssembly,
+        surface_id: &str,
+    ) -> SolverSelectionResult {
+        // Check for explicit per-surface configuration first
+        if let SolverSelectionConfig::PerSurface(ref configs) = self.selection_config {
+            if let Some(config) = configs.iter().find(|c| c.surface_id == surface_id) {
+                return SolverSelectionResult::new(
+                    config.method,
+                    format!("Explicit per-surface config for '{}'", surface_id),
+                );
+            }
+        }
+
+        // Check for forced method
+        if let SolverSelectionConfig::ForceMethod(method) = &self.selection_config {
+            return SolverSelectionResult::new(
+                *method,
+                format!("Explicit force to {}", method.name()),
+            );
+        }
+
+        // Fall back to automatic selection based on thermal mass
+        let method = self.select_method(wall);
+        let tau = self.calculate_time_constant(wall);
+
+        let reason = if let Some(override_method) = self.override_method {
+            format!("Override to {} (τ = {:.2}h)", override_method.name(), tau)
+        } else if tau < self.threshold_hours {
+            format!(
+                "Low thermal mass (τ = {:.2}h < {:.1}h threshold)",
+                tau, self.threshold_hours
+            )
+        } else {
+            format!(
+                "High thermal mass (τ = {:.2}h >= {:.1}h threshold)",
+                tau, self.threshold_hours
+            )
+        };
+
+        SolverSelectionResult::new(method, reason).with_time_constant(tau)
+    }
+
+    /// Get the explicit selection configuration.
+    pub fn selection_config(&self) -> &SolverSelectionConfig {
+        &self.selection_config
+    }
+
+    /// Set the explicit selection configuration.
+    pub fn set_selection_config(&mut self, config: SolverSelectionConfig) {
+        self.selection_config = config;
+    }
+
+    /// Create selector with automatic selection mode.
+    pub fn with_automatic_selection() -> Self {
+        Self {
+            selection_config: SolverSelectionConfig::Automatic,
+            ..Self::default()
+        }
+    }
+
+    /// Create selector with forced method.
+    pub fn with_forced_method(method: ThermalMethod) -> Self {
+        Self {
+            selection_config: SolverSelectionConfig::ForceMethod(method),
+            ..Self::default()
+        }
+    }
+
+    /// Create selector with per-surface explicit configuration.
+    pub fn with_per_surface_selection(configs: Vec<SurfaceSolverConfig>) -> Self {
+        Self {
+            selection_config: SolverSelectionConfig::PerSurface(configs),
+            ..Self::default()
+        }
+    }
+
     /// Validate CTF coefficients.
     ///
     /// # Arguments
@@ -339,6 +514,7 @@ impl Default for ThermalMethodSelector {
             enable_fallback: true,
             h_interior: 8.0,  // Typical interior film coefficient
             h_exterior: 25.0, // Typical exterior film coefficient
+            selection_config: SolverSelectionConfig::Automatic,
         }
     }
 }
@@ -637,5 +813,128 @@ mod tests {
             let name = method.name();
             assert!(!name.is_empty());
         }
+    }
+
+    #[test]
+    fn test_select_with_result() {
+        let selector = ThermalMethodSelector::default();
+        let wall = create_lightweight_wall();
+
+        let result = selector.select_with_result(&wall, "Wall");
+
+        assert!(result.time_constant_hours.is_some());
+        assert!(result.reason.contains("τ") || result.reason.contains("Low thermal mass"));
+    }
+
+    #[test]
+    fn test_select_with_result_per_surface_config() {
+        let mut selector = ThermalMethodSelector::default();
+        selector.set_selection_config(SolverSelectionConfig::PerSurface(vec![
+            SurfaceSolverConfig::wall(ThermalMethod::FiniteDifference),
+        ]));
+
+        let wall = create_lightweight_wall();
+        let result = selector.select_with_result(&wall, "Wall");
+
+        assert_eq!(result.method, ThermalMethod::FiniteDifference);
+        assert!(result.reason.contains("Explicit per-surface config"));
+    }
+
+    #[test]
+    fn test_select_with_result_force_method() {
+        let mut selector = ThermalMethodSelector::default();
+        selector.set_selection_config(SolverSelectionConfig::ForceMethod(
+            ThermalMethod::FiniteDifference,
+        ));
+
+        let wall = create_lightweight_wall();
+        let result = selector.select_with_result(&wall, "Wall");
+
+        assert_eq!(result.method, ThermalMethod::FiniteDifference);
+        assert!(result.reason.contains("Explicit force"));
+    }
+
+    #[test]
+    fn test_with_automatic_selection() {
+        let selector = ThermalMethodSelector::with_automatic_selection();
+        assert_eq!(selector.selection_config, SolverSelectionConfig::Automatic);
+    }
+
+    #[test]
+    fn test_with_forced_method() {
+        let selector = ThermalMethodSelector::with_forced_method(ThermalMethod::CTF);
+        assert_eq!(
+            selector.selection_config,
+            SolverSelectionConfig::ForceMethod(ThermalMethod::CTF)
+        );
+    }
+
+    #[test]
+    fn test_with_per_surface_selection() {
+        let configs = vec![
+            SurfaceSolverConfig::wall(ThermalMethod::FiveR1C),
+            SurfaceSolverConfig::roof(ThermalMethod::CTF),
+        ];
+        let selector = ThermalMethodSelector::with_per_surface_selection(configs.clone());
+        assert_eq!(
+            selector.selection_config,
+            SolverSelectionConfig::PerSurface(configs)
+        );
+    }
+
+    #[test]
+    fn test_surface_solver_config_helpers() {
+        let wall_config = SurfaceSolverConfig::wall(ThermalMethod::FiveR1C);
+        assert_eq!(wall_config.surface_id, "Wall");
+        assert_eq!(wall_config.method, ThermalMethod::FiveR1C);
+
+        let roof_config = SurfaceSolverConfig::roof(ThermalMethod::CTF);
+        assert_eq!(roof_config.surface_id, "Roof");
+        assert_eq!(roof_config.method, ThermalMethod::CTF);
+
+        let floor_config = SurfaceSolverConfig::floor(ThermalMethod::FiniteDifference);
+        assert_eq!(floor_config.surface_id, "Floor");
+        assert_eq!(floor_config.method, ThermalMethod::FiniteDifference);
+    }
+
+    #[test]
+    fn test_solver_selection_result() {
+        let result =
+            SolverSelectionResult::new(ThermalMethod::CTF, "test reason").with_time_constant(2.5);
+
+        assert_eq!(result.method, ThermalMethod::CTF);
+        assert_eq!(result.reason, "test reason");
+        assert_eq!(result.time_constant_hours, Some(2.5));
+    }
+
+    #[test]
+    fn test_solver_selection_config_variants() {
+        use SolverSelectionConfig::*;
+        assert_eq!(Automatic, Automatic);
+        assert_eq!(
+            ForceMethod(ThermalMethod::FiveR1C),
+            ForceMethod(ThermalMethod::FiveR1C)
+        );
+        assert_ne!(
+            ForceMethod(ThermalMethod::FiveR1C),
+            ForceMethod(ThermalMethod::CTF)
+        );
+    }
+
+    #[test]
+    fn test_selection_config_getter() {
+        let mut selector = ThermalMethodSelector::default();
+        assert_eq!(
+            selector.selection_config(),
+            &SolverSelectionConfig::Automatic
+        );
+
+        selector.set_selection_config(SolverSelectionConfig::ForceMethod(
+            ThermalMethod::FiniteDifference,
+        ));
+        assert_eq!(
+            selector.selection_config(),
+            &SolverSelectionConfig::ForceMethod(ThermalMethod::FiniteDifference)
+        );
     }
 }

--- a/src/physics/solver_manager.rs
+++ b/src/physics/solver_manager.rs
@@ -30,7 +30,9 @@
 use crate::physics::ctf_solver_wrapper::CTFSolverWrapper;
 use crate::physics::fd_solver_wrapper::FDSolverWrapper;
 use crate::physics::five_r1c_solver::FiveR1CSolver;
-use crate::physics::method_selector::{ThermalMethod, ThermalMethodSelector};
+use crate::physics::method_selector::{
+    SolverSelectionResult, ThermalMethod, ThermalMethodSelector,
+};
 use crate::physics::solver_trait::{HeatConductionSolver, SolverError};
 use crate::sim::assembly::BuildingAssembly;
 use log::{debug, warn};
@@ -108,14 +110,16 @@ impl SolverManager {
         &mut self,
         wall_index: usize,
         wall_assembly: &BuildingAssembly,
-    ) -> Result<(), SolverError> {
+        surface_id: &str,
+    ) -> Result<SolverSelectionResult, SolverError> {
         // Check if solver already exists
         if self.solvers.contains_key(&wall_index) {
-            return Ok(());
+            return Ok(self.selector.select_with_result(wall_assembly, surface_id));
         }
 
-        // Select appropriate solver method
-        let method = self.selector.select_method(wall_assembly);
+        // Select appropriate solver method with full result (for transparency)
+        let result = self.selector.select_with_result(wall_assembly, surface_id);
+        let method = result.method;
 
         // Create solver based on method
         let solver: Box<dyn HeatConductionSolver> = match method {
@@ -163,7 +167,7 @@ impl SolverManager {
         let method_name = method.name().to_string();
         *self.solver_counts.entry(method_name).or_insert(0) += 1;
 
-        Ok(())
+        Ok(result)
     }
 
     /// Get mutable reference to solver for a wall.
@@ -313,7 +317,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let result = manager.get_or_create_solver(0, &wall);
+        let result = manager.get_or_create_solver(0, &wall, "Wall");
         assert!(result.is_ok());
         assert_eq!(manager.num_solvers(), 1);
 
@@ -332,7 +336,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let result = manager.get_or_create_solver(0, &wall);
+        let result = manager.get_or_create_solver(0, &wall, "Wall");
         assert!(result.is_ok());
         assert_eq!(manager.num_solvers(), 1);
 
@@ -351,7 +355,7 @@ mod tests {
             .build()
             .unwrap();
 
-        manager.get_or_create_solver(0, &wall).unwrap();
+        manager.get_or_create_solver(0, &wall, "Wall").unwrap();
 
         // Calculate flux
         let flux = manager.step(0, 3600.0, 20.0, 5.0, 8.0, 25.0).unwrap();
@@ -376,8 +380,12 @@ mod tests {
             .unwrap();
 
         // Initialize solvers
-        manager.get_or_create_solver(0, &light_wall).unwrap();
-        manager.get_or_create_solver(1, &heavy_wall).unwrap();
+        manager
+            .get_or_create_solver(0, &light_wall, "Wall")
+            .unwrap();
+        manager
+            .get_or_create_solver(1, &heavy_wall, "Wall")
+            .unwrap();
 
         // Should have 2 solvers
         assert_eq!(manager.num_solvers(), 2);
@@ -398,7 +406,7 @@ mod tests {
             .build()
             .unwrap();
 
-        manager.get_or_create_solver(0, &wall).unwrap();
+        manager.get_or_create_solver(0, &wall, "Wall").unwrap();
         assert_eq!(manager.num_solvers(), 1);
 
         manager.clear();
@@ -415,7 +423,7 @@ mod tests {
             .build()
             .unwrap();
 
-        manager.get_or_create_solver(0, &wall).unwrap();
+        manager.get_or_create_solver(0, &wall, "Wall").unwrap();
 
         let solver = manager.get_solver_mut(0);
         assert!(solver.is_some());
@@ -432,7 +440,7 @@ mod tests {
             .unwrap();
 
         let mut manager_mut = SolverManager::default();
-        manager_mut.get_or_create_solver(0, &wall).unwrap();
+        manager_mut.get_or_create_solver(0, &wall, "Wall").unwrap();
 
         let solver = manager_mut.get_solver(0);
         assert!(solver.is_some());
@@ -458,7 +466,7 @@ mod tests {
             .build()
             .unwrap();
 
-        manager.get_or_create_solver(0, &wall).unwrap();
+        manager.get_or_create_solver(0, &wall, "Wall").unwrap();
 
         let rate = manager.energy_storage_rate(0);
         // All current solver implementations return 0 for energy storage rate
@@ -486,7 +494,7 @@ mod tests {
             .build()
             .unwrap();
 
-        manager.get_or_create_solver(0, &wall).unwrap();
+        manager.get_or_create_solver(0, &wall, "Wall").unwrap();
 
         // Should be valid after initialization
         assert!(manager.all_valid());
@@ -501,7 +509,7 @@ mod tests {
             .build()
             .unwrap();
 
-        manager.get_or_create_solver(0, &wall).unwrap();
+        manager.get_or_create_solver(0, &wall, "Wall").unwrap();
 
         let dist = manager.method_distribution();
         assert!(!dist.is_empty());
@@ -532,11 +540,11 @@ mod tests {
             .unwrap();
 
         // First initialization
-        manager.get_or_create_solver(0, &wall).unwrap();
+        manager.get_or_create_solver(0, &wall, "Wall").unwrap();
         assert_eq!(manager.num_solvers(), 1);
 
         // Re-initialization should succeed (no new solver created)
-        manager.get_or_create_solver(0, &wall).unwrap();
+        manager.get_or_create_solver(0, &wall, "Wall").unwrap();
         assert_eq!(manager.num_solvers(), 1);
     }
 
@@ -570,7 +578,7 @@ mod tests {
             .build()
             .unwrap();
 
-        manager.get_or_create_solver(0, &wall).unwrap();
+        manager.get_or_create_solver(0, &wall, "Wall").unwrap();
 
         let stats = manager.get_stats();
         // Should have exactly one FD solver
@@ -589,7 +597,7 @@ mod tests {
             .build()
             .unwrap();
 
-        manager.get_or_create_solver(0, &wall).unwrap();
+        manager.get_or_create_solver(0, &wall, "Wall").unwrap();
 
         let stats = manager.get_stats();
         // Should have exactly one 5R1C solver

--- a/src/sim/engine.rs
+++ b/src/sim/engine.rs
@@ -3231,6 +3231,68 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
         self.fd_enabled
     }
 
+    /// Enable the unified solver manager with explicit solver selection.
+    ///
+    /// The solver manager provides automatic method selection (5R1C/CTF/FD) based on
+    /// thermal mass, but with explicit configuration control per Issue #502 requirements.
+    ///
+    /// # Arguments
+    ///
+    /// * `selection_config` - Solver selection configuration (Automatic, ForceMethod, PerSurface)
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use fluxion::physics::method_selector::{
+    ///     ThermalMethodSelector, SolverSelectionConfig, SurfaceSolverConfig, ThermalMethod
+    /// };
+    ///
+    /// // Automatic selection based on thermal mass
+    /// model.enable_solver_manager(SolverSelectionConfig::Automatic);
+    ///
+    /// // Force all surfaces to use CTF
+    /// model.enable_solver_manager(SolverSelectionConfig::ForceMethod(ThermalMethod::CTF));
+    ///
+    /// // Per-surface explicit selection
+    /// model.enable_solver_manager(SolverSelectionConfig::PerSurface(vec![
+    ///     SurfaceSolverConfig::wall(ThermalMethod::FiveR1C),
+    ///     SurfaceSolverConfig::roof(ThermalMethod::CTF),
+    /// ]));
+    /// ```
+    pub fn enable_solver_manager(
+        &mut self,
+        selection_config: crate::physics::method_selector::SolverSelectionConfig,
+    ) {
+        use crate::physics::method_selector::ThermalMethodSelector;
+
+        let mut selector = ThermalMethodSelector::default();
+        selector.set_selection_config(selection_config);
+
+        self.solver_manager = Some(crate::physics::solver_manager::SolverManager::new(selector));
+    }
+
+    /// Get a reference to the solver manager if it exists.
+    pub fn get_solver_manager(&self) -> Option<&crate::physics::solver_manager::SolverManager> {
+        self.solver_manager.as_ref()
+    }
+
+    /// Get a mutable reference to the solver manager if it exists.
+    pub fn get_solver_manager_mut(
+        &mut self,
+    ) -> Option<&mut crate::physics::solver_manager::SolverManager> {
+        self.solver_manager.as_mut()
+    }
+
+    /// Disable the solver manager and revert to default 5R1C/CTF/FD behavior.
+    pub fn disable_solver_manager(&mut self) {
+        self.solver_manager = None;
+    }
+
+    /// Check if solver manager is enabled.
+    pub fn solver_manager_is_enabled(&self) -> bool {
+        self.solver_manager.is_some()
+    }
+
     /// Enable CTF with automatic fallback to FD if coefficients are invalid.
     ///
     /// This method attempts to enable CTF solver, but if coefficient calculation fails


### PR DESCRIPTION
## Summary

Added explicit solver selection configuration infrastructure to make Fluxion's solver selection intentional, not implicit (Issue #502).

## Changes Made

### 1. `src/physics/method_selector.rs`
- Added `SolverSelectionConfig` enum with variants:
  - `Automatic` - time-constant based selection (existing behavior)
  - `ForceMethod(ThermalMethod)` - explicit single method for all surfaces
  - `PerSurface(Vec<SurfaceSolverConfig>)` - per-surface explicit selection
- Added `SurfaceSolverConfig` for per-surface configuration with helper methods (`wall()`, `roof()`, `floor()`)
- Added `SolverSelectionResult` providing transparency into selection rationale (method, reason, time constant)
- Added `select_with_result()` method returning method + reason + time constant
- Added builder methods: `with_automatic_selection()`, `with_forced_method()`, `with_per_surface_selection()`
- Added getter/setter for `selection_config`

### 2. `src/physics/solver_manager.rs`
- Updated `get_or_create_solver()` to accept `surface_id` parameter for per-surface config lookup
- Returns `SolverSelectionResult` for transparency into selection decisions

### 3. `src/sim/engine.rs` (ThermalModel)
- Added `enable_solver_manager(selection_config)` method accepting `SolverSelectionConfig`
- Added `get_solver_manager()`, `get_solver_manager_mut()` accessors
- Added `disable_solver_manager()`, `solver_manager_is_enabled()` methods

## Why

Issue #502 requires that Fluxion can "choose reduced-order vs reference conduction intentionally, not implicitly." The previous implementation relied on implicit automatic selection based on thermal mass time constant without exposing configuration control or selection rationale.

## Implementation Details

The new API allows explicit control over solver selection:

\`\`\`rust
// Automatic selection based on thermal mass (existing behavior)
model.enable_solver_manager(SolverSelectionConfig::Automatic);

// Force all surfaces to use CTF
model.enable_solver_manager(SolverSelectionConfig::ForceMethod(ThermalMethod::CTF));

// Per-surface explicit selection
model.enable_solver_manager(SolverSelectionConfig::PerSurface(vec![
    SurfaceSolverConfig::wall(ThermalMethod::FiveR1C),
    SurfaceSolverConfig::roof(ThermalMethod::CTF),
]));
\`\`\`

Selection result provides transparency:
\`\`\`rust
let result = selector.select_with_result(&wall, "Wall");
println!("Method: {:?}, Reason: {}, τ: {:?}h", 
    result.method, result.reason, result.time_constant_hours);
\`\`\`

This satisfies Issue #502's definition of done: "Per-case or per-surface solver selection is testable and exposed through internal configuration."

---

This PR was written using [Vibe Kanban](https://vibekanban.com)