### PR TITLE
ci: push trigger + feature matrix expansion + native arm64 Docker (Phase 2)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  # Build and test Docker image
+  # Smoke test: build amd64 image, run basic container checks
   build-and-test:
     runs-on: ubuntu-latest
     permissions:
@@ -69,16 +69,9 @@ jobs:
       - name: Run container smoke test
         if: github.event_name != 'pull_request'
         run: |
-          # Start container in background
           docker run -d --name fluxion-test --pull=never ${{ steps.meta.outputs.tags }} sleep 30
-
-          # Wait for container to start
           sleep 5
-
-          # Check if container is running
           docker ps | grep fluxion-test
-
-          # Stop and remove container
           docker stop fluxion-test
           docker rm fluxion-test
 
@@ -87,20 +80,90 @@ jobs:
         run: |
           docker run --rm --pull=never ${{ steps.meta.outputs.tags }} python -c "import fluxion; print('Fluxion import successful')"
 
-  # Multi-platform build
-  multi-platform:
-    runs-on: ubuntu-latest
+  # Per-platform native builds — no QEMU, native runners for each arch
+  build-platform:
+    name: Build (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
     needs: build-and-test
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            slug: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            slug: arm64
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push platform image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          push: ${{ github.event_name != 'pull_request' }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,push-by-digest=true,name-canonical=true
+          cache-from: type=gha,scope=build-${{ matrix.slug }}
+          cache-to: type=gha,scope=build-${{ matrix.slug }},mode=max
+
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.slug }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Merge per-arch digests into a single multi-arch manifest list
+  merge-manifests:
+    name: Merge Manifests
+    runs-on: ubuntu-latest
+    needs: build-platform
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -119,20 +182,19 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=sha
 
-      - name: Build and push multi-platform image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          platforms: linux/amd64, linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create and push multi-arch manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect manifest
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 
   # Security scan
   security:

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -34,6 +34,44 @@ env:
 jobs:
   # -- Always: fast gate (both PR and main) ----------------------------------
 
+  test:
+    name: Test (${{ matrix.os }}, ${{ matrix.feature_set.name }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        rust: [stable]
+        feature_set:
+          - {name: "no-default",       flags: "--no-default-features"}
+          - {name: "wiring-tracing",   flags: "--features wiring-tracing"}
+          - {name: "multi-zone",       flags: "--features wiring-tracing,multi-zone"}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev pkg-config libfontconfig1-dev
+      - uses: ./.github/actions/setup-rust-python-env
+        with:
+          python-version: '3.10'
+
+      - name: Cache ONNX Runtime binaries
+        if: runner.os == 'macOS'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/ort.pyke.io
+          key: ort-binaries-aarch64-apple-darwin-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ort-binaries-aarch64-apple-darwin-
+
+      - name: Run tests
+        run: cargo test --lib --verbose ${{ matrix.feature_set.flags }}
+        env:
+          PYO3_PYTHON: /usr/bin/python3
+
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Phase 2 CI — Push trigger, feature matrix expansion, native arm64 Docker

> **Depends on:** #774 and #775 (Phase 1). This PR includes those changes — merge conflicts will be trivial once Phase 1 lands.

---

### 1. `ci.yml` — Add `push: [main]` trigger

Previously CI only ran on `pull_request`. Merges to `main` ran nothing, leaving the branch in an unknown state between PRs.

```yaml
# Before
on: pull_request

# After
on:
  push:
    branches: [main]
  pull_request:
```

---

### 2. `rust-tests.yml` — Expand feature matrix

The existing matrix tested `--no-default-features` only on 3 OSes. `wiring-tracing` and `multi-zone` features were never exercised in cross-platform CI.

**Before:** 3 jobs (1 feature set × 3 OS)
**After:** 9 jobs (3 feature sets × 3 OS)

| Feature set | Flags | Covers |
|---|---|---|
| `no-default` | `--no-default-features` | Baseline (existing) |
| `wiring-tracing` | `--features wiring-tracing` | Tracing integration |
| `multi-zone` | `--features wiring-tracing,multi-zone` | Multi-zone simulation |

Job names now show `(ubuntu-latest, wiring-tracing)` etc. for easier triage in the CI UI.

Note: `python-bindings` is deliberately excluded here — it's tested in `python-bindings.yml` with full maturin setup.

---

### 3. `docker.yml` — Replace QEMU arm64 with native `ubuntu-24.04-arm`

The old `multi-platform` job ran on a single `ubuntu-latest` runner and used QEMU to emulate arm64. QEMU arm64 builds are ~4-8× slower than native and introduce emulation bugs.

**New flow:**
1. `build-platform` matrix — two native jobs in parallel:
   - `linux/amd64` → `ubuntu-latest`
   - `linux/arm64` → `ubuntu-24.04-arm` (GitHub-hosted native arm64)
2. Each job pushes a platform image by content digest (no tags yet)
3. `merge-manifests` job downloads both digests, creates the multi-arch manifest list with proper tags

Per-platform GHA cache scopes (`build-amd64`, `build-arm64`) prevent cache thrashing between the two runners.

---

### Checklist

- [ ] Confirm `multi-zone` feature compiles on Windows (or add `exclude` if it doesn't)
- [ ] Verify `ubuntu-24.04-arm` runner availability in the repo's GitHub plan
- [ ] Review Phase 1 PRs (#774, #775) first to keep diffs small

## Summary by Sourcery

Expand CI coverage and modernize Docker builds with native multi-arch support and improved workflow configuration.

New Features:
- Run CI on pushes to the main branch in addition to pull requests.
- Test Rust crates across multiple feature sets and operating systems via an expanded matrix.
- Build and publish native multi-architecture Docker images for amd64 and arm64 with a manifest-based flow.

Enhancements:
- Simplify and tighten Docker smoke test steps for container verification.
- Refine cargo caching and artifact retention settings in CI to improve cache reuse and reduce storage.
- Remove redundant rustfmt and clippy jobs from the main CI workflow in favor of dedicated Rust testing workflows.
- Pin the Trivy GitHub Action to a specific commit for improved supply‑chain security.

Build:
- Split Docker builds into per-platform native jobs and a follow-up manifest merge job using content digests.
- Introduce per-architecture cache scopes for Docker builds to avoid cache thrashing between runners.

CI:
- Add a push trigger on the main branch so CI runs on merges.
- Update Rust test workflows to use a feature-set matrix and clearer job naming across OSes.

Tests:
- Run Rust test suites under no-default-features, wiring-tracing, and multi-zone feature combinations across ubuntu, macOS, and Windows.