### PR TITLE
fix: Use official ASHRAE 140 weather file for EPW compliance (#611)

### DIFF
--- a/src/analysis/delta.rs
+++ b/src/analysis/delta.rs
@@ -2,7 +2,7 @@ use crate::physics::cta::VectorField;
 use crate::sim::engine::ThermalModel;
 use crate::validation::ashrae_140_cases::CaseSpec;
 use crate::validation::diagnostic::HourlyData;
-use crate::weather::denver::DenverTmyWeather;
+use crate::weather::epw::EpwWeatherSource;
 use crate::weather::WeatherSource;
 use anyhow::Result;
 use csv::WriterBuilder;
@@ -236,8 +236,11 @@ fn run_simulation(spec: &CaseSpec, collect_hourly: bool) -> Result<SimulationRes
     }
     model.hvac_enabled = VectorField::new(hvac_enabled_vals.clone());
 
-    // Prepare weather (Denver TMY)
-    let weather = DenverTmyWeather::new();
+    // Prepare weather (Denver EPW)
+    let weather = EpwWeatherSource::from_file(
+        "assets/weather/USA_CO_Denver-Stapleton.Intl.AP.724690_TMY.epw",
+    )
+    .expect("Failed to load EPW weather data");
 
     // Accumulators
     let mut annual_heating_joules: f64 = 0.0;

--- a/src/bin/fluxion.rs
+++ b/src/bin/fluxion.rs
@@ -77,7 +77,7 @@ use fluxion::validation::guardrails;
 use fluxion::validation::reporter::{BaselineMetrics, ValidationReportGenerator};
 use fluxion::validation::statistical::StatisticalValidator;
 use fluxion::validation::ASHRAE140Validator;
-use fluxion::weather::denver::DenverTmyWeather;
+use fluxion::weather::epw::EpwWeatherSource;
 use fluxion::BatchOracle;
 use serde::Deserialize;
 use std::env;
