### PR TITLE
ci: remove duplicate lint jobs and enable cargo caching (Phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,8 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - name: Run integration tests
         run: |
           cargo test --test integration-wiring --features wiring-tracing
@@ -73,7 +75,7 @@ jobs:
         with:
           name: integration-test-results
           path: target/debug/
-          retention-days: 30
+          retention-days: 14
 
   rust-tests:
     name: Rust Tests & Linting
@@ -90,32 +92,7 @@ jobs:
       - uses: ./.github/actions/setup-rust-python-env
         with:
           python-version: '3.10'
-          cache: 'false'
       - name: Run tests
         run: cargo test --lib --verbose --no-default-features
         env:
           PYO3_PYTHON: /usr/bin/python3
-
-  fmt:
-    name: Rustfmt
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Rust and rustfmt
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-          components: rustfmt
-      - run: cargo fmt -- --check
-
-  clippy:
-    name: Clippy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-rust-python-env
-        with:
-          rust-components: clippy
-          python-version: '3.10'
-          cache: 'false'
-      - run: cargo clippy --lib -- -D warnings

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -30,7 +30,6 @@ jobs:
       - uses: ./.github/actions/setup-rust-python-env
         with:
           python-version: '3.10'
-          cache: 'false'
 
       - name: Cache ONNX Runtime binaries
         if: runner.os == 'macOS'
@@ -66,7 +65,6 @@ jobs:
         with:
           rust-components: clippy
           python-version: '3.10'
-          cache: 'false'
       - run: cargo clippy --lib -- -D warnings
 
   build-release:
@@ -77,5 +75,4 @@ jobs:
       - uses: ./.github/actions/setup-rust-python-env
         with:
           python-version: '3.10'
-          cache: 'false'
       - run: cargo build --release --verbose


### PR DESCRIPTION
## Phase 1 CI Cleanup — Dedup lint jobs & enable cargo caching

### Problem

Two separate issues were causing unnecessary CI slowness and cost on every PR:

1. **Duplicate lint jobs** — `ci.yml` ran its own `fmt` and `clippy` jobs in addition to the identical jobs already in `rust-tests.yml`. Every PR was running lint twice.

2. **Cargo caching disabled** — `cache: 'false'` was explicitly set in every `setup-rust-python-env` call in both `ci.yml` and `rust-tests.yml`. This forced a full Rust recompile on every single CI run.

### Changes

#### `.github/workflows/ci.yml`
- ❌ Removed `fmt` job (duplicate of `rust-tests.yml`)
- ❌ Removed `clippy` job (duplicate of `rust-tests.yml`)
- ✅ Removed `cache: 'false'` from `rust-tests` job's `setup-rust-python-env` call — caching now active
- ✅ Added `restore-keys` fallback to the `integration-tests` cargo cache step
- ✅ Reduced artifact `retention-days` from 30 → 14

#### `.github/workflows/rust-tests.yml`
- ✅ Removed `cache: 'false'` from `test` matrix job
- ✅ Removed `cache: 'false'` from `clippy` job  
- ✅ Removed `cache: 'false'` from `build-release` job

### Expected impact

- Eliminates 2 duplicate job executions per PR (~4–8 min saved on `ubuntu-latest`)
- Cargo cache hits should cut compile time by 60–80% on warm runs
- Estimated total savings: **5–12 min per PR**

### No functional changes

All tests, linting, and build jobs still run — this only removes duplication and stops intentionally disabling the cache.

## Summary by Sourcery

Deduplicate and streamline Rust CI workflows by removing redundant lint jobs and enabling cargo caching.

CI:
- Enable cargo caching in Rust CI jobs by removing explicit cache disabling and adding a restore-keys fallback for integration tests.
- Remove duplicate fmt and clippy jobs from the main CI workflow, relying on existing linting in rust-tests.
- Shorten retention for integration test artifacts from 30 to 14 days to reduce storage usage.