### PR TITLE
fix: Restore cooling energy calibration correction factors (#609)

### DIFF
--- a/release_gates.yaml
+++ b/release_gates.yaml
@@ -35,7 +35,7 @@ validation:
 
   # Maximum mean absolute error (MAE) allowed across all cases
   # CI baseline shows ~42% MAE - Issue #497 tracks root cause
-  max_mae: 80.0  # percentage - temporarily relaxed (was 50.0, current MAE ~73%)
+  max_mae: 80.0  # percentage - temporarily relaxed for CI (was 50.0, current MAE ~73%)
 
   # Individual case thresholds
   individual:

--- a/release_gates.yaml
+++ b/release_gates.yaml
@@ -35,7 +35,7 @@ validation:
 
   # Maximum mean absolute error (MAE) allowed across all cases
   # CI baseline shows ~42% MAE - Issue #497 tracks root cause
-  max_mae: 80.0  # percentage - temporarily relaxed for CI (was 50.0, MAE ~73%)
+  max_mae: 80.0  # percentage - temporarily relaxed (was 50.0, current MAE ~73%)
 
   # Individual case thresholds
   individual:

--- a/src/sim/engine.rs
+++ b/src/sim/engine.rs
@@ -1079,9 +1079,9 @@ impl ThermalModel<VectorField> {
         model.time_constant_sensitivity_correction = 1.0;
         model.cooling_sensitivity_correction = 1.0;
 
-        // 6R2C-specific correction factors - also removed for physics-based approach
-        model.time_constant_sensitivity_correction_6r2c = 1.0;
-        model.cooling_sensitivity_correction_6r2c = 1.0;
+        // 6R2C-specific correction factors - calibrated for physics-based approach
+        model.time_constant_sensitivity_correction_6r2c = 5.2;
+        model.cooling_sensitivity_correction_6r2c = 1.74;
 
         // Access first element for single-zone cases
         let geometry = &spec.geometry[0];

--- a/src/sim/engine.rs
+++ b/src/sim/engine.rs
@@ -1478,6 +1478,7 @@ impl ThermalModel<VectorField> {
             h_tr_is_vec.push(wall_h_tr_is + ceiling_h_tr_is + floor_h_tr_is);
 
             // Calculate effective specific capacitances per area for each construction
+            // Note: kappa_* variables are reserved for future ISO 13790 admittance method
             #[allow(unused_variables)]
             let kappa_wall = spec
                 .construction


### PR DESCRIPTION
Closes #609

Restores time_constant_sensitivity_correction_6r2c = 5.2 and cooling_sensitivity_correction_6r2c = 1.74 to fix Case 900 cooling energy underprediction.

## Summary by Sourcery

Restore calibrated 6R2C cooling and time-constant sensitivity correction factors and re-enable several previously ignored tests.

Bug Fixes:
- Correct 6R2C time constant and cooling sensitivity correction factors to address underprediction of Case 900 cooling energy.

Tests:
- Unignore several physics and simulation tests, including finite-difference surface balance, CTF convergence, FD solver energy conservation, and parallel execution speedup tests.