### PR TITLE
fix(ashrae140): use direct [min, max] range check instead of midpoint±tolerance

### DIFF
--- a/docs/compliance/deviations-register.md
+++ b/docs/compliance/deviations-register.md
@@ -151,7 +151,7 @@
 **Description:** `validate_energy_against_reference()` uses `midpoint ± (half_range × 1.15)` instead of direct `[ref_min, ref_max]` comparison. This artificially widens the acceptance band and passes results that should fail. `validate_peak_load_against_reference()` correctly uses `[min, max]` — energy must be made consistent.  
 **Fix:** Replace energy comparator with same pattern as peak load comparator; remove ±15%/±10% tolerance constants.  
 **Impact:** Systematic false-pass rate. Pass rate will initially drop when fixed (correctly exposing true failures).  
-**Status:** IN PROGRESS (exact fix spec posted to #723)  
+**Status:** CLOSED (fix applied — `validate_energy_against_reference()` now uses `[ref_min, ref_max]` direct range check, matching `validate_peak_load_against_reference()`)  
 **Priority:** P1 (Wave 3 gate)
 
 ---

--- a/src/validation/ashrae_140_validator.rs
+++ b/src/validation/ashrae_140_validator.rs
@@ -2532,14 +2532,16 @@ impl ASHRAE140Validator {
         actual: f64,
         ref_min: f64,
         ref_max: f64,
-        tolerance: f64,
+        _tolerance: f64,
     ) -> ValidationResult {
+        // ASHRAE 140: pass if result falls within actual min-max range of reference ensemble
+        let in_range = (actual >= ref_min) && (actual <= ref_max);
         let ref_mid = (ref_min + ref_max) / 2.0;
-        let ref_half_range = (ref_max - ref_min) / 2.0;
-        let tolerance_range = ref_half_range * (1.0 + tolerance);
-        let in_range =
-            (actual >= ref_mid - tolerance_range) && (actual <= ref_mid + tolerance_range);
-        let error_pct = ((actual - ref_mid).abs() / ref_mid) * 100.0;
+        let error_pct = if ref_mid > 0.0 {
+            ((actual - ref_mid).abs() / ref_mid) * 100.0
+        } else {
+            0.0
+        };
 
         ValidationResult {
             in_range,

--- a/tests/ashrae_140_case_960_sunspace.rs
+++ b/tests/ashrae_140_case_960_sunspace.rs
@@ -45,14 +45,16 @@ fn validate_energy_against_reference(
     actual: f64,
     ref_min: f64,
     ref_max: f64,
-    tolerance: f64,
+    _tolerance: f64,
 ) -> (bool, f64) {
+    // ASHRAE 140: pass if result falls within actual min-max range of reference ensemble
+    let in_range = (actual >= ref_min) && (actual <= ref_max);
     let ref_mid = (ref_min + ref_max) / 2.0;
-    let ref_half_range = (ref_max - ref_min) / 2.0;
-    let tolerance_range = ref_half_range * (1.0 + tolerance);
-
-    let in_range = (actual >= ref_mid - tolerance_range) && (actual <= ref_mid + tolerance_range);
-    let error_pct = ((actual - ref_mid).abs() / ref_mid) * 100.0;
+    let error_pct = if ref_mid > 0.0 {
+        ((actual - ref_mid).abs() / ref_mid) * 100.0
+    } else {
+        0.0
+    };
 
     (in_range, error_pct)
 }

--- a/tests/ashrae_140_case_970_validation.rs
+++ b/tests/ashrae_140_case_970_validation.rs
@@ -29,14 +29,16 @@ fn validate_energy_against_reference(
     actual: f64,
     ref_min: f64,
     ref_max: f64,
-    tolerance: f64,
+    _tolerance: f64,
 ) -> (bool, f64) {
+    // ASHRAE 140: pass if result falls within actual min-max range of reference ensemble
+    let in_range = (actual >= ref_min) && (actual <= ref_max);
     let ref_mid = (ref_min + ref_max) / 2.0;
-    let ref_half_range = (ref_max - ref_min) / 2.0;
-    let tolerance_range = ref_half_range * (1.0 + tolerance);
-
-    let in_range = (actual >= ref_mid - tolerance_range) && (actual <= ref_mid + tolerance_range);
-    let error_pct = ((actual - ref_mid).abs() / ref_mid) * 100.0;
+    let error_pct = if ref_mid > 0.0 {
+        ((actual - ref_mid).abs() / ref_mid) * 100.0
+    } else {
+        0.0
+    };
 
     (in_range, error_pct)
 }


### PR DESCRIPTION
Per ASHRAE 140-2023 Section 1.5, a result passes only if it falls within the actual min-max range of the reference ensemble, not a midpoint±tolerance approximation.

Fix: `validate_energy_against_reference()` now uses direct `[ref_min, ref_max]` range check, matching the already-correct `validate_peak_load_against_reference()`.

DEV-013 closed. Closes #723.