### PR TITLE
fix(clippy): remove unused imports from thermal model files

### DIFF
--- a/src/sim/thermal_model_core.rs
+++ b/src/sim/thermal_model_core.rs
@@ -3,50 +3,23 @@
 //! ISO 13790-compliant 5R1C/6R2C thermal network implementation.
 //! Contains the core thermal model types, struct, and implementations.
 
-use log::{debug, error, info, trace, warn};
-use std::collections::HashMap;
 use std::sync::OnceLock;
 
-use crate::ai::surrogate::SurrogateManager;
-use crate::physics::constants::thermal::ashrae_140::INTERIOR_FILM_COEFF;
 use crate::physics::cta::{ContinuousTensor, VectorField};
-use crate::physics::ctf_coefficients::{CTFCalculator, CTFCoefficients, CTFMaterial};
-use crate::physics::ctf_solver::{CTFSolver, CTFSolverConfig};
-use crate::physics::ctf_zone_coupling::CtfZoneCouplingSolver;
 use crate::sim::adaptive_timestep::TimestepMode;
 use crate::sim::assembly::BuildingAssembly;
-use crate::sim::boundary::{
-    ConstantGroundTemperature, DynamicGroundTemperature, GroundTemperature,
-};
 use crate::sim::components::WallSurface;
-use crate::sim::equipment::Equipment;
-use crate::sim::holiday;
-use crate::sim::hvac::{
-    AnyEquipment, CyclingTracker, EconomizerMode, HVACMode as EquipmentHVACMode, IdealLoadsSystem,
-    PredictiveController, VariableCapacityEquipment,
-};
-use crate::sim::hvac_controller::{HVACMode, HvacSystemMode, IdealHVACController};
-use crate::sim::interzone::{calculate_stack_effect_ach, calculate_ventilation_heat_transfer};
-use crate::sim::lighting::LightingSchedule;
-use crate::sim::occupancy::{BuildingType, OccupancyProfile};
-use crate::sim::profiles;
+use crate::sim::hvac::{CyclingTracker, EconomizerMode, IdealLoadsSystem, PredictiveController};
+use crate::sim::hvac_controller::{HvacSystemMode, IdealHVACController};
+use crate::sim::occupancy::BuildingType;
 use crate::sim::schedule::DailySchedule;
 use crate::sim::shading::{Overhang, ShadeFin, Side};
-use crate::sim::solar::{calculate_hourly_solar, WindowProperties};
-use crate::sim::thermal_integration::{
-    backward_euler_update, crank_nicolson_update, select_integration_method,
-    ThermalIntegrationMethod,
-};
+use crate::sim::solar::WindowProperties;
 use crate::sim::thermal_model_data::ThermalModelData;
-use crate::sim::timestep_solver::StepParameters;
 use crate::sim::view_factors;
-use crate::validation::ashrae_140_cases::{
-    CaseSpec, GeometrySpec, Orientation, ShadingType, WindowArea,
-};
+use crate::validation::ashrae_140_cases::{CaseSpec, Orientation, ShadingType};
 use crate::validation::config::{validate_assembly, validate_constants};
 use crate::validation::diagnostics::SimulationDiagnostics;
