### PR TITLE
chore(adaptive-timestep): deprecate TimeConstantAnalyzer (closes #828)

### DIFF
--- a/src/sim/adaptive_timestep.rs
+++ b/src/sim/adaptive_timestep.rs
@@ -291,11 +291,38 @@ impl AdaptiveTimestepScheduler {
     }
 }
 
-/// Time constant analyzer for ASHRAE 140 cases
+/// Time constant analyzer for ASHRAE 140 cases (DEPRECATED).
 ///
-/// Calculates thermal time constants for standard test cases.
+/// **Deprecated as of Issue #828.** This analyzer keys off ASHRAE 140 case
+/// identifiers (e.g. `"600"`, `"900FF"`) and returns hard-coded time-constant
+/// values from a lookup table. After PR #821 / Probe H, the solver derives
+/// τ directly from physics:
+///
+/// ```text
+/// τ_seconds = Σ Cm  /  Σ h_tr_ms
+/// ```
+///
+/// via [`crate::sim::engine::ThermalModel::estimate_time_constant_hours`],
+/// which is independent of `case_id` and consistent with the ISO 13790
+/// `h_ms = 9.1 × A_m` formulation introduced by PR #821. The lookup table
+/// here was last updated against pre-PR #821 conductances and disagrees
+/// with current physics (e.g. the table says `h = 800 W/K` for Case 600
+/// while the simulator now produces `h_tr_ms ≈ 1340 W/K`).
+///
+/// The struct and its methods are retained for downstream callers (and
+/// integration tests in `tests/adaptive_timestep_integration.rs`) but
+/// emit deprecation warnings. New code should call
+/// `model.estimate_time_constant_hours()` instead.
+///
+/// Issue #740 separately tracks removing the case-id keying from the
+/// solver path entirely; this deprecation is the precursor cleanup.
+#[deprecated(
+    since = "1.0.0",
+    note = "Keys off ASHRAE 140 case_id and uses pre-PR #821 conductances.             Use `ThermalModel::estimate_time_constant_hours()` instead,             which derives τ from Cm/h_tr_ms directly. See Issue #828."
+)]
 pub struct TimeConstantAnalyzer;
 
+#[allow(deprecated)]
 impl TimeConstantAnalyzer {
     /// Calculate time constant for ASHRAE 140 case
     ///
@@ -427,6 +454,7 @@ pub struct CaseTimeConstant {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
 

--- a/tests/adaptive_timestep_integration.rs
+++ b/tests/adaptive_timestep_integration.rs
@@ -2,6 +2,7 @@
 //!
 //! This module contains integration tests for the adaptive timestep feature,
 //! validating accuracy improvements for high-mass buildings (Case 900 series).
+#![allow(deprecated)] // Issue #828: TimeConstantAnalyzer is deprecated; tests retained until full removal.
 
 use fluxion::ai::surrogate::SurrogateManager;
 use fluxion::physics::cta::VectorField;


### PR DESCRIPTION
## Summary

Closes #828. Marks `TimeConstantAnalyzer` as `#[deprecated]` so any external caller of the case-id-keyed time-constant lookup gets a compiler warning pointing at the canonical alternative.

## Why

After PR #821 / Probe H, the solver derives τ directly from physics in `ThermalModel::estimate_time_constant_hours()`:

```rust
τ_seconds = Σ Cm  /  Σ h_tr_ms
```

This is independent of `case_id` and consistent with the ISO 13790 `h_ms = 9.1 × A_m` formulation. The legacy `TimeConstantAnalyzer::for_case` lookup table is now:

1. **Inconsistent with current physics** — table says `h = 800 W/K` for Case 600 while the simulator now produces `h_tr_ms ≈ 1340 W/K`.
2. **Keys off `case_id`**, which Issue #740 forbids for blind-validation hygiene.
3. **Dead-but-misleading** for any future maintainer reading the code.

## What I did

- Marked the struct `#[deprecated(since = "1.0.0", note = "...")]` with a doc comment pointing to `ThermalModel::estimate_time_constant_hours()`.
- Added `#[allow(deprecated)]` on the `impl` block so internal cross-method calls (`classify_case`, `recommended_timestep`, `generate_table` all transitively call `for_case`) don't fire the warning — only external consumers do.
- Added `#![allow(deprecated)]` to `tests/adaptive_timestep_integration.rs` with a comment back at #828, so the test suite stays clean.
- Did NOT delete the symbol — downstream callers (the in-tree integration tests, plus possibly external code) still compile, just with a warning.

## What I did not do

- Did not touch the case-id-keyed solver wiring (that's #740's scope).
- Did not delete the table — followed the issue's "deprecate, not delete" recommendation since the public API is consumed by tests outside the `adaptive_timestep` module.
- Did not refactor `classify_case` / `recommended_timestep` — they are wrappers that share the same case-id keying flaw and should be deprecated together. The struct-level deprecation tags them automatically.

## Test impact

| Suite | `main` | This PR | Δ |
|---|---:|---:|---|
| Library unit tests | 2425 / 2425 ✅ | **2425 / 2425 ✅** | 0 |
| `adaptive_timestep_integration` | 8 / 10 | 8 / 10 | 0 (2 pre-existing failures unchanged) |
| ASHRAE 140 600-series | 4 / 26 | 4 / 26 | 0 |
| ASHRAE 140 900-series | 9 / 17 | 9 / 17 | 0 |
| Library build warnings | 0 | **0** | 0 (deprecation silenced internally) |

## References

- ISO 13790:2008 §7.2.2.2 (canonical 5R1C `h_ms` formulation)
- PR #821 (introduced Probe H — physics-based τ derivation)
- Issue #740 (broader case-id removal scope)

## Summary by Sourcery

Deprecate the case-id-based TimeConstantAnalyzer in favor of the physics-derived ThermalModel::estimate_time_constant_hours while preserving compatibility for existing callers.

Enhancements:
- Add deprecation attributes and detailed documentation to TimeConstantAnalyzer to steer users toward ThermalModel::estimate_time_constant_hours.
- Allow deprecated usage internally and in tests so existing integration tests and downstream code compile without new warnings.