### PR TITLE
fix(ashrae-140): apply ISO 13790 Eq. 64 to lumped 5R1C h_em (partial #831)

### DIFF
--- a/src/sim/thermal_model_core.rs
+++ b/src/sim/thermal_model_core.rs
@@ -1095,22 +1095,47 @@ impl ThermalModel<VectorField> {
             // calculation from layer resistances is sufficient.
             let h_tr_em_physics = h_tr_em_base;
 
-            // === Issue #821 / Probe A+B: drop floor from lumped 5R1C h_em ===
+            // === Issue #831: ISO 13790 §7.2.2.2 Eq. 64 — series-consistent lumped h_em ===
             //
-            // The floor's heat path to its boundary (ground) is already captured by
-            // `h_tr_floor` (a separate node connected to T_ground in the heat balance).
-            // The legacy code ALSO summed `h_tr_em_floor` (= floor_U × A_floor) into the
-            // lumped `h_tr_em`, which `update_optimization_cache` then partially injects
-            // into `derived_h_ext` as part of `h_tr_em_non_south`. The floor's
-            // conductance therefore appeared twice — once correctly as ground coupling,
-            // and once spuriously as part of the air↔outdoor parallel path. For
-            // Case 600 this added ~9 W/K of bogus loss and depressed peak free-float
-            // air temperature by ~3 °C.
+            // After PR #821 corrected `h_ms` to the ISO 13790 lumped form
+            // `h_ms = 9.1 × A_m` and PR #830 fixed the EPW parser, the legacy
+            // half-insulation `h_em_physics + h_em_roof` value (~100 W/K for
+            // Case 600) is inconsistent with the ISO 13790 5R1C topology:
+            // `h_em` and `h_ms` in series must equal the overall opaque
+            // transmittance `h_op = Σ U·A`. The half-insulation formulation
+            // produces ~85 W/K for the wall element while `U_wall × A_wall`
+            // is ~39 W/K — a 2.2× over-coupling that lets the mass node dump
+            // its accumulated solar back to the outdoor sink too quickly.
             //
-            // The 9R4C per-surface vectors below still receive the per-surface floor
-            // value, since that solver topology has a dedicated floor mass node and
-            // does not consume the lumped `h_tr_em`.
-            let h_tr_em_total = h_tr_em_physics + h_tr_em_roof;
+            // ISO 13790:2008 Eq. 64 specifies:
+            //
+            //     h_em = 1 / (1/h_op  -  1/h_ms)
+            //
+            // where h_op is summed over opaque mass-bearing elements
+            // (walls + roof; floor is excluded — it has its own ground node
+            // via h_tr_floor, and including it here double-counts as in
+            // PR #821's Probe A+B).
+            //
+            // The opaque-solar-to-mass term `phi_m += A_op × U × α × I × R_ext`
+            // (computed in `calculate_zone_solar_gain` and stored in
+            // `opaque_solar_gains`) is mathematically equivalent to the
+            // sol-air boost `h_em × (α × I / h_ext)` when h_em equals U × A,
+            // so this change makes the two paths self-consistent. No change
+            // to phi_m is needed.
+            //
+            // The per-surface 9R4C vectors below continue to use the
+            // half-insulation values because the 9R4C topology has a
+            // dedicated mass node per surface and does NOT consume the
+            // lumped `h_tr_em`.
+            let h_op_walls_roof = spec.construction.wall.u_value(None, None) * opaque_area
+                + spec.construction.roof.u_value(None, None) * zone_floor_area;
+
+            let h_tr_em_total = if h_op_walls_roof > 0.0 && h_op_walls_roof < h_ms_iso_13790 {
+                1.0 / (1.0 / h_op_walls_roof - 1.0 / h_ms_iso_13790)
+            } else {
+                // Fallback: degenerate construction — use legacy half-insulation total.
+                h_tr_em_physics + h_tr_em_roof
+            };
 
             // Debug output for all contributions
             h_tr_em_vec.push(h_tr_em_total.max(0.1));

--- a/src/sim/thermal_model_iterative.rs
+++ b/src/sim/thermal_model_iterative.rs
@@ -217,7 +217,7 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
                                                    // DEBUG: DEBUG_ZONE_SOLAR removed (PR #821)
 
             // Now calculate solar gain once per unique orientation
-            for (orientation, (total_win_area, total_opaque_area)) in surfaces_by_orientation {
+            for (orientation, (total_win_area, _total_opaque_area)) in surfaces_by_orientation {
                 // Create temporary window properties with the combined window area for this orientation
                 let oriented_window_props = WindowProperties {
                     area: total_win_area,

--- a/src/sim/thermal_model_iterative.rs
+++ b/src/sim/thermal_model_iterative.rs
@@ -293,17 +293,14 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
                     }
 
                     // 2. Opaque Solar Gain (Wall/Roof)
-                    if opaque_area > 0.0 && total_opaque_area > 0.0 {
-                        // Sol-air temperature method for opaque surfaces
-                        // Q = alpha * I * Re * U * A
-                        // Scale by ratio of per-surface opaque area to total orientation opaque area
-                        let area_ratio = opaque_area / total_opaque_area;
-                        total_opaque_gain += opaque_area
-                            * surface.u_value
-                            * irradiance.total_wm2
-                            * alpha
-                            * re
-                            * area_ratio;
+                    // Issue #831: Sol-air method  q = α × I × R_ext × U × A
+                    // Previously this multiplied by an extra `area_ratio = opaque_area / total_opaque_area`,
+                    // which double-attenuated the gain by `1/N` per orientation. With one wall surface per
+                    // orientation in Case 600 (N=1) the bug had no effect, but with multiple orientations
+                    // sharing surfaces (e.g. roof spans the floor footprint) the gain was halved.
+                    if opaque_area > 0.0 {
+                        total_opaque_gain +=
+                            opaque_area * surface.u_value * irradiance.total_wm2 * alpha * re;
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Partial work on #831: applies one principled, ISO 13790-justified change to restore some of the 600/650FF max-temperature behaviour that PR #821 lost when PR #830 corrected the EPW parser. **Does not close #826** — the remaining 17 °C gap to the ASHRAE 140 reference band requires further investigation that is out of scope for this PR.

## Test impact (vs `main`)

| Suite | `main` | This PR | Δ |
|---|---:|---:|---|
| 600-series ASHRAE 140 | 4 / 26 | **6 / 26** | **+2** (`case_630`/`case_640::test_peak_heating`) |
| 900-series ASHRAE 140 | 9 / 17 | 9 / 17 | 0 (no regression) |
| Library unit tests | 2425 / 2425 ✅ | 2425 / 2425 ✅ | 0 |
| FF zero-HVAC guards (PR #821) | 3 / 3 ✅ | 3 / 3 ✅ | 0 |

| Test | `main` | This PR | Reference | Status |
|---|---:|---:|---:|---|
| 600FF max | 45.63 °C | **48.28 °C** | [64.9, 75.1] | still failing −16.6 °C |
| 650FF max | 45.63 °C | **48.28 °C** | [63.2, 73.5] | still failing −14.9 °C |
| 600FF min | −10.89 °C | **−7.70 °C** | [−18.8, −15.6] | got slightly worse (warmer) |
| 650FF min | −10.89 °C | **−7.70 °C** | [−23.0, −21.0] | got slightly worse (warmer) |

## Changes

### 1. ISO 13790 Eq. 64 lumped `h_em` (`src/sim/thermal_model_core.rs`)

Replace the legacy half-insulation-rule lumped `h_em = h_em_physics + h_em_roof` (~100 W/K for Case 600) with the canonical ISO 13790:2008 §7.2.2.2 Eq. 64 series formula:

```
h_em = 1 / (1 / h_op  -  1 / h_ms)
```

where `h_op = Σ U·A` over opaque mass-bearing elements (walls + roof; floor stays in `h_tr_floor`). For Case 600, `h_op ≈ 54 W/K` and `h_ms ≈ 1340 W/K`, giving `h_em ≈ 50 W/K`. This makes `h_em` and `h_ms` in series equal the canonical opaque envelope transmittance, which is the ISO 13790 invariant the rest of the lumped network expects.

The old half-insulation form over-coupled the mass node to the outdoor sink by ~2.2× for the wall element (legacy 85 W/K vs canonical U·A 39 W/K). The 9R4C per-surface vectors continue to use the half-insulation values because that solver topology has a dedicated mass node per surface and does NOT consume the lumped `h_tr_em`.

### 2. Remove opaque-solar-to-mass double-attenuation (`src/sim/thermal_model_iterative.rs`)

The previous formula in the per-orientation opaque-solar loop multiplied each surface contribution by both `opaque_area` AND `area_ratio = opaque_area / total_opaque_area`, giving only `1/N` of the correct heat input when N surfaces share an orientation.

Case 600 has 1 surface per orientation so this bug was masked, but it would reduce opaque solar gains by ≥ 50% for any case with multiple surfaces per orientation (e.g. Case 960 multi-zone). The corrected sol-air method is `q = α · I · R_ext · U · A_op` summed over surfaces.

## Why the remaining 17 °C gap is not closed

A parametric sweep of `h_tr_ms` multipliers over the corrected solar inputs shows the summer max plateaus at ~58 °C (mult=0.2) regardless of further tuning. ASHRAE 140 reference simulators reach 65-75 °C with the same daily window solar (~75 kWh) that this model now sees.

The remaining gap requires one or more of:
- **(a)** Further reduction of envelope loss beyond ISO 13790 Eq. 64 (e.g. revisiting the south-bypass collapse from PR #821).
- **(b)** Larger solar coupling to the mass node (e.g. proper sol-air temperature on the `h_em` path instead of plain `outdoor_temp`).
- **(c)** Audit of the Perez sky model output against EnergyPlus reference.

Each of those is a multi-day investigation that should be a separate PR with reference-cited justification, not a numerical fit. Diagnostic data is being appended to #831 for the next session to consume.

## What this PR is and isn't

- ✅ **Is** a small, principled, physics-justified improvement that takes one direction in the ISO 13790 spec.
- ✅ **Is** safe to merge: zero regressions, +2 incidental test passes, full library tests still green, FF zero-HVAC guards still green.
- ❌ **Is not** the full fix for #826. Both 600/650FF max and min tests still fail.
- ❌ **Is not** a closure of #831 — the issue stays open with diagnostic data for the follow-up agent.

## References

- ISO 13790:2008 §7.2.2.2 Eqs. 63-65 (lumped 5R1C network).
- ASHRAE 140-2023 Annex B Tables B1-2..B1-5 (test case parameters).

## Related issues

- Partial work on #831 (calibration follow-up to #830).
- Blocks: #826 (FF winter minima still fail).
- References: #821 (the original FF max-temperature fix that this PR partially restores).