-use crate::weather::HourlyWeatherData;
-use crossbeam::channel::{Receiver, Sender};
 
 type SolversAndSolAirResult = (
     Vec<f64>,

--- a/src/sim/thermal_model_data.rs
+++ b/src/sim/thermal_model_data.rs
@@ -24,7 +24,6 @@ use crate::testing::integration::wiring::WiringTracer;
 use crate::validation::ashrae_140_cases::{NightVentilation, Orientation};
 use crate::validation::diagnostics::SimulationDiagnostics;
 use crate::weather::HourlyWeatherData;
-use log::{debug, error, info, trace, warn};
 use std::sync::Arc;
 
 pub struct ThermalModelData<T: ContinuousTensor<f64> + Clone> {

--- a/src/sim/thermal_model_iterative.rs
+++ b/src/sim/thermal_model_iterative.rs
@@ -3,50 +3,18 @@
 //! ISO 13790-compliant 5R1C/6R2C thermal network implementation.
 //! Contains the core thermal model types, struct, and implementations.
 
-use crossbeam::channel::{Receiver, Sender};
-use log::{debug, error, info, trace, warn};
 use std::collections::HashMap;
-use std::sync::OnceLock;
 
-use crate::ai::surrogate::SurrogateManager;
-use crate::physics::constants::thermal::ashrae_140::INTERIOR_FILM_COEFF;
 use crate::physics::cta::{ContinuousTensor, VectorField};
-use crate::physics::ctf_coefficients::{CTFCalculator, CTFCoefficients, CTFMaterial};
-use crate::physics::ctf_solver::{CTFSolver, CTFSolverConfig};
-use crate::physics::ctf_zone_coupling::CtfZoneCouplingSolver;
-use crate::sim::adaptive_timestep::TimestepMode;
-use crate::sim::assembly::BuildingAssembly;
 use crate::sim::boundary::{
     ConstantGroundTemperature, DynamicGroundTemperature, GroundTemperature,
 };
-use crate::sim::components::WallSurface;
-use crate::sim::equipment::Equipment;
 use crate::sim::holiday;
-use crate::sim::hvac::{
-    AnyEquipment, CyclingTracker, EconomizerMode, HVACMode as EquipmentHVACMode, IdealLoadsSystem,
-    PredictiveController, VariableCapacityEquipment,
-};
-use crate::sim::hvac_controller::{HVACMode, HvacSystemMode, IdealHVACController};
-use crate::sim::interzone::{calculate_stack_effect_ach, calculate_ventilation_heat_transfer};
-use crate::sim::lighting::LightingSchedule;
-use crate::sim::occupancy::{BuildingType, OccupancyProfile};
-use crate::sim::profiles;
-use crate::sim::schedule::DailySchedule;
-use crate::sim::shading::{Overhang, ShadeFin, Side};
+use crate::sim::shading::ShadeFin;
 use crate::sim::solar::{calculate_hourly_solar, WindowProperties};
-use crate::sim::thermal_integration::{
-    backward_euler_update, crank_nicolson_update, select_integration_method,
-    ThermalIntegrationMethod,
-};
-use crate::sim::thermal_model_core::{get_daily_cycle, ThermalModel, ThermalModelType};
-use crate::sim::thermal_model_data::ThermalModelData;
+use crate::sim::thermal_model_core::{get_daily_cycle, ThermalModel};
 use crate::sim::timestep_solver::StepParameters;
-use crate::sim::view_factors;
-use crate::validation::ashrae_140_cases::{
-    CaseSpec, GeometrySpec, Orientation, ShadingType, WindowArea,
-};
-use crate::validation::config::{validate_assembly, validate_constants};
-use crate::validation::diagnostics::SimulationDiagnostics;
+use crate::validation::ashrae_140_cases::{GeometrySpec, Orientation, WindowArea};
 use crate::weather::HourlyWeatherData;
 
 impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>> ThermalModel<T> {

--- a/src/sim/thermal_model_physics.rs
+++ b/src/sim/thermal_model_physics.rs
@@ -4,49 +4,24 @@
 //! Contains the core thermal model types, struct, and implementations.
 
 use crossbeam::channel::{Receiver, Sender};
-use log::{debug, error, info, trace, warn};
-use std::collections::HashMap;
-use std::sync::OnceLock;
+use log::{error, info, warn};
 
 use crate::ai::surrogate::SurrogateManager;
-use crate::physics::constants::thermal::ashrae_140::INTERIOR_FILM_COEFF;
 use crate::physics::cta::{ContinuousTensor, VectorField};
-use crate::physics::ctf_coefficients::{CTFCalculator, CTFCoefficients, CTFMaterial};
-use crate::physics::ctf_solver::{CTFSolver, CTFSolverConfig};
-use crate::physics::ctf_zone_coupling::CtfZoneCouplingSolver;
 use crate::sim::adaptive_timestep::TimestepMode;
-use crate::sim::assembly::BuildingAssembly;
-use crate::sim::boundary::{
-    ConstantGroundTemperature, DynamicGroundTemperature, GroundTemperature,
-};
-use crate::sim::components::WallSurface;
 use crate::sim::equipment::Equipment;
-use crate::sim::holiday;
-use crate::sim::hvac::{
-    AnyEquipment, CyclingTracker, EconomizerMode, HVACMode as EquipmentHVACMode, IdealLoadsSystem,
-    PredictiveController, VariableCapacityEquipment,
-};
-use crate::sim::hvac_controller::{HVACMode, HvacSystemMode, IdealHVACController};
+use crate::sim::hvac::{HVACMode as EquipmentHVACMode, VariableCapacityEquipment};
+use crate::sim::hvac_controller::HVACMode;
 use crate::sim::interzone::{calculate_stack_effect_ach, calculate_ventilation_heat_transfer};
 use crate::sim::lighting::LightingSchedule;
-use crate::sim::occupancy::{BuildingType, OccupancyProfile};
+use crate::sim::occupancy::OccupancyProfile;
 use crate::sim::profiles;
-use crate::sim::schedule::DailySchedule;
-use crate::sim::shading::{Overhang, ShadeFin, Side};
-use crate::sim::solar::{calculate_hourly_solar, WindowProperties};
 use crate::sim::thermal_integration::{
     backward_euler_update, crank_nicolson_update, select_integration_method,
     ThermalIntegrationMethod,
 };
-use crate::sim::thermal_model_core::{get_daily_cycle, ThermalModel, ThermalModelType};
-use crate::sim::thermal_model_data::ThermalModelData;
+use crate::sim::thermal_model_core::{get_daily_cycle, ThermalModel};
 use crate::sim::timestep_solver::StepParameters;
-use crate::sim::view_factors;
-use crate::validation::ashrae_140_cases::{
-    CaseSpec, GeometrySpec, Orientation, ShadingType, WindowArea,
-};
-use crate::validation::config::{validate_assembly, validate_constants};
-use crate::validation::diagnostics::SimulationDiagnostics;
 use crate::weather::HourlyWeatherData;
 
 impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>> ThermalModel<T> {

--- a/src/sim/thermal_model_solvers.rs
+++ b/src/sim/thermal_model_solvers.rs
@@ -3,51 +3,16 @@
 //! ISO 13790-compliant 5R1C/6R2C thermal network implementation.
 //! Contains the core thermal model types, struct, and implementations.
 
-use crossbeam::channel::{Receiver, Sender};
-use log::{debug, error, info, trace, warn};
-use std::collections::HashMap;
-use std::sync::OnceLock;
+use log::{debug, info, trace, warn};
 
-use crate::ai::surrogate::SurrogateManager;
 use crate::physics::constants::thermal::ashrae_140::INTERIOR_FILM_COEFF;
 use crate::physics::cta::{ContinuousTensor, VectorField};
-use crate::physics::ctf_coefficients::{CTFCalculator, CTFCoefficients, CTFMaterial};
+use crate::physics::ctf_coefficients::{CTFCalculator, CTFMaterial};
 use crate::physics::ctf_solver::{CTFSolver, CTFSolverConfig};
 use crate::physics::ctf_zone_coupling::CtfZoneCouplingSolver;
 use crate::sim::adaptive_timestep::TimestepMode;
-use crate::sim::assembly::BuildingAssembly;
-use crate::sim::boundary::{
-    ConstantGroundTemperature, DynamicGroundTemperature, GroundTemperature,
-};
-use crate::sim::components::WallSurface;
-use crate::sim::equipment::Equipment;
-use crate::sim::holiday;
-use crate::sim::hvac::{
-    AnyEquipment, CyclingTracker, EconomizerMode, HVACMode as EquipmentHVACMode, IdealLoadsSystem,
-    PredictiveController, VariableCapacityEquipment,
-};
-use crate::sim::hvac_controller::{HVACMode, HvacSystemMode, IdealHVACController};
-use crate::sim::interzone::{calculate_stack_effect_ach, calculate_ventilation_heat_transfer};
-use crate::sim::lighting::LightingSchedule;
-use crate::sim::occupancy::{BuildingType, OccupancyProfile};
-use crate::sim::profiles;
 use crate::sim::schedule::DailySchedule;
-use crate::sim::shading::{Overhang, ShadeFin, Side};
-use crate::sim::solar::{calculate_hourly_solar, WindowProperties};
-use crate::sim::thermal_integration::{
-    backward_euler_update, crank_nicolson_update, select_integration_method,
-    ThermalIntegrationMethod,
-};
-use crate::sim::thermal_model_core::{get_daily_cycle, ThermalModel, ThermalModelType};
-use crate::sim::thermal_model_data::ThermalModelData;
-use crate::sim::timestep_solver::StepParameters;
-use crate::sim::view_factors;
-use crate::validation::ashrae_140_cases::{
-    CaseSpec, GeometrySpec, Orientation, ShadingType, WindowArea,
-};
-use crate::validation::config::{validate_assembly, validate_constants};
-use crate::validation::diagnostics::SimulationDiagnostics;
-use crate::weather::HourlyWeatherData;
+use crate::sim::thermal_model_core::{ThermalModel, ThermalModelType};
 
 impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>> ThermalModel<T> {
     /// Updates derived physical parameters based on geometry and constants.


### PR DESCRIPTION
## Summary
Fixes 102 clippy unused import warnings that were being treated as errors in CI.

## Changes
Removes unused imports from thermal model files:
- `src/sim/thermal_model_core.rs`
- `src/sim/thermal_model_data.rs`
- `src/sim/thermal_model_iterative.rs`
- `src/sim/thermal_model_physics.rs`
- `src/sim/thermal_model_solvers.rs`

## Testing
- `cargo clippy --lib -- -D warnings` passes
- All 2379 tests pass

## Note
This is a prerequisite fix - these warnings exist on main and block CI. The actual thermal model/HVAC refactoring will be in a separate PR.