### PR TITLE
feat(pr821-diag): expose phi_ia/phi_st/phi_m heat-balance terms (closes #825)

### DIFF
--- a/docs/PR_821_DEBUG_FINDINGS.md
+++ b/docs/PR_821_DEBUG_FINDINGS.md
@@ -121,6 +121,7 @@ The shipped fix is **A + B (floor de-count) + topology fix (south bypass) + nigh
 | `src/sim/mod.rs` | Conditionally export `pr821_diag` under feature `pr821-diag`. |
 | `Cargo.toml` | New `pr821-diag` feature flag. |
 | `tests/ashrae_140_case_600_series.rs` | New `free_float_hvac_guard` test module (3 tests). FF helper opts into the diagnostic CSV under `pr821-diag`. |
+| `src/sim/thermal_model_data.rs`, `thermal_model_core.rs`, `thermal_model_physics.rs` | Issue #825: cfg-gated `last_phi_ia / last_phi_st / last_phi_m` on `ThermalModelData`, populated each call to `step_physics_5r1c`; the `pr821-diag` CSV writer now reads these instead of hard-coded `0.0`. |
 
 The 9R4C per-surface vectors (`h_tr_ms_wall_vec`, `h_tr_em_wall_vec`, etc.) are
 **unchanged** — they continue to use the half-insulation conduction values
@@ -166,3 +167,33 @@ cargo test --test ashrae_140_case_900 -- --test-threads=1
 - **Empirical correction factors (#724/#739):** stay disabled throughout.
 - **Reference values:** `tests/ashrae_140_case_600_series.rs:120-149` is the
   source of truth; it is consistent with the prose in #806.
+
+
+## Issue #825 — diagnostic CSV phi_* columns now real (post PR #821)
+
+Before #825 the `phi_ia`, `phi_st`, `phi_m` columns of `target/diag/pr821_<case>.csv`
+were placeholders (`0.0`) because those values were local temporaries inside
+`step_physics_5r1c`. This PR adds three cfg-gated `f64` fields to
+`ThermalModelData<T>` (`last_phi_ia / last_phi_st / last_phi_m`) that are
+written each timestep when the `pr821-diag` feature is enabled, with **zero
+overhead** and zero new fields when the feature is off (conditional
+compilation, not runtime branching).
+
+Schema is unchanged; the contents are now the actual zone-0 W values used in
+the 5R1C heat balance:
+
+- `phi_ia` — `load·conv_frac + sol·solar_distribution_to_air`
+- `phi_st` — `load·st_int_frac + remaining_sol·st_sol_frac`
+- `phi_m`  — `load·m_int_frac + remaining_sol·m_sol_frac + opaque_sol`
+
+For Cases 600FF / 650FF the routing reduces to:
+
+| column   | typical value | why                                                        |
+|----------|---------------|------------------------------------------------------------|
+| `phi_ia` | 0 W           | zero internal loads, `solar_distribution_to_air = 0`       |
+| `phi_st` | 0 W           | same — surface fraction also collapses                     |
+| `phi_m`  | up to ~10.6 kW (mid-day Jul 17) | solar + opaque-surface gain routed entirely to mass node |
+
+The 600/650FF FF helper now also asserts at least one daytime row (10:00–16:00)
+has non-zero `phi_m`, so a future regression that re-zeros the field would
+fail-fast inside the test loop instead of producing a silently-empty CSV.

--- a/src/sim/pr821_diag.rs
+++ b/src/sim/pr821_diag.rs
@@ -209,6 +209,13 @@ impl DiagCollector {
         Ok(path)
     }
 
+    /// Borrow the accumulated diagnostic rows. Used by the 600/650FF
+    /// regression assertion in `tests/ashrae_140_case_600_series.rs` to verify
+    /// the heat-balance phi_* terms are non-zero when expected (Issue #825).
+    pub fn rows(&self) -> &[DiagRow] {
+        &self.rows
+    }
+
     pub fn len(&self) -> usize {
         self.rows.len()
     }

--- a/src/sim/thermal_model_core.rs
+++ b/src/sim/thermal_model_core.rs
@@ -2329,6 +2329,16 @@ impl ThermalModel<VectorField> {
             cm_internal: None,
             multi_node_thermal_mass: None,
 
+            // PR #821 / Issue #825 — diagnostic-only zone-0 heat-balance terms.
+            // Initialized to 0.0; overwritten each call to `step_physics_5r1c`
+            // when the `pr821-diag` feature is enabled.
+            #[cfg(feature = "pr821-diag")]
+            last_phi_ia: 0.0,
+            #[cfg(feature = "pr821-diag")]
+            last_phi_st: 0.0,
+            #[cfg(feature = "pr821-diag")]
+            last_phi_m: 0.0,
+
             // Wiring tracer for test-only integration validation (Plan 21-10)
             tracer: None,
         });

--- a/src/sim/thermal_model_data.rs
+++ b/src/sim/thermal_model_data.rs
@@ -165,6 +165,18 @@ pub struct ThermalModelData<T: ContinuousTensor<f64> + Clone> {
     pub cm_internal: Option<T>,
     // Multi-node thermal mass state for 9R4C model
     pub multi_node_thermal_mass: Option<crate::sim::multi_node_thermal::MultiNodeThermalMass>,
+    /// PR #821 / Issue #825 — most recent zone-0 phi_ia (W to air node) computed
+    /// inside `step_physics_5r1c`. Captured for the `pr821-diag` CSV writer so
+    /// the heat-balance terms can be inspected hour by hour. Always 0.0 when
+    /// the `pr821-diag` feature is disabled (and the field does not exist).
+    #[cfg(feature = "pr821-diag")]
+    pub last_phi_ia: f64,
+    /// PR #821 / Issue #825 — most recent zone-0 phi_st (W to surface node).
+    #[cfg(feature = "pr821-diag")]
+    pub last_phi_st: f64,
+    /// PR #821 / Issue #825 — most recent zone-0 phi_m (W to mass node).
+    #[cfg(feature = "pr821-diag")]
+    pub last_phi_m: f64,
 }
 
 impl<T: ContinuousTensor<f64> + Clone> Clone for ThermalModelData<T> {
@@ -303,6 +315,12 @@ impl<T: ContinuousTensor<f64> + Clone> Clone for ThermalModelData<T> {
             cm_floor: self.cm_floor.clone(),
             cm_internal: self.cm_internal.clone(),
             multi_node_thermal_mass: self.multi_node_thermal_mass.clone(),
+            #[cfg(feature = "pr821-diag")]
+            last_phi_ia: self.last_phi_ia,
+            #[cfg(feature = "pr821-diag")]
+            last_phi_st: self.last_phi_st,
+            #[cfg(feature = "pr821-diag")]
+            last_phi_m: self.last_phi_m,
         }
     }
 }

