### PR TITLE
feat: Enhance surrogate model with SHAP and ensembles (#553)

### DIFF
--- a/src/sim/thermal_model_core.rs
+++ b/src/sim/thermal_model_core.rs
@@ -353,9 +353,9 @@ impl ThermalModel<VectorField> {
         model.time_constant_sensitivity_correction = 1.0;
         model.cooling_sensitivity_correction = 1.0;
 
-        // 6R2C-specific correction factors - also removed for physics-based approach
-        model.time_constant_sensitivity_correction_6r2c = 1.0;
-        model.cooling_sensitivity_correction_6r2c = 1.0;
+        // 6R2C-specific correction factors - calibrated for physics-based approach
+        model.time_constant_sensitivity_correction_6r2c = 5.2;
+        model.cooling_sensitivity_correction_6r2c = 1.74;
 
         // Access first element for single-zone cases
         let geometry = &spec.geometry[0];
@@ -752,6 +752,7 @@ impl ThermalModel<VectorField> {
             h_tr_is_vec.push(wall_h_tr_is + ceiling_h_tr_is + floor_h_tr_is);
 
             // Calculate effective specific capacitances per area for each construction
+            // Note: kappa_* variables are reserved for future ISO 13790 admittance method
             #[allow(unused_variables)]
             let kappa_wall = spec
                 .construction


### PR DESCRIPTION
Rebased version of PR #619 adapted for the modular thermal model structure.

## Changes from Original PR #619
The original PR #619 was created before the thermal model refactor (PR #628). This version adapts the changes for the new modular structure:

- **thermal_model_core.rs**: Updated 6R2C correction factors from 1.0 to 5.2 (heating) and 1.74 (cooling) for physics-based calibration
- **thermal_model_core.rs**: Added kappa_* comment for future ISO 13790 admittance method

## What was already merged
-  - Added in PR #618 (adaptive hourly calibration)
-  exports - Already on main
-  - Already on main

## Testing
Builds successfully with only warnings.

## Summary by Sourcery

Adjust 6R2C thermal model calibration parameters and document reserved variables for future ISO 13790 admittance method.

Enhancements:
- Update 6R2C-specific thermal sensitivity correction factors for heating and cooling to reflect physics-based calibration.
- Add documentation comment reserving kappa_* variables for a future ISO 13790 admittance-based implementation.