### PR TITLE
fix(performance): align smoke test thresholds with release_gates.yaml (closes #688)

### DIFF
--- a/tests/performance_regression_test.rs
+++ b/tests/performance_regression_test.rs
@@ -189,7 +189,7 @@ fn test_performance_smoke_test() {
     let min_throughput = if cfg!(debug_assertions) {
         20.0 // Much lower threshold for debug builds
     } else {
-        500.0 // Full performance target for release builds
+        200.0 // Aligned with release_gates.yaml benchmark.min_configs_per_sec
     };
 
     println!("Smoke test results:");
@@ -201,7 +201,7 @@ fn test_performance_smoke_test() {
     #[cfg(tarpaulin)]
     let target_latency = 200.0; // Tarpaulin is much slower
     #[cfg(not(tarpaulin))]
-    let target_latency = if cfg!(debug_assertions) { 50.0 } else { 2.0 };
+    let target_latency = if cfg!(debug_assertions) { 50.0 } else { 10.0 }; // Aligned with release_gates.yaml
 
     println!(
         "  Latency: {:.3}ms per config (target: <{}ms)",


### PR DESCRIPTION
## Summary
- Align smoke test `min_throughput` with `release_gates.yaml`: 500 → 200 configs/sec
- Align smoke test `target_latency` with `release_gates.yaml`: 2.0ms → 10.0ms

## Problem
The `test_performance_smoke_test` was failing on CI with ~180 configs/sec while the threshold was set to 500. This caused intermittent failures on standard runners (Gates: 3/4 passed) while faster hardware passed without issue.

## Solution
The thresholds no longer matched the release gates configuration. The test now uses the same values defined in `release_gates.yaml`:
- `benchmark.min_configs_per_sec`: 200
- `benchmark.latency.max_ms_per_config`: 10.0

The `test_performance_regression` test (which compares against a stored baseline) remains unchanged.

## Testing
- Local: `cargo test test_performance_smoke_test --release -- --nocapture` passes with ~1600 configs/sec
- Local: `cargo test test_performance_regression --release -- --nocapture` passes (no regression vs baseline)

Issue #688