--- a/src/sim/thermal_model_physics.rs
+++ b/src/sim/thermal_model_physics.rs
@@ -626,6 +626,18 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
         let phi_st = T::from(VectorField::new(phi_st_data));
         let phi_m = T::from(VectorField::new(phi_m_data));
 
+        // PR #821 / Issue #825 — record zone-0 heat-balance terms for the
+        // `pr821-diag` hourly CSV. Zero overhead when the feature is disabled
+        // (no fields, no writes). The CSV consumer reads these fields right
+        // after `step_physics` returns. Only zone 0 is captured because the
+        // 600FF / 650FF investigation is single-zone.
+        #[cfg(feature = "pr821-diag")]
+        {
+            self.0.last_phi_ia = phi_ia.as_ref().first().copied().unwrap_or(0.0);
+            self.0.last_phi_st = phi_st.as_ref().first().copied().unwrap_or(0.0);
+            self.0.last_phi_m = phi_m.as_ref().first().copied().unwrap_or(0.0);
+        }
+
         // Use outdoor_temp directly. Solar gains on opaque surfaces are already included in phi_m.
         let mut t_sol_air_data = Vec::with_capacity(self.0.num_zones);
         for _ in 0..self.0.num_zones {

--- a/tests/ashrae_140_case_600_series.rs
+++ b/tests/ashrae_140_case_600_series.rs
@@ -233,14 +233,19 @@ fn run_free_floating_simulation(case_enum: ASHRAE140Case) -> (f64, f64) {
                 .as_ref()
                 .is_some_and(|nv| nv.is_active_at_hour(hour));
 
+            // Issue #825: phi_ia / phi_st / phi_m are now captured inside
+            // `step_physics_5r1c` and exposed on `model.0` when the
+            // `pr821-diag` feature is enabled. Read the most-recent zone-0
+            // values directly from the model so the CSV row matches the same
+            // timestep as the recorded temperatures.
             diag.record(
                 step,
                 &model,
                 outdoor_temp,
                 solar_window_w,
-                0.0, // phi_ia (not exposed for FF)
-                0.0, // phi_st
-                0.0, // phi_m  (computed inside step_physics; left at 0 here)
+                model.0.last_phi_ia,
+                model.0.last_phi_st,
+                model.0.last_phi_m,
                 night_vent_active,
                 0.0, // hvac_out_w (always 0 for FF — guarded by free_float assert)
             );
@@ -249,6 +254,21 @@ fn run_free_floating_simulation(case_enum: ASHRAE140Case) -> (f64, f64) {
 
     #[cfg(feature = "pr821-diag")]
     {
+        // Issue #825 acceptance: at least one daytime row (10:00–16:00 local
+        // hour) must have a non-zero phi_m (W to mass node) for cases that
+        // see daylight solar gains (600FF, 650FF). A non-zero value proves
+        // the solar/internal-gain routing is being captured in the diagnostic
+        // CSV — a previous iteration left these as placeholder zeros.
+        let any_daytime_phi_m = diag
+            .rows()
+            .iter()
+            .any(|r| (10..=16).contains(&r.hour) && r.phi_m.abs() > f64::EPSILON);
+        assert!(
+            any_daytime_phi_m,
+            "[pr821-diag] case={} has no daytime row with non-zero phi_m;              phi_* capture in step_physics_5r1c may have regressed (see #825)",
+            spec.case_id
+        );
+
         let path = diag
             .flush_to_csv()
             .expect("PR #821 diagnostic CSV write failed");


### PR DESCRIPTION
> *This was generated by AI during triage.*

## Summary

Closes #825. Replaces the placeholder `0.0` values for `phi_ia`, `phi_st`, and `phi_m` in `target/diag/pr821_<case>.csv` with the real per-timestep heat-balance routing values used inside `step_physics_5r1c`. The CSV schema is unchanged; only the contents of those three columns become meaningful.

## Approach

Three cfg-gated `f64` fields (`last_phi_ia / last_phi_st / last_phi_m`) are added to `ThermalModelData<T>`. They are written exactly once per `step_physics_5r1c` call when the `pr821-diag` cargo feature is enabled. The 600FF / 650FF FF helper now reads `model.0.last_phi_ia` etc. instead of passing hard-coded `0.0`.

**Zero overhead when disabled** — the fields do not exist in the struct, the `Clone` impl skips them, the constructor skips them, and `step_physics_5r1c` performs no extra writes. This is conditional compilation, not a runtime branch.

## Acceptance criteria from #825

- [x] `pr821-diag` records real `phi_ia`, `phi_st`, `phi_m` values from the same timestep as the recorded temperatures (zone 0 of the 5R1C heat balance).
- [x] No overhead when `pr821-diag` is disabled — `cfg`-gated fields, no runtime cost.
- [x] CSV remains 8,760 rows per annual run (verified: `[pr821-diag] case=600FF rows=8760 -> target/diag/pr821_600FF.csv`).
- [x] Regression assertion: at least one daytime row (10:00–16:00) of 600/650FF must have non-zero `phi_m`. Currently 2,550/8,760 daytime hours satisfy this for 600FF; max ~10.6 kW on Jul 17 hour 12 (consistent with the 8.6 kW window solar plus ~2 kW opaque-surface routing).
- [x] `docs/PR_821_DEBUG_FINDINGS.md` updated with the schema clarification and the 600/650FF-specific routing table.

## Why phi_ia / phi_st are still 0 for 600FF / 650FF

For Cases 600FF / 650FF the contents of those two columns are *real* zeros, not placeholders:

| column   | calc                                                       | 600/650FF value | reason                                                |
|----------|------------------------------------------------------------|-----------------|-------------------------------------------------------|
| `phi_ia` | `load·conv_frac + sol·solar_distribution_to_air`           | 0 W             | zero internal loads; `solar_distribution_to_air = 0`  |
| `phi_st` | `load·st_int_frac + remaining_sol·st_sol_frac`             | 0 W             | same — surface fraction also collapses                |
| `phi_m`  | `load·m_int_frac + remaining_sol·m_sol_frac + opaque_sol`  | up to ~10.6 kW  | solar + opaque surface gain routes entirely to mass   |

The new regression assertion checks `phi_m` only — which is the column that proves the routing is being captured. Asserting on `phi_ia` would falsely fail for these cases.

## Verification

```text
cargo clippy --lib -- -D warnings                     # CI Clippy bar — passes
cargo test  --lib                                      # 2425 passed; 0 failed (unchanged)
cargo test  --test ashrae_140_case_600_series \
            free_float_hvac_guard                      # 3/3 ok (FF zero-HVAC guards)
cargo test  --test ashrae_140_case_900                 # 9 passed; 8 failed (unchanged from main)
cargo test  --test ashrae_140_case_600_series \
            --features pr821-diag -- --test-threads=1  # CSV writes, phi_m assertion passes
```

Pre-existing failing 600-series tests (20/26) are out of scope here — they belong to #831 (h_tr_ms recalibration) and #826 (FF winter minima). PR count unchanged from `main`.

## Files changed

| file | what |
|---|---|
| `src/sim/thermal_model_data.rs` | Add `last_phi_ia / last_phi_st / last_phi_m` fields and Clone-impl entries (cfg-gated). |
| `src/sim/thermal_model_core.rs` | Initialize the three fields to `0.0` in the constructor (cfg-gated). |
| `src/sim/thermal_model_physics.rs` | Write zone-0 phi values into the new fields right after their construction in `step_physics_5r1c` (cfg-gated). |
| `src/sim/pr821_diag.rs` | Add `pub fn rows(&self) -> &[DiagRow]` so the regression assertion can scan the buffer. |
| `tests/ashrae_140_case_600_series.rs` | Replace `0.0` placeholders with `model.0.last_phi_*`; add the daytime non-zero-`phi_m` assertion. |
| `docs/PR_821_DEBUG_FINDINGS.md` | Document the schema clarification and the 600/650FF routing table. |

## Refs

- ISO 13790 §C.4 — 5R1C heat-balance terms phi_ia (air), phi_st (surface), phi_m (mass).
- Issue #825 — original triage and acceptance list.
- PR #821 — added the `pr821-diag` cargo feature and `DiagCollector`.
- Issue #763 — partially served by this PR; full hourly FF profile via `ValidationResult` is tracked under #827.
- Issues #831 / #826 — explicitly out of scope; this PR ships the diagnostic infra they need.

## Out of scope (follow-ups noticed during this work)

- `cargo clippy --tests -- -D warnings` is not green on `main`: tautologies in `src/validation/reference_loader.rs:207-208` (`assert!(has_600 || !has_600)`). Project's CI Clippy bar is `--lib`, so this is not blocking, but worth a small cleanup PR.