### PR TITLE
ci: pin trivy-action to commit SHA (supply-chain hardening)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -147,7 +147,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        # Pinned to commit SHA for supply-chain security (master as of 2026-05-12)
+        # To update: get latest SHA from https://github.com/aquasecurity/trivy-action/commits/master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
         with:
           scan-type: 'fs'
           scan-ref: '.'


### PR DESCRIPTION
## Phase 1 CI Cleanup — Pin `trivy-action` to commit SHA

### Problem

`docker.yml` references `aquasecurity/trivy-action@master` — a floating mutable ref. Any commit pushed to `trivy-action`'s `master` branch (including accidental breakages or supply-chain compromises) immediately affects all future runs without any review.

### Change

Pins `trivy-action` to the exact commit SHA `ed142fd0673e97e23eac54620cfb913e5ce36c25` (master as of 2026-05-12), with an update comment directing to the upstream commits page.

```yaml
# Before
uses: aquasecurity/trivy-action@master

# After
# Pinned to commit SHA for supply-chain security (master as of 2026-05-12)
# To update: get latest SHA from https://github.com/aquasecurity/trivy-action/commits/master
uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
```

### No functional changes

Same Trivy version, same scan configuration. Only the reference is made immutable.

## Summary by Sourcery

CI:
- Update Trivy scan step in docker workflow to use a fixed commit SHA instead of the floating master branch reference.