@@ -589,7 +589,10 @@ fn validate_diagnostic_case(case_spec: &str) -> Result<()> {
 
             // Run validation
             let validator = ASHRAE140Validator::new();
-            let weather = DenverTmyWeather::new();
+            let weather = EpwWeatherSource::from_file(
+                "assets/weather/USA_CO_Denver-Stapleton.Intl.AP.724690_TMY.epw",
+            )
+            .expect("Failed to load EPW weather data");
             let (results, _) = validator.simulate_case_with_diagnostics(&spec, &weather, case_spec);
 
             println!(
@@ -1032,7 +1035,10 @@ fn main() -> Result<()> {
             let spec = case_id_to_spec(&case)
                 .ok_or_else(|| anyhow::anyhow!("Unknown case ID: {}", case))?;
             let validator = ASHRAE140Validator::new();
-            let weather = DenverTmyWeather::new();
+            let weather = EpwWeatherSource::from_file(
+                "assets/weather/USA_CO_Denver-Stapleton.Intl.AP.724690_TMY.epw",
+            )
+            .expect("Failed to load EPW weather data");
             let (_, diagnostic) = validator.simulate_case_with_diagnostics(&spec, &weather, &case);
             let breakdown = diagnostic.energy_breakdown;
             let entries =
@@ -1051,7 +1057,10 @@ fn main() -> Result<()> {
             let spec = case_id_to_spec(&case)
                 .ok_or_else(|| anyhow::anyhow!("Unknown case ID: {}", case))?;
             let validator = ASHRAE140Validator::new();
-            let weather = DenverTmyWeather::new();
+            let weather = EpwWeatherSource::from_file(
+                "assets/weather/USA_CO_Denver-Stapleton.Intl.AP.724690_TMY.epw",
+            )
+            .expect("Failed to load EPW weather data");
             let (_, diagnostic) = validator.simulate_case_with_diagnostics(&spec, &weather, &case);
             // Ensure temperature profile has data (free-floating case)
             if diagnostic.temp_profile.hourly_temps.is_empty() {

--- a/src/validation/ashrae_140_cases.rs
+++ b/src/validation/ashrae_140_cases.rs
@@ -2122,17 +2122,20 @@ impl CaseBuilder {
         Ok(spec)
     }
 
-    /// Generate weather data for ASHRAE 140 cases using Denver TMY.
+    /// Generate weather data for ASHRAE 140 cases using EPW file.
     ///
     /// This creates a vector of 8760 HourlyWeatherData instances representing
     /// a full year of Denver weather with DNI, DHI, GHI, temperature, and humidity.
     ///
-    /// Note: Weather data should be loaded dynamically from DenverTmyWeather in validation,
+    /// Note: Weather data should be loaded dynamically from EpwWeatherSource in validation,
     /// not pre-generated here to avoid performance issues.
     #[allow(dead_code)]
     pub fn generate_denver_weather_data() -> Vec<HourlyWeatherData> {
-        use crate::weather::denver::DenverTmyWeather;
-        let weather = DenverTmyWeather::new();
+        use crate::weather::epw::EpwWeatherSource;
+        let weather = EpwWeatherSource::from_file(
+            "assets/weather/USA_CO_Denver-Stapleton.Intl.AP.724690_TMY.epw",
+        )
+        .expect("Failed to load EPW weather data");
 
         (0..8760)
             .map(|hour| weather.get_hourly_data(hour).unwrap())

--- a/src/validation/ashrae_140_validator.rs
+++ b/src/validation/ashrae_140_validator.rs
@@ -10,7 +10,7 @@ use crate::validation::diagnostic::{
 use crate::validation::diagnostics::SimulationDiagnostics;
 use crate::validation::multi_reference::MultiReferenceDB;
 use crate::validation::report::{BenchmarkData, BenchmarkReport, MetricType, ValidationStatus};
-use crate::weather::denver::DenverTmyWeather;
+use crate::weather::epw::EpwWeatherSource;
 use crate::weather::WeatherSource;
 use rayon::prelude::*;
 use std::path::Path;
@@ -339,7 +339,10 @@ impl ASHRAE140Validator {
         let mut report = BenchmarkReport::new();
         let mut diagnostic_report = DiagnosticReport::new(self.diagnostic_config.clone());
         let benchmark_data = benchmark::get_all_benchmark_data();
-        let weather = DenverTmyWeather::new();
+        let weather = EpwWeatherSource::from_file(
+            "assets/weather/USA_CO_Denver-Stapleton.Intl.AP.724690_TMY.epw",
+        )
+        .expect("Failed to load EPW weather data");
 
         // Cases to validate - all 18 ASHRAE 140 cases
         let cases = vec![
@@ -563,7 +566,10 @@ impl ASHRAE140Validator {
     pub fn validate_with_ideal_control(&mut self, case: ASHRAE140Case) -> BenchmarkReport {
         let mut report = BenchmarkReport::new();
         let benchmark_data = benchmark::get_all_benchmark_data();
-        let weather = DenverTmyWeather::new();
+        let weather = EpwWeatherSource::from_file(
+            "assets/weather/USA_CO_Denver-Stapleton.Intl.AP.724690_TMY.epw",
+        )
+        .expect("Failed to load EPW weather data");
 
         let case_id = case.number();
         if let Some(data) = benchmark_data.get(&case_id) {
@@ -653,7 +659,7 @@ impl ASHRAE140Validator {
     fn simulate_case_with_ideal_control(
         &self,
         spec: &CaseSpec,
-        weather: &DenverTmyWeather,
+        weather: &EpwWeatherSource,
         controller: &IdealHVACController,
     ) -> CaseResults {
         let mut model = ThermalModel::<VectorField>::from_spec(spec);
@@ -864,7 +870,10 @@ impl ASHRAE140Validator {
     ) -> (BenchmarkReport, DiagnosticCollector) {
         let mut report = BenchmarkReport::new();
         let benchmark_data = benchmark::get_all_benchmark_data();
-        let weather = DenverTmyWeather::new();
+        let weather = EpwWeatherSource::from_file(
+            "assets/weather/USA_CO_Denver-Stapleton.Intl.AP.724690_TMY.epw",
+        )
+        .expect("Failed to load EPW weather data");
 
         let case_id = case.number();
         if let Some(data) = benchmark_data.get(&case_id) {
@@ -990,7 +999,10 @@ impl ASHRAE140Validator {
         let mut report = BenchmarkReport::new();
         report.set_start(); // Record start time
         let benchmark_data = benchmark::get_all_benchmark_data();
-        let weather = DenverTmyWeather::new();
+        let weather = EpwWeatherSource::from_file(
+            "assets/weather/USA_CO_Denver-Stapleton.Intl.AP.724690_TMY.epw",
+        )
+        .expect("Failed to load EPW weather data");
 
         // Cases to validate - baseline cases + diagnostic cases
         // Skip baseline cases if skip_baseline_cases is true (Phase 18)
@@ -1412,7 +1424,7 @@ impl ASHRAE140Validator {
         }
     }
 
-    fn simulate_case(&self, spec: &CaseSpec, weather: &DenverTmyWeather) -> CaseResults {
+    fn simulate_case(&self, spec: &CaseSpec, weather: &EpwWeatherSource) -> CaseResults {
         let mut model = ThermalModel::<VectorField>::from_spec(spec);
 
         // Phase 29: Enable advanced solver (CTF/FD) for high-mass cases
@@ -1621,7 +1633,7 @@ impl ASHRAE140Validator {
     fn simulate_case_with_diagnostics_collector(
         &mut self,
         spec: &CaseSpec,
-        weather: &DenverTmyWeather,
+        weather: &EpwWeatherSource,
     ) -> CaseResults {
         let mut model = ThermalModel::<VectorField>::from_spec(spec);
         // Attach simulation diagnostics if requested (Phase 5)
@@ -1914,7 +1926,7 @@ impl ASHRAE140Validator {
     pub fn simulate_case_with_diagnostics(
         &self,
         spec: &CaseSpec,
-        weather: &DenverTmyWeather,
+        weather: &EpwWeatherSource,
         case_id: &str,
     ) -> (CaseResults, CaseDiagnostic) {
         let mut model = ThermalModel::<VectorField>::from_spec(spec);
@@ -2213,7 +2225,10 @@ impl ASHRAE140Validator {
     /// ```
     pub fn validate_ashrae_140(spec: &CaseSpec) -> FreeFloatValidationResult {
         let mut model = ThermalModel::<VectorField>::from_spec(spec);
-        let weather = DenverTmyWeather::new();
+        let weather = EpwWeatherSource::from_file(
+            "assets/weather/USA_CO_Denver-Stapleton.Intl.AP.724690_TMY.epw",
+        )
+        .expect("Failed to load EPW weather data");
 
         // Reset tracking for clean simulation
         model.reset_peak_power();
@@ -2287,7 +2302,10 @@ impl ASHRAE140Validator {
     pub fn validate_case_960(&self) -> ValidationReport {
         let spec = ASHRAE140Case::Case960.spec();
         let mut model = ThermalModel::<VectorField>::from_spec(&spec);
-        let weather = DenverTmyWeather::new();
+        let weather = EpwWeatherSource::from_file(
+            "assets/weather/USA_CO_Denver-Stapleton.Intl.AP.724690_TMY.epw",
+        )
+        .expect("Failed to load EPW weather data");
 
         // SESSION 23 FIX: Enable 6R2C model for proper sunspace thermal dynamics
         // The 6R2C model (6 Resistances, 2 Capacitances) better represents:
@@ -2475,7 +2493,10 @@ pub fn validate_case_with_diagnostics(
         model.set_diagnostics(Some(diag));
     }
 
-    let weather = DenverTmyWeather::new();
+    let weather = EpwWeatherSource::from_file(
+        "assets/weather/USA_CO_Denver-Stapleton.Intl.AP.724690_TMY.epw",
+    )
+    .expect("Failed to load EPW weather data");
 
     // Simulation state
     let mut _annual_heating_joules = 0.0;

--- a/src/validation/case_960.rs
+++ b/src/validation/case_960.rs
@@ -19,7 +19,7 @@ use crate::sim::engine::ThermalModel;
 use crate::validation::ashrae_140_cases::ASHRAE140Case;
 use crate::validation::ashrae_140_multi_zone::Case960Reference;
 use crate::validation::report::ValidationStatus;
-use crate::weather::denver::DenverTmyWeather;
+use crate::weather::epw::EpwWeatherSource;
 use crate::weather::WeatherSource;
 use serde::{Deserialize, Serialize};
 
@@ -51,7 +51,7 @@ pub struct Case960ReferenceImplementation {
     reference: Case960Reference,
     /// Weather data for Denver
     #[allow(dead_code)]
-    weather: DenverTmyWeather,
+    weather: EpwWeatherSource,
 }
 
 impl Default for Case960ReferenceImplementation {
@@ -65,7 +65,10 @@ impl Case960ReferenceImplementation {
     pub fn new() -> Self {
         Self {
             reference: Case960Reference::load_case_960_reference_data(),
-            weather: DenverTmyWeather::new(),
+            weather: EpwWeatherSource::from_file(
+                "assets/weather/USA_CO_Denver-Stapleton.Intl.AP.724690_TMY.epw",
+            )
+            .expect("Failed to load EPW weather data"),
         }
     }
 
@@ -110,7 +113,10 @@ impl Case960ReferenceImplementation {
     /// Case960Result containing annual energy, peak loads, and temperature profiles
     pub fn run_case_960_simulation() -> Case960Result {
         let mut model = Self::create_case_960_thermal_model();
-        let weather = DenverTmyWeather::new();
+        let weather = EpwWeatherSource::from_file(
+            "assets/weather/USA_CO_Denver-Stapleton.Intl.AP.724690_TMY.epw",
+        )
+        .expect("Failed to load EPW weather data");
 
         // Reset energy tracking for clean simulation
         model.reset_heating_cooling_energy();

--- a/src/validation/thermal_mass_energy_accounting.rs
+++ b/src/validation/thermal_mass_energy_accounting.rs
@@ -358,10 +358,13 @@ pub fn calculate_zone_energy(model: &ThermalModel<VectorField>) -> f64 {
 pub fn validate_energy_balance_over_year(
     model: &mut ThermalModel<VectorField>,
 ) -> EnergyBalanceReport {
-    use crate::weather::denver::DenverTmyWeather;
+    use crate::weather::epw::EpwWeatherSource;
     use crate::weather::WeatherSource;
 
-    let weather = DenverTmyWeather::new();
+    let weather = EpwWeatherSource::from_file(
+        "assets/weather/USA_CO_Denver-Stapleton.Intl.AP.724690_TMY.epw",
+    )
+    .expect("Failed to load EPW weather data");
     let steps = 8760;
     let dt = 3600.0; // Timestep duration in seconds (1 hour)
     let num_zones = model.num_zones;

--- a/tests/ashrae_140_case_600_series.rs
+++ b/tests/ashrae_140_case_600_series.rs
@@ -174,11 +174,13 @@ fn run_annual_simulation(case_enum: ASHRAE140Case) -> (f64, f64, f64, f64) {
         let energy_kwh = model.step_physics(step, weather_data.dry_bulb_temp, 3600.0);
         let energy_joules = energy_kwh * 3.6e6;
 
-        if energy_kwh > 0.0 || zone_temp_before < model.heating_setpoint {
+        // Classify energy based on HVAC output sign, not zone temperature
+        // Positive = heating energy, Negative = cooling energy
+        if energy_kwh > 0.0 {
             total_heating += energy_joules;
             let power_watts = energy_joules / 3600.0;
             peak_heating = peak_heating.max(power_watts);
-        } else if energy_kwh < 0.0 || zone_temp_before > model.cooling_setpoint {
+        } else if energy_kwh < 0.0 {
             total_cooling += -energy_joules;
             let power_watts = -energy_joules / 3600.0;
             peak_cooling = peak_cooling.max(power_watts);


### PR DESCRIPTION
## Summary

Replace synthetic `DenverTmyWeather` with real EPW weather data from the official ASHRAE 140 compliant TMY file (USA_CO_Denver-Stapleton.Intl.AP.724690_TMY.epw) for EPW compliance per issue #611.

## Changes

- Replaced all instances of `DenverTmyWeather` with `EpwWeatherSource` loading from `assets/weather/USA_CO_Denver-Stapleton.Intl.AP.724690_TMY.epw`
- Updated weather loading in:
  - `src/validation/ashrae_140_validator.rs` - 5 locations
  - `src/validation/case_960.rs` - 2 locations
  - `src/validation/ashrae_140_cases.rs` - 1 location
  - `src/analysis/delta.rs` - 1 location
  - `src/validation/thermal_mass_energy_accounting.rs` - 1 location
  - `src/bin/fluxion.rs` - 3 locations
- Fixed energy accumulation bug in `tests/ashrae_140_case_600_series.rs`: removed incorrect `||` conditions that misclassified cooling as heating based on zone temperature

## Verification

\`\`\`bash
cargo test --test ashrae_140_validation  # 3/3 passed
cargo test                              # 2382 passed, 0 failed
\`\`\`

## Issue

Fixes #611 - EPW compliance requires using official ASHRAE 140 weather data instead of synthetic weather.