### PR TITLE
ci: tiered CI - fast gate on PR branch, full suite on main merge (Phase 4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,20 +14,30 @@ permissions:
   pull-requests: write
 
 # Job execution policy
-# ──────────────────────────────────────────────────────────────────────────────
-# PR branch push  →  NO jobs in this file run (fast gate is in rust-tests.yml).
-#                    Python and integration jobs are too slow for per-commit
-#                    feedback; failures will surface before the next release.
-# Main merge      →  All jobs here run to catch anything that slipped through.
-# ──────────────────────────────────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
+# PR branch push  ->  NO jobs in this file run (fast gate is in rust-tests.yml).
+#                     Python and integration jobs are too slow for per-commit
+#                     feedback; failures will surface before the next release.
+# Main merge      ->  All jobs here run to catch anything that slipped through.
+# ---------------------------------------------------------------------------
+#
+# Runner routing (Linux jobs)
+# ---------------------------------------------------------------------------
+# Set the repository variable FLUXION_LINUX_RUNNER to route heavy Linux jobs
+# to self-hosted Hetzner runners for more parallelism at lower cost:
+#   gh variable set FLUXION_LINUX_RUNNER --body "fluxion-ci" \
+#     --repo anchapin/fluxion
+# When unset or empty, jobs fall back to GitHub-hosted ubuntu-latest (free).
+# See docs/self-hosted-runners.md for provisioning instructions.
+# ---------------------------------------------------------------------------
 
 jobs:
-  # Maturin release build + pytest — takes 5-10 min on a cold cache.
+  # Maturin release build + pytest -- takes 5-10 min on a cold cache.
   # Not suitable as a per-commit gate; failures are caught on merge.
   python-examples:
     name: Python Bindings & pytest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.FLUXION_LINUX_RUNNER || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust-python-env
@@ -54,12 +64,12 @@ jobs:
           source venv/bin/activate
           pytest -q
 
-  # Integration test suite (wiring, e2e, batch-oracle, CLI) — slow compile
+  # Integration test suite (wiring, e2e, batch-oracle, CLI) -- slow compile
   # plus multi-feature builds; only run on main.
   integration-tests:
     name: Integration Tests
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.FLUXION_LINUX_RUNNER || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
       - name: Install system dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: pull_request
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -10,8 +13,20 @@ permissions:
   contents: read
   pull-requests: write
 
+# Job execution policy
+# ──────────────────────────────────────────────────────────────────────────────
+# PR branch push  →  NO jobs in this file run (fast gate is in rust-tests.yml).
+#                    Python and integration jobs are too slow for per-commit
+#                    feedback; failures will surface before the next release.
+# Main merge      →  All jobs here run to catch anything that slipped through.
+# ──────────────────────────────────────────────────────────────────────────────
+
 jobs:
+  # Maturin release build + pytest — takes 5-10 min on a cold cache.
+  # Not suitable as a per-commit gate; failures are caught on merge.
   python-examples:
+    name: Python Bindings & pytest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -39,8 +54,11 @@ jobs:
           source venv/bin/activate
           pytest -q
 
+  # Integration test suite (wiring, e2e, batch-oracle, CLI) — slow compile
+  # plus multi-feature builds; only run on main.
   integration-tests:
-    name: Run Integration Tests
+    name: Integration Tests
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -57,10 +75,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - name: Run integration tests
         run: |
           cargo test --test integration-wiring --features wiring-tracing
@@ -73,49 +93,4 @@ jobs:
         with:
           name: integration-test-results
           path: target/debug/
-          retention-days: 30
-
-  rust-tests:
-    name: Rust Tests & Linting
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install system dependencies
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libssl-dev pkg-config libfontconfig1-dev
-          version: 1.0
-          retry: 3
-          retry_wait_seconds: 10
-      - uses: ./.github/actions/setup-rust-python-env
-        with:
-          python-version: '3.10'
-          cache: 'false'
-      - name: Run tests
-        run: cargo test --lib --verbose --no-default-features
-        env:
-          PYO3_PYTHON: /usr/bin/python3
-
-  fmt:
-    name: Rustfmt
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Rust and rustfmt
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-          components: rustfmt
-      - run: cargo fmt -- --check
-
-  clippy:
-    name: Clippy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-rust-python-env
-        with:
-          rust-components: clippy
-          python-version: '3.10'
-          cache: 'false'
-      - run: cargo clippy --lib -- -D warnings
+          retention-days: 14

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -15,14 +15,24 @@ env:
   PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1
 
 # Job execution policy
-# ──────────────────────────────────────────────────────────────────────────────
-# PR branch push  →  fmt + clippy + test-pr (ubuntu-latest, unit tests only).
-#                    Target wall time: < 5 minutes.
-# Main merge      →  All of the above + test-full (3-platform matrix) +
-#                    build-release.
-# ──────────────────────────────────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
+# PR branch push  ->  fmt + clippy + test-pr (ubuntu-latest, unit tests only).
+#                     Target wall time: < 5 minutes.
+# Main merge      ->  All of the above + test-full (3-platform matrix) +
+#                     build-release.
+# ---------------------------------------------------------------------------
+#
+# Runner routing (Linux jobs)
+# ---------------------------------------------------------------------------
+# FLUXION_LINUX_RUNNER repo variable controls where heavy Linux jobs run.
+# Set to "fluxion-ci" to use self-hosted Hetzner runners; leave unset to
+# use GitHub-hosted ubuntu-latest (free for public repos).
+# macOS and Windows jobs always use GitHub-hosted runners.
+# See docs/self-hosted-runners.md for provisioning instructions.
+# ---------------------------------------------------------------------------
 
 jobs:
+  # -- Always: fast gate (both PR and main) ----------------------------------
 
   fmt:
     name: Rustfmt
@@ -45,12 +55,12 @@ jobs:
           python-version: '3.10'
       - run: cargo clippy --lib -- -D warnings
 
-  # ── PR only: single-platform unit tests ───────────────────────────────────
+  # -- PR only: single-platform unit tests -----------------------------------
   # Gives fast signal (< 3 min) without spending 3x runner-minutes on the
   # cross-platform matrix for every commit pushed to a branch.
 
   test-pr:
-    name: Unit Tests (Ubuntu · PR gate)
+    name: Unit Tests (Ubuntu / PR gate)
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
@@ -67,14 +77,16 @@ jobs:
         env:
           PYO3_PYTHON: /usr/bin/python3
 
-  # ── Main only: cross-platform matrix ──────────────────────────────────────
-  # Validates that nothing is accidentally Linux/x86-specific before the
-  # changes land on main and are picked up by release tooling.
+  # -- Main only: cross-platform matrix --------------------------------------
+  # Validates that nothing is accidentally Linux/x86-specific before changes
+  # land on main. Linux slot uses FLUXION_LINUX_RUNNER if set (self-hosted
+  # Hetzner), falling back to GitHub-hosted ubuntu-latest. macOS and Windows
+  # always use GitHub-hosted runners.
 
   test-full:
     name: Test Suite (${{ matrix.os }})
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ (matrix.os == 'ubuntu-latest' && vars.FLUXION_LINUX_RUNNER) || matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -104,12 +116,12 @@ jobs:
         env:
           PYO3_PYTHON: /usr/bin/python3
 
-  # ── Main only: release build verification ────────────────────────────────
+  # -- Main only: release build verification ---------------------------------
 
   build-release:
     name: Build Release
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.FLUXION_LINUX_RUNNER || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust-python-env

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -1,6 +1,9 @@
 name: Rust Tests & Linting
 
-on: [pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -11,40 +14,15 @@ env:
   RUST_BACKTRACE: 1
   PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1
 
+# Job execution policy
+# ──────────────────────────────────────────────────────────────────────────────
+# PR branch push  →  fmt + clippy + test-pr (ubuntu-latest, unit tests only).
+#                    Target wall time: < 5 minutes.
+# Main merge      →  All of the above + test-full (3-platform matrix) +
+#                    build-release.
+# ──────────────────────────────────────────────────────────────────────────────
+
 jobs:
-  test:
-    name: Test Suite
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [stable]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install system dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libssl-dev pkg-config libfontconfig1-dev
-      - uses: ./.github/actions/setup-rust-python-env
-        with:
-          python-version: '3.10'
-
-      - name: Cache ONNX Runtime binaries
-        if: runner.os == 'macOS'
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/Library/Caches/ort.pyke.io
-          key: ort-binaries-aarch64-apple-darwin-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ort-binaries-aarch64-apple-darwin-
-
-      - name: Run tests
-        run: cargo test --lib --verbose --no-default-features
-        env:
-          PYO3_PYTHON: /usr/bin/python3
 
   fmt:
     name: Rustfmt
@@ -67,8 +45,70 @@ jobs:
           python-version: '3.10'
       - run: cargo clippy --lib -- -D warnings
 
+  # ── PR only: single-platform unit tests ───────────────────────────────────
+  # Gives fast signal (< 3 min) without spending 3x runner-minutes on the
+  # cross-platform matrix for every commit pushed to a branch.
+
+  test-pr:
+    name: Unit Tests (Ubuntu · PR gate)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev pkg-config libfontconfig1-dev
+      - uses: ./.github/actions/setup-rust-python-env
+        with:
+          python-version: '3.10'
+      - name: Run tests
+        run: cargo test --lib --verbose --no-default-features
+        env:
+          PYO3_PYTHON: /usr/bin/python3
+
+  # ── Main only: cross-platform matrix ──────────────────────────────────────
+  # Validates that nothing is accidentally Linux/x86-specific before the
+  # changes land on main and are picked up by release tooling.
+
+  test-full:
+    name: Test Suite (${{ matrix.os }})
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        rust: [stable]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev pkg-config libfontconfig1-dev
+      - uses: ./.github/actions/setup-rust-python-env
+        with:
+          python-version: '3.10'
+      - name: Cache ONNX Runtime binaries
+        if: runner.os == 'macOS'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/ort.pyke.io
+          key: ort-binaries-aarch64-apple-darwin-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ort-binaries-aarch64-apple-darwin-
+      - name: Run tests
+        run: cargo test --lib --verbose --no-default-features
+        env:
+          PYO3_PYTHON: /usr/bin/python3
+
+  # ── Main only: release build verification ────────────────────────────────
+
   build-release:
     name: Build Release
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/docs/self-hosted-runners.md
+++ b/docs/self-hosted-runners.md
@@ -1,0 +1,230 @@
+# Self-Hosted Runners on Hetzner Cloud
+
+This guide covers provisioning cheap Hetzner Cloud VMs as GitHub Actions
+self-hosted runners for fluxion's heavy CI jobs, and explains the automatic
+fallback to GitHub-hosted runners when no self-hosted runner is available.
+
+## Overview
+
+Fluxion uses a **tiered CI strategy** (see [Phase 4 PR](https://github.com/anchapin/fluxion/pull/788)):
+
+| Trigger | Runner | Jobs |
+|---|---|---|
+| PR branch push | GitHub-hosted (free) | `fmt`, `clippy`, `test-pr` (ubuntu-latest) |
+| Main merge | Self-hosted preferred, GH-hosted fallback | `test-full` (3-platform), `build-release`, `integration-tests`, `python-examples` |
+
+The routing is controlled by a single repository variable:
+
+```
+FLUXION_LINUX_RUNNER=fluxion-ci   # routes Linux jobs to self-hosted runners
+# (unset or empty)                 # falls back to ubuntu-latest GitHub-hosted
+```
+
+**Security note:** Self-hosted runners are only used for `push` events on
+`main`, never for `pull_request`. This is safe for public repos — forked PRs
+cannot execute code on your self-hosted infrastructure.
+
+---
+
+## Prerequisites
+
+1. **Hetzner Cloud account** — [console.hetzner.cloud](https://console.hetzner.cloud)
+2. **hcloud CLI** installed and authenticated:
+   ```bash
+   brew install hcloud          # macOS
+   # or: https://github.com/hetznercloud/cli/releases
+   hcloud context create fluxion
+   # paste your Hetzner API token when prompted
+   ```
+3. **SSH key** added to your Hetzner project:
+   ```bash
+   hcloud ssh-key create --name my-key --public-key-from-file ~/.ssh/id_ed25519.pub
+   hcloud ssh-key list   # confirm it appears
+   ```
+4. **GitHub CLI** (`gh`) for obtaining the registration token:
+   ```bash
+   brew install gh
+   gh auth login
+   ```
+
+---
+
+## Provisioning a runner
+
+### 1. Get a runner registration token
+
+Registration tokens are single-use and expire after 1 hour:
+
+```bash
+REG_TOKEN=$(gh api -X POST \
+  repos/anchapin/fluxion/actions/runners/registration-token \
+  --jq .token)
+echo "$REG_TOKEN"   # keep this, you'll pass it to the script
+```
+
+### 2. Run the provisioning script
+
+```bash
+chmod +x scripts/provision-hetzner-runner.sh
+
+scripts/provision-hetzner-runner.sh \
+  --github-repo    anchapin/fluxion \
+  --github-token   "$REG_TOKEN" \
+  --hcloud-ssh-key my-key
+```
+
+The script will:
+- Create a **cx22** VM (2 vCPU, 4 GB RAM, Ubuntu 24.04) at ~€4/month
+- Install: `git`, `docker`, `build-essential`, `libssl-dev`, `libfontconfig1-dev`, Rust stable
+- Download the GitHub Actions runner agent (v2.323.0)
+- Register it with labels `self-hosted,linux,x86_64,fluxion-ci`
+- Start it as a **systemd service** (auto-restarts on reboot)
+
+**Optional flags:**
+
+| Flag | Default | Description |
+|---|---|---|
+| `--server-type` | `cx22` | Hetzner server type. `cx32` (4 vCPU/8GB) for heavier builds |
+| `--location` | `hel1` | Data center: `hel1`\|`nbg1`\|`fsn1` (EU), `ash` (US-East), `sin` (Asia) |
+| `--runner-name` | `fluxion-runner-<ts>` | Unique name shown in GitHub UI |
+| `--runner-labels` | `self-hosted,linux,x86_64,fluxion-ci` | Comma-separated labels |
+
+### 3. Activate the runner
+
+Once provisioning completes, flip the repository variable:
+
+```bash
+gh variable set FLUXION_LINUX_RUNNER --body "fluxion-ci" \
+  --repo anchapin/fluxion
+```
+
+Verify the runner is online:
+
+```
+https://github.com/anchapin/fluxion/settings/actions/runners
+```
+
+The next push to `main` will route Linux jobs to your self-hosted runner.
+GitHub-hosted runners handle macOS and Windows automatically.
+
+---
+
+## Scaling to multiple runners
+
+Run the script multiple times with different `--runner-name` values.
+All runners with the `fluxion-ci` label join the same pool — GitHub
+distributes jobs across them automatically:
+
+```bash
+for i in 1 2 3; do
+  REG_TOKEN=$(gh api -X POST \
+    repos/anchapin/fluxion/actions/runners/registration-token --jq .token)
+  scripts/provision-hetzner-runner.sh \
+    --github-repo    anchapin/fluxion \
+    --github-token   "$REG_TOKEN" \
+    --hcloud-ssh-key my-key \
+    --runner-name    "fluxion-runner-${i}"
+done
+```
+
+Three cx22 nodes run in parallel for ~€12/month total.
+
+---
+
+## Fallback behaviour
+
+The `FLUXION_LINUX_RUNNER` variable controls routing for all heavy Linux jobs:
+
+```yaml
+# ci.yml and rust-tests.yml — relevant jobs use this expression:
+runs-on: ${{ vars.FLUXION_LINUX_RUNNER || 'ubuntu-latest' }}
+```
+
+| `FLUXION_LINUX_RUNNER` value | Where jobs run |
+|---|---|
+| `fluxion-ci` | Your self-hosted Hetzner runner(s) |
+| unset or empty | GitHub-hosted `ubuntu-latest` (free for public repo) |
+
+To fall back immediately (e.g. runner is down for maintenance):
+
+```bash
+gh variable delete FLUXION_LINUX_RUNNER --repo anchapin/fluxion
+# or set it to ubuntu-latest explicitly:
+gh variable set FLUXION_LINUX_RUNNER --body "ubuntu-latest" --repo anchapin/fluxion
+```
+
+---
+
+## Security hardening
+
+- **Ephemeral jobs only on main:** `pull_request` jobs always use GitHub-hosted
+  runners. Forked PRs never touch your self-hosted machines.
+- **Dedicated runner user:** The script runs the agent as a non-root `runner`
+  user with Docker group membership.
+- **No persistent secrets on disk:** Use GitHub Actions secrets (`${{ secrets.X }}`),
+  not files baked into the image.
+- **Firewall:** By default Hetzner VMs expose all ports. Add a firewall rule:
+  ```bash
+  hcloud firewall create --name fluxion-runner-fw
+  hcloud firewall add-rule fluxion-runner-fw \
+    --direction in --protocol tcp --port 22 --source-ip 0.0.0.0/0
+  hcloud firewall apply-to-resource fluxion-runner-fw \
+    --type server --server <RUNNER_NAME>
+  ```
+  The runner polls GitHub outbound — no inbound ports beyond SSH are needed.
+- **Periodic OS updates:** SSH in weekly and run `apt-get upgrade -y`, or
+  use unattended-upgrades.
+
+---
+
+## Maintenance
+
+### Check runner status
+
+```bash
+ssh root@<SERVER_IP> \
+  "cd /home/runner/actions-runner && ./svc.sh status"
+```
+
+### Update the runner agent
+
+GitHub will notify you when a new runner version is available. To update:
+
+```bash
+# 1. Stop the service
+ssh root@<SERVER_IP> \
+  "cd /home/runner/actions-runner && ./svc.sh stop"
+
+# 2. Get a new registration token and re-run the provisioning script
+#    with --runner-name matching the existing server, or update manually:
+ssh root@<SERVER_IP> bash << 'EOF'
+cd /home/runner/actions-runner
+NEW_VERSION=2.323.0   # update to latest
+curl -fsSL https://github.com/actions/runner/releases/download/v${NEW_VERSION}/actions-runner-linux-x64-${NEW_VERSION}.tar.gz \
+  | tar xz
+./svc.sh start
+EOF
+```
+
+---
+
+## Decommissioning a runner
+
+```bash
+# 1. Remove-token (single-use, 1h expiry)
+REMOVAL_TOKEN=$(gh api -X POST \
+  repos/anchapin/fluxion/actions/runners/remove-token --jq .token)
+
+# 2. Deregister and stop the agent
+ssh root@<SERVER_IP> \
+  "cd /home/runner/actions-runner && \
+   ./svc.sh stop && \
+   ./svc.sh uninstall && \
+   ./config.sh remove --token $REMOVAL_TOKEN"
+
+# 3. Delete the VM
+hcloud server delete <RUNNER_NAME>
+
+# 4. If this was your last runner, clear the repo variable
+gh variable delete FLUXION_LINUX_RUNNER --repo anchapin/fluxion
+```

--- a/scripts/provision-hetzner-runner.sh
+++ b/scripts/provision-hetzner-runner.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# provision-hetzner-runner.sh
+#
+# Provisions a Hetzner Cloud VM and registers it as a GitHub Actions
+# self-hosted runner for the fluxion repository.
+#
+# PREREQUISITES
+#   - hcloud CLI installed and authenticated:
+#       brew install hcloud          # macOS
+#       hcloud context create fluxion
+#   - GitHub runner registration token (NOT a PAT):
+#       gh api -X POST repos/anchapin/fluxion/actions/runners/registration-token \
+#         --jq .token
+#   - SSH key already added to your Hetzner project:
+#       hcloud ssh-key list
+#
+# USAGE
+#   ./scripts/provision-hetzner-runner.sh \
+#     --github-repo    anchapin/fluxion \
+#     --github-token   <RUNNER_REGISTRATION_TOKEN> \
+#     --hcloud-ssh-key <SSH_KEY_NAME_IN_HETZNER> \
+#     [--server-type   cx22]               # 2 vCPU, 4 GB RAM, ~EUR 4/mo
+#     [--location      hel1]               # hel1 | nbg1 | fsn1 | ash | sin
+#     [--runner-name   fluxion-runner-1]
+#     [--runner-labels "self-hosted,linux,x86_64,fluxion-ci"]
+#
+# RUNNER LABELS
+#   The default label set includes "fluxion-ci". After provisioning, set the
+#   repository variable so heavy CI jobs route to this runner:
+#     gh variable set FLUXION_LINUX_RUNNER --body "fluxion-ci" \
+#       --repo anchapin/fluxion
+#   Remove (or empty) the variable to fall back to GitHub-hosted runners.
+#
+# TEARDOWN
+#   1. Get a removal token:
+#        REMOVAL_TOKEN=$(gh api -X POST \
+#          repos/anchapin/fluxion/actions/runners/remove-token --jq .token)
+#   2. Deregister the runner:
+#        ssh root@<SERVER_IP> \
+#          "cd /home/runner/actions-runner && \
+#           ./svc.sh stop && ./svc.sh uninstall && \
+#           ./config.sh remove --token $REMOVAL_TOKEN"
+#   3. Delete the VM:
+#        hcloud server delete <RUNNER_NAME>
+
+set -euo pipefail
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+GITHUB_REPO="${GITHUB_REPO:-}"
+GITHUB_TOKEN="${GITHUB_TOKEN:-}"
+SERVER_TYPE="${SERVER_TYPE:-cx22}"
+LOCATION="${LOCATION:-hel1}"
+RUNNER_NAME="${RUNNER_NAME:-fluxion-runner-$(date +%s)}"
+RUNNER_LABELS="${RUNNER_LABELS:-self-hosted,linux,x86_64,fluxion-ci}"
+HCLOUD_SSH_KEY="${HCLOUD_SSH_KEY:-}"
+RUNNER_VERSION="2.323.0"
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --github-repo)    GITHUB_REPO="$2";    shift 2 ;;
+    --github-token)   GITHUB_TOKEN="$2";   shift 2 ;;
+    --server-type)    SERVER_TYPE="$2";    shift 2 ;;
+    --location)       LOCATION="$2";       shift 2 ;;
+    --runner-name)    RUNNER_NAME="$2";    shift 2 ;;
+    --runner-labels)  RUNNER_LABELS="$2";  shift 2 ;;
+    --hcloud-ssh-key) HCLOUD_SSH_KEY="$2"; shift 2 ;;
+    --help|-h)
+      sed -n '/^# PREREQUISITES/,/^set -euo/p' "$0" | grep '^#' | sed 's/^# \?//'
+      exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+# ── Validation ────────────────────────────────────────────────────────────────
+fail() { echo "ERROR: $*" >&2; exit 1; }
+
+[[ -z "$GITHUB_REPO" ]]    && fail "--github-repo is required (e.g. anchapin/fluxion)"
+[[ -z "$GITHUB_TOKEN" ]]   && fail "--github-token is required (runner registration token, not a PAT)"
+[[ -z "$HCLOUD_SSH_KEY" ]] && fail "--hcloud-ssh-key is required (run: hcloud ssh-key list)"
+command -v hcloud &>/dev/null || fail "hcloud CLI not found: https://github.com/hetznercloud/cli"
+command -v jq &>/dev/null    || fail "jq not found (brew install jq / apt install jq)"
+
+# ── Create the server ─────────────────────────────────────────────────────────
+echo "==> Creating Hetzner server '${RUNNER_NAME}' (${SERVER_TYPE} @ ${LOCATION})"
+SERVER_JSON=$(hcloud server create \
+  --name          "$RUNNER_NAME" \
+  --type          "$SERVER_TYPE" \
+  --image         "ubuntu-24.04" \
+  --location      "$LOCATION"    \
+  --ssh-key       "$HCLOUD_SSH_KEY" \
+  --poll-interval 5s \
+  --output json)
+
+SERVER_IP=$(echo "$SERVER_JSON" | jq -r '.server.public_net.ipv4.ip')
+echo "==> Server IP: ${SERVER_IP}"
+
+# ── Wait for SSH ──────────────────────────────────────────────────────────────
+echo "==> Waiting for SSH ..."
+for i in $(seq 1 30); do
+  ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 \
+      -o BatchMode=yes "root@${SERVER_IP}" echo ok &>/dev/null && break
+  echo "   attempt ${i}/30 — retrying in 5s"
+  sleep 5
+done
+
+# ── Remote provisioning ───────────────────────────────────────────────────────
+echo "==> Provisioning runner on ${SERVER_IP} ..."
+ssh -o StrictHostKeyChecking=no "root@${SERVER_IP}" bash -s -- \
+  "$GITHUB_REPO" "$GITHUB_TOKEN" "$RUNNER_NAME" "$RUNNER_LABELS" "$RUNNER_VERSION" \
+  << 'REMOTE'
+#!/usr/bin/env bash
+set -euo pipefail
+GITHUB_REPO="$1"
+GITHUB_TOKEN="$2"
+RUNNER_NAME="$3"
+RUNNER_LABELS="$4"
+RUNNER_VERSION="$5"
+
+echo "--- System packages"
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y -qq \
+  curl git jq unzip sudo ca-certificates gnupg lsb-release \
+  build-essential pkg-config \
+  libssl-dev libfontconfig1-dev libfreetype6-dev
+
+echo "--- Docker"
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+  -o /etc/apt/keyrings/docker.asc
+chmod a+r /etc/apt/keyrings/docker.asc
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
+https://download.docker.com/linux/ubuntu \
+$(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+  > /etc/apt/sources.list.d/docker.list
+apt-get update -qq
+apt-get install -y -qq docker-ce docker-ce-cli containerd.io
+systemctl enable --now docker
+
+echo "--- Rust stable"
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+  | sh -s -- -y --default-toolchain stable --no-modify-path
+source /root/.cargo/env
+rustup component add rustfmt clippy
+
+echo "--- Runner user"
+useradd -m -s /bin/bash runner 2>/dev/null || true
+usermod -aG docker runner
+cp -r /root/.cargo /home/runner/.cargo 2>/dev/null || true
+chown -R runner:runner /home/runner/.cargo 2>/dev/null || true
+echo 'source /home/runner/.cargo/env' >> /home/runner/.bashrc
+
+echo "--- GitHub Actions runner v${RUNNER_VERSION}"
+RUNNER_DIR="/home/runner/actions-runner"
+mkdir -p "$RUNNER_DIR"
+cd "$RUNNER_DIR"
+TARBALL="actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
+curl -fsSL \
+  "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${TARBALL}" \
+  -o "$TARBALL"
+tar xzf "$TARBALL"
+rm "$TARBALL"
+chown -R runner:runner "$RUNNER_DIR"
+
+echo "--- Registering with GitHub"
+sudo -u runner ./config.sh \
+  --url         "https://github.com/${GITHUB_REPO}" \
+  --token       "$GITHUB_TOKEN" \
+  --name        "$RUNNER_NAME" \
+  --labels      "$RUNNER_LABELS" \
+  --runnergroup Default \
+  --work        _work \
+  --unattended \
+  --replace
+
+echo "--- systemd service"
+./svc.sh install runner
+./svc.sh start
+
+echo "--- Runner status"
+./svc.sh status
+REMOTE
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "Runner '${RUNNER_NAME}' is live at ${SERVER_IP}"
+echo "  Labels : ${RUNNER_LABELS}"
+echo "  View   : https://github.com/${GITHUB_REPO}/settings/actions/runners"
+echo ""
+echo "Activate for heavy CI jobs:"
+echo "  gh variable set FLUXION_LINUX_RUNNER --body fluxion-ci --repo ${GITHUB_REPO}"
+echo ""
+echo "To decommission later:"
+echo "  TOKEN=\$(gh api -X POST repos/${GITHUB_REPO}/actions/runners/remove-token --jq .token)"
+echo "  ssh root@${SERVER_IP} \"cd /home/runner/actions-runner && ./svc.sh stop && ./svc.sh uninstall && ./config.sh remove --token \$TOKEN\""
+echo "  hcloud server delete ${RUNNER_NAME}"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,8 +69,8 @@ pub mod api;
 pub mod cli;
 pub mod interop;
 pub mod napi;
-pub mod performance;
 pub mod orchestration;
+pub mod performance;
 pub mod physics;
 #[cfg(feature = "python-bindings")]
 pub mod python;

--- a/src/orchestration/decision_types.rs
+++ b/src/orchestration/decision_types.rs
@@ -119,11 +119,7 @@ impl OrchestrationDecision {
 
     /// Convenience: construct with an empty feature map.
     pub fn simple(kind: OrchestrationDecisionKind, chosen: impl Into<String>) -> Self {
-        Self::new(
-            kind,
-            chosen,
-            Value::Object(serde_json::Map::new()),
-        )
+        Self::new(kind, chosen, Value::Object(serde_json::Map::new()))
     }
 }
 
@@ -134,11 +130,26 @@ mod tests {
 
     #[test]
     fn test_kind_as_str() {
-        assert_eq!(OrchestrationDecisionKind::SolverSelection.as_str(), "solver_selection");
-        assert_eq!(OrchestrationDecisionKind::AdaptiveTimestep.as_str(), "adaptive_timestep");
-        assert_eq!(OrchestrationDecisionKind::SurrogateRouting.as_str(), "surrogate_routing");
-        assert_eq!(OrchestrationDecisionKind::ConstraintWarning.as_str(), "constraint_warning");
-        assert_eq!(OrchestrationDecisionKind::HvacHorizon.as_str(), "hvac_horizon");
+        assert_eq!(
+            OrchestrationDecisionKind::SolverSelection.as_str(),
+            "solver_selection"
+        );
+        assert_eq!(
+            OrchestrationDecisionKind::AdaptiveTimestep.as_str(),
+            "adaptive_timestep"
+        );
+        assert_eq!(
+            OrchestrationDecisionKind::SurrogateRouting.as_str(),
+            "surrogate_routing"
+        );
+        assert_eq!(
+            OrchestrationDecisionKind::ConstraintWarning.as_str(),
+            "constraint_warning"
+        );
+        assert_eq!(
+            OrchestrationDecisionKind::HvacHorizon.as_str(),
+            "hvac_horizon"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Phase 4 - Tiered CI

Every push to a PR branch currently runs the full suite: 3-platform cross-platform matrix, maturin release build + pytest, and integration tests. That adds up to 10-20 min of wall time on every commit, making it slow to iterate.

This PR implements the classic tiered pattern:

| Trigger | Jobs that run |
|---|---|
| PR branch push | `fmt` + `clippy` + `test-pr` (ubuntu-latest unit tests) - target: < 5 min |
| Main merge | Everything above + `test-full` (3-platform matrix) + `build-release` + `integration-tests` + `python-examples` |

Anything that slips through the PR gate is caught on main before the next release.

---

### `ci.yml` changes

- Added `push: branches: [main]` trigger (was pull_request-only, so nothing ran on main merges)
- Removed `fmt`, `clippy`, `rust-tests` jobs (now canonical in `rust-tests.yml`)
- Gated `integration-tests` and `python-examples` to main merge only
- Fixed cargo cache paths to granular registry/index + registry/cache + git/db layout
- Added `restore-keys` to cargo cache (was missing)
- Fixed artifact retention: 30 days -> 14 days

### `rust-tests.yml` changes

- Added `push: branches: [main]` trigger
- Renamed `test` -> `test-pr`: ubuntu-latest only, `if: pull_request` (fast PR gate)
- Added `test-full`: 3-platform matrix, `if: push to main`
- Gated `build-release` to main-only
- Removed `cache: 'false'` from all setup-rust-python-env calls

---

### Relationship to other open PRs

This PR supersedes the workflow-file changes in:
- #774 (Phase 1 dedup + cache) - the fmt/clippy dedup and cache fix are included here
- #786 (Phase 2 push trigger + matrix) - the push:[main] trigger and cross-platform split are included here

The action-file and Cargo.toml changes in #787 (Phase 3) are independent - that PR touches only Cargo.toml and composite actions and can merge in any order.

Recommended merge order: close #774 and #786 in favour of this PR, merge #787, then merge this one.