### PR TITLE
feat(ai): deepen modular_surrogate with Option B per ARCH-012

### DIFF
--- a/src/ai/modular_surrogate.rs
+++ b/src/ai/modular_surrogate.rs
@@ -70,7 +70,10 @@ impl CompositeSurrogate {
         }
     }
 
-    pub fn with_weights(components: Vec<ComponentSurrogate>, weights: Vec<f64>) -> Result<Self, String> {
+    pub fn with_weights(
+        components: Vec<ComponentSurrogate>,
+        weights: Vec<f64>,
+    ) -> Result<Self, String> {
         if components.is_empty() {
             return Err("CompositeSurrogate requires at least one component".to_string());
         }
@@ -126,9 +129,8 @@ impl CompositeSurrogate {
     }
 
     pub fn predict_loads(&self, temps: &[f64]) -> Vec<f64> {
-        self.predict_loads_with_fallback(temps).unwrap_or_else(|_| {
-            vec![0.0; temps.len()]
-        })
+        self.predict_loads_with_fallback(temps)
+            .unwrap_or_else(|_| vec![0.0; temps.len()])
     }
 
     pub fn predict_loads_with_fallback(&self, temps: &[f64]) -> Result<Vec<f64>, String> {
@@ -139,7 +141,12 @@ impl CompositeSurrogate {
         let predictions: Result<Vec<Vec<f64>>, String> = self
             .components
             .iter()
-            .map(|c| c.predict_loads_governed(temps, crate::ai::surrogate::SurrogateMode::NeuralWithFallback))
+            .map(|c| {
+                c.predict_loads_governed(
+                    temps,
+                    crate::ai::surrogate::SurrogateMode::NeuralWithFallback,
+                )
+            })
             .collect();
 
         let predictions = match predictions {
@@ -150,10 +157,7 @@ impl CompositeSurrogate {
             }
         };
 
-        let num_outputs = predictions
-            .first()
-            .map(|p| p.len())
-            .unwrap_or(temps.len());
+        let num_outputs = predictions.first().map(|p| p.len()).unwrap_or(temps.len());
 
         let mut weighted_sum = vec![0.0; num_outputs];
         for (pred, &weight) in predictions.iter().zip(self.weights.iter()) {
@@ -217,10 +221,7 @@ impl CompositeSurrogate {
             .map(|c| c.predict_loads(temps))
             .collect();
 
-        let num_outputs = predictions
-            .first()
-            .map(|p| p.len())
-            .unwrap_or(temps.len());
+        let num_outputs = predictions.first().map(|p| p.len()).unwrap_or(temps.len());
 
         let mut weighted_sum = vec![0.0; num_outputs];
         for (pred, &weight) in predictions.iter().zip(self.weights.iter()) {

--- a/src/ai/modular_surrogate.rs
+++ b/src/ai/modular_surrogate.rs
@@ -51,6 +51,7 @@ impl ComponentSurrogate {
 #[derive(Clone, Debug)]
 pub struct CompositeSurrogate {
     components: Vec<ComponentSurrogate>,
+    weights: Vec<f64>,
     domain: SurrogateDomain,
 }
 
@@ -61,7 +62,35 @@ impl CompositeSurrogate {
             "CompositeSurrogate requires at least one component"
         );
         let domain = Self::compute_intersection_domain(&components);
-        Self { components, domain }
+        let weights = vec![1.0 / components.len() as f64; components.len()];
+        Self {
+            components,
+            weights,
+            domain,
+        }
+    }
+
+    pub fn with_weights(components: Vec<ComponentSurrogate>, weights: Vec<f64>) -> Result<Self, String> {
+        if components.is_empty() {
+            return Err("CompositeSurrogate requires at least one component".to_string());
+        }
+        if components.len() != weights.len() {
+            return Err(format!(
+                "Components ({}) and weights ({}) length mismatch",
+                components.len(),
+                weights.len()
+            ));
+        }
+        let weight_sum: f64 = weights.iter().sum();
+        if (weight_sum - 1.0).abs() > 1e-9 {
+            return Err(format!("Weights must sum to 1.0, got {}", weight_sum));
+        }
+        let domain = Self::compute_intersection_domain(&components);
+        Ok(Self {
+            components,
+            weights,
+            domain,
+        })
     }
 
     fn compute_intersection_domain(components: &[ComponentSurrogate]) -> SurrogateDomain {
@@ -97,27 +126,139 @@ impl CompositeSurrogate {
     }
 
     pub fn predict_loads(&self, temps: &[f64]) -> Vec<f64> {
+        self.predict_loads_with_fallback(temps).unwrap_or_else(|_| {
+            vec![0.0; temps.len()]
+        })
+    }
+
+    pub fn predict_loads_with_fallback(&self, temps: &[f64]) -> Result<Vec<f64>, String> {
         if components_empty(&self.components) {
-            return vec![0.0; temps.len()];
+            return Ok(vec![0.0; temps.len()]);
         }
 
-        let first_pred = self.components[0].predict_loads(temps);
-        let mut sum = first_pred;
+        let predictions: Result<Vec<Vec<f64>>, String> = self
+            .components
+            .iter()
+            .map(|c| c.predict_loads_governed(temps, crate::ai::surrogate::SurrogateMode::NeuralWithFallback))
+            .collect();
 
-        for component in &self.components[1..] {
-            let pred = component.predict_loads(temps);
-            let len = std::cmp::min(sum.len(), pred.len());
-            sum.truncate(len);
-            for (s, &p) in sum.iter_mut().zip(pred.iter()) {
-                *s += p;
+        let predictions = match predictions {
+            Ok(p) => p,
+            Err(e) => {
+                log::warn!("Component failed, using analytical fallback: {}", e);
+                return self.components[0].manager.analytical_loads(temps);
+            }
+        };
+
+        let num_outputs = predictions
+            .first()
+            .map(|p| p.len())
+            .unwrap_or(temps.len());
+
+        let mut weighted_sum = vec![0.0; num_outputs];
+        for (pred, &weight) in predictions.iter().zip(self.weights.iter()) {
+            for (i, &val) in pred.iter().enumerate().take(num_outputs) {
+                weighted_sum[i] += val * weight;
             }
         }
 
-        if sum.len() < temps.len() {
-            sum.resize(temps.len(), 0.0);
+        Ok(weighted_sum)
+    }
+
+    pub fn component_confidence_scores(&self, temps: &[f64]) -> Vec<f64> {
+        let predictions: Vec<Vec<f64>> = self
+            .components
+            .iter()
+            .map(|c| c.predict_loads(temps))
+            .collect();
+
+        if predictions.is_empty() {
+            return vec![];
         }
 
-        sum
+        let num_outputs = predictions[0].len();
+        let n = predictions.len();
+
+        let mut means = vec![0.0; num_outputs];
+        for pred in &predictions {
+            for (i, &val) in pred.iter().enumerate().take(num_outputs) {
+                means[i] += val / n as f64;
+            }
+        }
+
+        let mut scores = vec![0.0; n];
+        for (j, pred) in predictions.iter().enumerate() {
+            let mut total_deviation = 0.0;
+            for (i, &val) in pred.iter().enumerate().take(num_outputs) {
+                let deviation = (val - means[i]).powi(2);
+                total_deviation += deviation;
+            }
+            scores[j] = (-total_deviation.sqrt()).exp();
+        }
+
+        let sum: f64 = scores.iter().sum();
+        if sum > 0.0 {
+            for score in &mut scores {
+                *score /= sum;
+            }
+        }
+
+        scores
+    }
+
+    pub fn predict_with_uncertainty(&self, temps: &[f64]) -> (Vec<f64>, Vec<f64>) {
+        if components_empty(&self.components) {
+            return (vec![0.0; temps.len()], vec![0.0; temps.len()]);
+        }
+
+        let predictions: Vec<Vec<f64>> = self
+            .components
+            .iter()
+            .map(|c| c.predict_loads(temps))
+            .collect();
+
+        let num_outputs = predictions
+            .first()
+            .map(|p| p.len())
+            .unwrap_or(temps.len());
+
+        let mut weighted_sum = vec![0.0; num_outputs];
+        for (pred, &weight) in predictions.iter().zip(self.weights.iter()) {
+            for (i, &val) in pred.iter().enumerate().take(num_outputs) {
+                weighted_sum[i] += val * weight;
+            }
+        }
+
+        let mut variances = vec![0.0; num_outputs];
+        if self.components.len() > 1 {
+            for pred in &predictions {
+                for (i, &val) in pred.iter().enumerate().take(num_outputs) {
+                    let diff = val - weighted_sum[i];
+                    variances[i] += diff * diff;
+                }
+            }
+            for var in &mut variances {
+                *var /= (self.components.len() - 1).max(1) as f64;
+            }
+        }
+
+        let std: Vec<f64> = variances.iter().map(|v| v.sqrt()).collect();
+        (weighted_sum, std)
+    }
+
+    pub fn predict_with_confidence(&self, temps: &[f64]) -> (Vec<f64>, Vec<f64>, Vec<f64>) {
+        let (mean, std) = self.predict_with_uncertainty(temps);
+        let lower: Vec<f64> = mean
+            .iter()
+            .zip(std.iter())
+            .map(|(&m, &s)| m - 2.0 * s)
+            .collect();
+        let upper: Vec<f64> = mean
+            .iter()
+            .zip(std.iter())
+            .map(|(&m, &s)| m + 2.0 * s)
+            .collect();
+        (mean, lower, upper)
     }
 
     pub fn predict_loads_governed(

--- a/src/physics/method_selector.rs
+++ b/src/physics/method_selector.rs
@@ -1016,12 +1016,10 @@ mod tests {
             per_surface_selection: true,
         };
 
-        assert_eq!(config.threshold_hours, 3.5);
         assert_eq!(
             config.override_method,
             Some(ThermalMethod::FiniteDifference)
         );
-        assert!(!config.enable_fallback);
         assert!(config.enable_automatic_selection);
         assert!(config.per_surface_selection);
     }

--- a/src/physics/method_selector.rs
+++ b/src/physics/method_selector.rs
@@ -222,8 +222,6 @@ impl ThermalMethodSelector {
             h_exterior: 25.0,
             selection_config: if config.per_surface_selection {
                 SolverSelectionConfig::PerSurface(vec![])
-            } else if config.enable_automatic_selection {
-                SolverSelectionConfig::Automatic
             } else {
                 SolverSelectionConfig::ForceMethod(
                     config
@@ -1016,10 +1014,12 @@ mod tests {
             per_surface_selection: true,
         };
 
+        assert_eq!(config.threshold_hours, 3.5);
         assert_eq!(
             config.override_method,
             Some(ThermalMethod::FiniteDifference)
         );
+        assert!(!config.enable_fallback);
         assert!(config.enable_automatic_selection);
         assert!(config.per_surface_selection);
     }

--- a/src/physics/method_selector.rs
+++ b/src/physics/method_selector.rs
@@ -222,6 +222,8 @@ impl ThermalMethodSelector {
             h_exterior: 25.0,
             selection_config: if config.per_surface_selection {
                 SolverSelectionConfig::PerSurface(vec![])
+            } else if config.enable_automatic_selection {
+                SolverSelectionConfig::Automatic
             } else {
                 SolverSelectionConfig::ForceMethod(
                     config

--- a/tests/test_modular_surrogates.rs
+++ b/tests/test_modular_surrogates.rs
@@ -29,22 +29,57 @@ mod tests {
     }
 
     #[test]
-    fn test_composite_surrogate_two_components_sum() {
+    fn test_composite_surrogate_weighted_sum() {
         let manager1 = SurrogateManager::new().unwrap();
         let manager2 = SurrogateManager::new().unwrap();
         let comp1 = ComponentSurrogate::new("solar", manager1);
         let comp2 = ComponentSurrogate::new("hvac", manager2);
-        let composite = CompositeSurrogate::new(vec![comp1, comp2]);
+
+        let weights = vec![0.7, 0.3];
+        let composite = CompositeSurrogate::with_weights(vec![comp1, comp2], weights).unwrap();
 
         let temps = vec![20.0, 21.0, 22.0];
         let loads = composite.predict_loads(&temps);
 
-        // Both mock managers return 1.2, so sum = 2.4
-        assert_eq!(loads, vec![2.4, 2.4, 2.4]);
+        assert_eq!(loads, vec![1.2, 1.2, 1.2]);
     }
 
     #[test]
-    fn test_composite_surrogate_three_components() {
+    fn test_composite_surrogate_default_equal_weights() {
+        let manager = SurrogateManager::new().unwrap();
+        let comp = ComponentSurrogate::new("test", manager.clone());
+        let composite = CompositeSurrogate::new(vec![comp.clone(), comp]);
+
+        let temps = vec![20.0, 21.0, 22.0];
+        let loads = composite.predict_loads(&temps);
+
+        assert_eq!(loads, vec![1.2, 1.2, 1.2]);
+    }
+
+    #[test]
+    fn test_composite_surrogate_weights_must_sum_to_one() {
+        let manager = SurrogateManager::new().unwrap();
+        let comp1 = ComponentSurrogate::new("solar", manager.clone());
+        let comp2 = ComponentSurrogate::new("hvac", manager);
+
+        let result = CompositeSurrogate::with_weights(vec![comp1, comp2], vec![0.5, 0.3]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("must sum to 1.0"));
+    }
+
+    #[test]
+    fn test_composite_surrogate_weights_length_mismatch() {
+        let manager = SurrogateManager::new().unwrap();
+        let comp1 = ComponentSurrogate::new("solar", manager.clone());
+        let comp2 = ComponentSurrogate::new("hvac", manager);
+
+        let result = CompositeSurrogate::with_weights(vec![comp1, comp2], vec![0.5, 0.3, 0.2]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("length mismatch"));
+    }
+
+    #[test]
+    fn test_composite_surrogate_three_components_equal_weights() {
         let managers: Vec<_> = (0..3).map(|_| SurrogateManager::new().unwrap()).collect();
         let components = managers
             .into_iter()
@@ -56,10 +91,26 @@ mod tests {
         let temps = vec![20.0, 25.0, 30.0];
         let loads = composite.predict_loads(&temps);
 
-        // 3 * 1.2 = 3.6 (use tolerance for floating point)
         for &val in &loads {
-            assert!((val - 3.6).abs() < 1e-9, "Expected ~3.6, got {}", val);
+            assert!((val - 1.2).abs() < 1e-9, "Expected ~1.2, got {}", val);
         }
+    }
+
+    #[test]
+    fn test_composite_surrogate_three_components_custom_weights() {
+        let managers: Vec<_> = (0..3).map(|_| SurrogateManager::new().unwrap()).collect();
+        let components = managers
+            .into_iter()
+            .enumerate()
+            .map(|(i, m)| ComponentSurrogate::new(&format!("comp{}", i), m))
+            .collect();
+        let weights = vec![0.5, 0.3, 0.2];
+        let composite = CompositeSurrogate::with_weights(components, weights).unwrap();
+
+        let temps = vec![20.0, 25.0, 30.0];
+        let loads = composite.predict_loads(&temps);
+
+        assert_eq!(loads, vec![1.2, 1.2, 1.2]);
     }
 
     #[test]
@@ -90,6 +141,96 @@ mod tests {
         ];
         let composite = CompositeSurrogate::new(comps);
         assert_eq!(composite.num_components(), 3);
+    }
+
+    #[test]
+    fn test_predict_with_uncertainty_single_component() {
+        let manager = SurrogateManager::new().unwrap();
+        let comp = ComponentSurrogate::new("solar", manager);
+        let composite = CompositeSurrogate::new(vec![comp]);
+
+        let temps = vec![20.0, 21.0, 22.0];
+        let (mean, std) = composite.predict_with_uncertainty(&temps);
+
+        assert_eq!(mean, vec![1.2, 1.2, 1.2]);
+        assert_eq!(std, vec![0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn test_predict_with_uncertainty_identical_components() {
+        let manager1 = SurrogateManager::new().unwrap();
+        let manager2 = SurrogateManager::new().unwrap();
+        let comp1 = ComponentSurrogate::new("solar", manager1);
+        let comp2 = ComponentSurrogate::new("hvac", manager2);
+        let composite = CompositeSurrogate::new(vec![comp1, comp2]);
+
+        let temps = vec![20.0, 21.0];
+        let (mean, std) = composite.predict_with_uncertainty(&temps);
+
+        assert_eq!(mean, vec![1.2, 1.2]);
+        assert_eq!(std, vec![0.0, 0.0]);
+    }
+
+    #[test]
+    fn test_predict_with_confidence_intervals() {
+        let manager1 = SurrogateManager::new().unwrap();
+        let manager2 = SurrogateManager::new().unwrap();
+        let comp1 = ComponentSurrogate::new("solar", manager1);
+        let comp2 = ComponentSurrogate::new("hvac", manager2);
+        let composite = CompositeSurrogate::new(vec![comp1, comp2]);
+
+        let temps = vec![20.0, 21.0];
+        let (mean, lower, upper) = composite.predict_with_confidence(&temps);
+
+        assert_eq!(mean, vec![1.2, 1.2]);
+        for i in 0..mean.len() {
+            assert!(lower[i] <= mean[i], "lower bound should be <= mean");
+            assert!(upper[i] >= mean[i], "upper bound should be >= mean");
+        }
+    }
+
+    #[test]
+    fn test_component_confidence_scores() {
+        let manager1 = SurrogateManager::new().unwrap();
+        let manager2 = SurrogateManager::new().unwrap();
+        let comp1 = ComponentSurrogate::new("solar", manager1);
+        let comp2 = ComponentSurrogate::new("hvac", manager2);
+        let composite = CompositeSurrogate::new(vec![comp1, comp2]);
+
+        let temps = vec![20.0, 21.0];
+        let scores = composite.component_confidence_scores(&temps);
+
+        assert_eq!(scores.len(), 2);
+        let sum: f64 = scores.iter().sum();
+        assert!((sum - 1.0).abs() < 1e-9, "scores should sum to 1, got {}", sum);
+    }
+
+    #[test]
+    fn test_component_confidence_scores_single_component() {
+        let manager = SurrogateManager::new().unwrap();
+        let comp = ComponentSurrogate::new("solar", manager);
+        let composite = CompositeSurrogate::new(vec![comp]);
+
+        let temps = vec![20.0, 21.0];
+        let scores = composite.component_confidence_scores(&temps);
+
+        assert_eq!(scores.len(), 1);
+        assert!((scores[0] - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_predict_loads_with_fallback() {
+        let manager1 = SurrogateManager::new().unwrap();
+        let manager2 = SurrogateManager::new().unwrap();
+        let comp1 = ComponentSurrogate::new("solar", manager1);
+        let comp2 = ComponentSurrogate::new("hvac", manager2);
+        let composite = CompositeSurrogate::new(vec![comp1, comp2]);
+
+        let temps = vec![20.0, 21.0];
+        let result = composite.predict_loads_with_fallback(&temps);
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), vec![1.2, 1.2]);
     }
 
     #[test]
@@ -125,22 +266,19 @@ mod tests {
 
     #[test]
     fn test_surrogate_manager_predict_delegates_to_composite() {
-        // Create a composite with two mock managers
         let manager1 = SurrogateManager::new().unwrap();
         let manager2 = SurrogateManager::new().unwrap();
         let comp1 = ComponentSurrogate::new("comp1", manager1);
         let comp2 = ComponentSurrogate::new("comp2", manager2);
         let composite = CompositeSurrogate::new(vec![comp1, comp2]);
 
-        // Create a SurrogateManager with the composite
         let mut manager = SurrogateManager::new().unwrap();
         manager.composite = Some(composite);
 
         let temps = vec![20.0, 22.0];
         let loads = manager.predict_loads(&temps);
 
-        // Should sum two 1.2's = 2.4
-        assert_eq!(loads, vec![2.4, 2.4]);
+        assert_eq!(loads, vec![1.2, 1.2]);
     }
 
     #[test]
@@ -170,8 +308,8 @@ mod tests {
         let results = manager.predict_loads_batched(&batch);
 
         assert_eq!(results.len(), 2);
-        assert_eq!(results[0], vec![2.4, 2.4]);
-        assert_eq!(results[1], vec![2.4, 2.4]);
+        assert_eq!(results[0], vec![1.2, 1.2]);
+        assert_eq!(results[1], vec![1.2, 1.2]);
     }
 
     #[test]

--- a/tests/test_modular_surrogates.rs
+++ b/tests/test_modular_surrogates.rs
@@ -202,7 +202,11 @@ mod tests {
 
         assert_eq!(scores.len(), 2);
         let sum: f64 = scores.iter().sum();
-        assert!((sum - 1.0).abs() < 1e-9, "scores should sum to 1, got {}", sum);
+        assert!(
+            (sum - 1.0).abs() < 1e-9,
+            "scores should sum to 1, got {}",
+            sum
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements Option B (deepen) for ARCH-012, replacing the thin wrapper layer with a deepened module that provides:

- **Ensemble weighting** - `CompositeSurrogate::with_weights()` for non-equal weighted predictions
- **Uncertainty quantification** - `predict_with_uncertainty()` returning (mean, std)
- **Fallback logic** - `predict_loads_with_fallback()` catches component failures and falls back to analytical
- **Per-component confidence scores** - `component_confidence_scores()` using softmax-normalized inverse-distance

## Changes

- `src/ai/modular_surrogate.rs` - Added 4 new methods and updated `predict_loads` to use weighted sum
- `tests/test_modular_surrogates.rs` - Updated tests to verify new behavior; 22 tests pass

## Benefits

- **Locality:** Module now does more than delegate — provides ensemble logic callers don't need to reimplement
- **Leverage:** Uncertainty and confidence give callers insight into prediction reliability

## Testing

```
cargo test --lib  # 2405 passed
cargo test --test test_modular_surrogates  # 22 passed (2 ignored for real ONNX models)
```