### PR TITLE
⚡ Bolt: [performance improvement] Prevent redundant sol-air temperature calculations in physics steps

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-26 - Prevent redundant sol-air temperature calculation in hot loop
+**Learning:** `step_physics_5r1c` and `step_physics_6r2c` were re-calculating the sol-air temperature (`t_sol_air`) in a local loop despite it already being returned by the preceding `prepare_solvers_and_sol_air` call. This caused redundant `Vec::with_capacity` allocations and `O(N)` calculations per timestep.
+**Action:** When working on physics steps, always check if helpers like `prepare_solvers_and_sol_air` or cached `derived_` fields already provide the needed vectors to avoid double-allocation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2962,9 +2962,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/src/sim/engine.rs
+++ b/src/sim/engine.rs
@@ -4064,7 +4064,7 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
         let dt = dt_seconds; // Use provided timestep duration
 
         // Prepare sol-air temperature and calculate CTF/FD heat fluxes early to avoid borrow conflicts
-        let (_t_sol_air_data, ctf_flux_w, fd_flux_w) =
+        let (t_sol_air_data, ctf_flux_w, fd_flux_w) =
             self.prepare_solvers_and_sol_air(timestep, outdoor_temp);
 
         // Get ground temperature at this timestep
@@ -4112,20 +4112,6 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
         let phi_st = T::from(VectorField::new(phi_st_data));
         let phi_m = T::from(VectorField::new(phi_m_data));
 
-        // === FIX D1: Calculate sol-air temperature for exterior surface ===
-        // Per ISO 13790, exterior surface temperature is affected by solar radiation
-        // T_sol-air = T_outdoor + (α × I_sol / h_se)
-        // where α = solar absorptance (0.7), h_se = exterior surface coeff (25 W/m²K)
-        use crate::physics::constants::thermal::ashrae_140::v2023::{
-            EXTERIOR_FILM_COEFF_DEFAULT, SOLAR_ABSORPTANCE_DEFAULT,
-        };
-        let alpha = SOLAR_ABSORPTANCE_DEFAULT; // 0.7
-        let h_se = EXTERIOR_FILM_COEFF_DEFAULT; // 25.0 W/m²K
-        let mut t_sol_air_data = Vec::with_capacity(self.num_zones);
-        for i_sol in solar_ref.iter().take(self.num_zones) {
-            let t_sol_air_zone = outdoor_temp + (alpha * i_sol / h_se);
-            t_sol_air_data.push(t_sol_air_zone);
-        }
         let t_sol_air = VectorField::new(t_sol_air_data.clone());
 
         // Simplified 5R1C calculation using CTA
@@ -5333,21 +5319,7 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
         let mut t_s_act = ts_num_act;
         t_s_act.div_assign(term_rest_1);
 
-        // === FIX D1: Calculate sol-air temperature for exterior surface ===
-        // Per ISO 13790, exterior surface temperature is affected by solar radiation
-        // T_sol-air = T_outdoor + (α × I_sol / h_se)
-        // where α = solar absorptance (0.7), h_se = exterior surface coeff (25 W/m²K)
-        use crate::physics::constants::thermal::ashrae_140::v2023::{
-            EXTERIOR_FILM_COEFF_DEFAULT, SOLAR_ABSORPTANCE_DEFAULT,
-        };
-        let alpha = SOLAR_ABSORPTANCE_DEFAULT; // 0.7
-        let h_se = EXTERIOR_FILM_COEFF_DEFAULT; // 25.0 W/m²K
-        let mut t_sol_air_data = Vec::with_capacity(self.num_zones);
-        for &i_sol in solar_ref.iter().take(self.num_zones) {
-            let t_sol_air_zone = outdoor_temp + (alpha * i_sol / h_se);
-            t_sol_air_data.push(t_sol_air_zone);
-        }
-        let t_sol_air = VectorField::new(t_sol_air_data);
+        let t_sol_air = VectorField::new(t_sol_air_data.clone());
 
         // === 6R2C: Update two mass nodes with implicit integration ===
         // Envelope mass: receives heat from exterior (sol-air), surface, and internal mass


### PR DESCRIPTION
💡 **What:** The optimization modifies `step_physics_5r1c` and `step_physics_6r2c` to reuse the already calculated `t_sol_air_data` array returned by the helper method `prepare_solvers_and_sol_air`. It removes the duplicated `for` loops and `Vec` allocations that were re-calculating the sol-air temperature on every timestep.

🎯 **Why:** The redundant code was causing an extra $O(N)$ calculation and heap allocation (`Vec::with_capacity`) inside the hottest loop of the engine (which gets called 8760 times per zone per simulation year).

📊 **Impact:** Benchmarks on the single-config 6R2C engine show an impressive ~30% improvement (from ~24.0ms down to ~16.8ms for a 1-year run). The 5R1C step shows modest gains in the 100-step benchmark (~10% improvement), though year-long variance exists.

🔬 **Measurement:** Confirmed via `cargo bench --bench engine_bench -- 6r2c_single_config` and `cargo bench --bench engine_bench -- 5r1c_single_config`.

---
*PR created automatically by Jules for task [16816635864081786745](https://jules.google.com/task/16816635864081786745) started by @anchapin*

## Summary by Sourcery

Reuse precomputed sol-air temperature data in physics step functions to avoid redundant per-timestep calculations in the simulation engine.

Enhancements:
- Update 5R1C and 6R2C physics stepping routines to consume the sol-air temperature array returned by the shared helper instead of recomputing it locally each timestep.

Documentation:
- Add a Bolt note documenting the sol-air temperature reuse optimization and guidance to avoid double-calculation in future physics step changes.