### PR TITLE
feat(validation): expose opt-in hourly FF temperature profile (closes #827)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -293,3 +293,8 @@ harness = true
 name = "validation_case_900_peak_attribution"
 path = "tests/validation/case_900_peak_attribution.rs"
 harness = true
+
+[[test]]
+name = "validation_hourly_ff_profile"
+path = "tests/validation/hourly_ff_profile.rs"
+harness = true

--- a/docs/PR_821_DEBUG_FINDINGS.md
+++ b/docs/PR_821_DEBUG_FINDINGS.md
@@ -197,3 +197,37 @@ For Cases 600FF / 650FF the routing reduces to:
 The 600/650FF FF helper now also asserts at least one daytime row (10:00–16:00)
 has non-zero `phi_m`, so a future regression that re-zeros the field would
 fail-fast inside the test loop instead of producing a silently-empty CSV.
+
+
+## Issue #827 — hourly FF temperature profile via ValidationResult API (post #825)
+
+The `pr821-diag` cargo feature writes `target/diag/pr821_<case>.csv` for offline
+analysis. PR for #827 adds a programmatic counterpart on the public Rust API
+so downstream consumers (validation reports, peer-review tooling, blind-validation
+harnesses) can read the same hourly zone-0 temperature trace **without** the
+feature flag and **without** touching the filesystem.
+
+### Surface
+
+- `FreeFloatValidationResult.hourly_temperatures: Option<Vec<f64>>` —
+  populated only for FF cases (case_id ending in `FF`). For non-FF cases the
+  field stays `None` and no `Vec` is allocated.
+- `CaseResults.hourly_temperatures: Option<Vec<f64>>` — same semantics on
+  the larger validator-result struct used by `simulate_case` and
+  `simulate_case_with_diagnostics`.
+
+### Cost
+
+| case kind | per-hour vector | allocation per simulate call |
+|-----------|-----------------|------------------------------|
+| FF        | `Some(Vec<f64>)` of length 8760 | one `Vec::with_capacity(8760)` (~70 KB) |
+| non-FF    | `None`                          | zero                                    |
+
+### Regression test
+
+`tests/validation/hourly_ff_profile.rs` (registered as the
+`validation_hourly_ff_profile` target) consumes the in-memory profile and
+asserts on length, min/max consistency, and diurnal-swing presence for
+600FF / 650FF / 900FF, plus the `None` invariant for the non-FF Case 600.
+The test does no filesystem I/O, so it can run in any CI shape regardless
+of the `pr821-diag` cargo feature.

--- a/src/validation/ashrae_140_validator.rs
+++ b/src/validation/ashrae_140_validator.rs
@@ -45,6 +45,12 @@ pub struct FreeFloatValidationResult {
     pub free_float_min_temp: f64,
     /// Maximum zone temperature (°C) for free-floating cases
     pub free_float_max_temp: f64,
+    /// Issue #827: opt-in hourly zone-0 air temperature profile (°C),
+    /// one entry per simulated step (8760 for an annual run).
+    /// Populated only for free-floating cases (case_id ending in `FF`);
+    /// `None` for HVAC-controlled cases. Allocated once per FF case
+    /// (~70 KB), so non-FF cases pay no allocation cost.
+    pub hourly_temperatures: Option<Vec<f64>>,
 }
 
 /// ASHRAE Standard 140 validation for building energy programs.
@@ -768,6 +774,13 @@ impl ASHRAE140Validator {
 
         let mut min_temp_celsius: f64 = f64::INFINITY;
         let mut max_temp_celsius: f64 = f64::NEG_INFINITY;
+        // Issue #827: pre-allocate the hourly profile once for FF cases only
+        // (~70 KB). For non-FF cases the Option stays `None` — zero allocation.
+        let mut hourly_temperatures: Option<Vec<f64>> = if is_free_floating {
+            Some(Vec::with_capacity(8760))
+        } else {
+            None
+        };
 
         for step in 0..STEPS {
             let hour_of_day = step % 24;
@@ -871,6 +884,10 @@ impl ASHRAE140Validator {
                     }
                     min_temp_celsius = min_temp_celsius.min(zone_0_temp);
                     max_temp_celsius = max_temp_celsius.max(zone_0_temp);
+                    // Issue #827
+                    if let Some(v) = &mut hourly_temperatures {
+                        v.push(zone_0_temp);
+                    }
                 }
             }
         }
@@ -896,6 +913,8 @@ impl ASHRAE140Validator {
             } else {
                 None
             },
+            // Issue #827
+            hourly_temperatures,
         }
     }
 
@@ -1573,6 +1592,13 @@ impl ASHRAE140Validator {
 
         let mut min_temp_celsius: f64 = f64::INFINITY;
         let mut max_temp_celsius: f64 = f64::NEG_INFINITY;
+        // Issue #827: pre-allocate the hourly profile once for FF cases only
+        // (~70 KB). For non-FF cases the Option stays `None` — zero allocation.
+        let mut hourly_temperatures: Option<Vec<f64>> = if is_free_floating {
+            Some(Vec::with_capacity(8760))
+        } else {
+            None
+        };
 
         // SESSION 32: Run simulation loop and accumulate energy manually
         // Reset model's internal energy tracking to avoid interference with raw accumulation
@@ -1709,6 +1735,10 @@ impl ASHRAE140Validator {
                 if let Some(&zone_0_temp) = model.temperatures.as_slice().first() {
                     min_temp_celsius = min_temp_celsius.min(zone_0_temp);
                     max_temp_celsius = max_temp_celsius.max(zone_0_temp);
+                    // Issue #827
+                    if let Some(v) = &mut hourly_temperatures {
+                        v.push(zone_0_temp);
+                    }
                 }
             }
         }
@@ -1735,6 +1765,8 @@ impl ASHRAE140Validator {
             } else {
                 None
             },
+            // Issue #827
+            hourly_temperatures,
         }
     }
 
@@ -1780,6 +1812,13 @@ impl ASHRAE140Validator {
 
         let mut min_temp_celsius: f64 = f64::INFINITY;
         let mut max_temp_celsius: f64 = f64::NEG_INFINITY;
+        // Issue #827: pre-allocate the hourly profile once for FF cases only
+        // (~70 KB). For non-FF cases the Option stays `None` — zero allocation.
+        let mut hourly_temperatures: Option<Vec<f64>> = if is_free_floating {
+            Some(Vec::with_capacity(8760))
+        } else {
+            None
+        };
 
         for step in 0..STEPS {
             let hour_of_day = step % 24;
@@ -1881,6 +1920,10 @@ impl ASHRAE140Validator {
                 if let Some(&zone_0_temp) = model.temperatures.as_slice().first() {
                     min_temp_celsius = min_temp_celsius.min(zone_0_temp);
                     max_temp_celsius = max_temp_celsius.max(zone_0_temp);
+                    // Issue #827
+                    if let Some(v) = &mut hourly_temperatures {
+                        v.push(zone_0_temp);
+                    }
                 }
             }
 
@@ -1940,6 +1983,8 @@ impl ASHRAE140Validator {
             } else {
                 None
             },
+            // Issue #827
+            hourly_temperatures,
         }
     }
 }
@@ -1958,6 +2003,12 @@ pub struct CaseResults {
     pub min_temp_celsius: Option<f64>,
     /// Maximum zone temperature (°C) for free-floating cases
     pub max_temp_celsius: Option<f64>,
+    /// Issue #827: opt-in hourly zone-0 air temperature profile (°C),
+    /// one entry per simulated step (8760 for an annual run).
+    /// Populated only for free-floating cases; `None` for HVAC-controlled
+    /// cases. Allocated once per FF case (~70 KB), so non-FF cases pay no
+    /// allocation cost.
+    pub hourly_temperatures: Option<Vec<f64>>,
 }
 
 /// Diagnostic data collected during case simulation.
@@ -2068,6 +2119,13 @@ impl ASHRAE140Validator {
         let mut annual_cooling_joules = 0.0;
         let mut min_temp_celsius: f64 = f64::INFINITY;
         let mut max_temp_celsius: f64 = f64::NEG_INFINITY;
+        // Issue #827: pre-allocate the hourly profile once for FF cases only
+        // (~70 KB). For non-FF cases the Option stays `None` — zero allocation.
+        let mut hourly_temperatures: Option<Vec<f64>> = if is_free_floating {
+            Some(Vec::with_capacity(8760))
+        } else {
+            None
+        };
 
         // Track energy components
         let mut total_solar_gains_joules = 0.0;
@@ -2220,6 +2278,10 @@ impl ASHRAE140Validator {
                     min_temp_celsius = min_temp_celsius.min(zone_0_temp);
                     max_temp_celsius = max_temp_celsius.max(zone_0_temp);
                     diagnostic.temp_profile.update(zone_0_temp);
+                    // Issue #827
+                    if let Some(v) = &mut hourly_temperatures {
+                        v.push(zone_0_temp);
+                    }
                 }
             }
 
@@ -2306,6 +2368,8 @@ impl ASHRAE140Validator {
             } else {
                 None
             },
+            // Issue #827
+            hourly_temperatures,
         };
 
         (results, diagnostic)
@@ -2358,6 +2422,13 @@ impl ASHRAE140Validator {
         // Run simulation for one year (8760 hours)
         let mut min_temp = f64::INFINITY;
         let mut max_temp = f64::NEG_INFINITY;
+        // Issue #827: pre-allocate the hourly profile once for FF cases only
+        // (~70 KB). For non-FF cases the Option stays `None` — zero allocation.
+        let mut hourly_temperatures: Option<Vec<f64>> = if is_free_floating {
+            Some(Vec::with_capacity(8760))
+        } else {
+            None
+        };
         let num_zones = model.num_zones;
 
         for step in 0..8760 {
@@ -2397,11 +2468,16 @@ impl ASHRAE140Validator {
             let zone_temp = model.get_temperatures()[0];
             min_temp = min_temp.min(zone_temp);
             max_temp = max_temp.max(zone_temp);
+            // Issue #827: also push to the opt-in hourly profile when allocated
+            if let Some(v) = &mut hourly_temperatures {
+                v.push(zone_temp);
+            }
         }
 
         FreeFloatValidationResult {
             free_float_min_temp: min_temp,
             free_float_max_temp: max_temp,
+            hourly_temperatures,
         }
     }
 

--- a/tests/validation/hourly_ff_profile.rs
+++ b/tests/validation/hourly_ff_profile.rs
@@ -1,0 +1,106 @@
+//! Regression test for Issue #827 — hourly free-float temperature profile via
+//! the `FreeFloatValidationResult` API.
+//!
+//! Consumes the in-memory hourly profile (no filesystem touch — the
+//! `pr821-diag` CSV is the offline equivalent) and asserts on:
+//!   1. The profile is `Some` for FF cases, `None` for non-FF cases.
+//!   2. Length is exactly 8760 (annual hourly run).
+//!   3. The recorded min/max equal the cumulative min/max from the profile.
+//!   4. The series shows real diurnal swing (at least one adjacent-hour
+//!      increase AND one decrease) — guards against a future regression that
+//!      collapses the profile to a constant.
+//!
+//! Acceptance criteria from the issue (all met):
+//!   - opt-in `hourly_temperatures: Option<Vec<f64>>` populated only for FF
+//!   - no allocation for non-FF cases (Option stays `None`)
+//!   - regression test consumes the in-memory profile (this file)
+//!   - `pr821-diag` CSV remains available as a separate artefact (unchanged)
+
+use fluxion::validation::ashrae_140_cases::ASHRAE140Case;
+use fluxion::validation::ashrae_140_validator::{validate_ashrae_140, FreeFloatValidationResult};
+
+fn assert_ff_profile_shape(case_id: &str, result: &FreeFloatValidationResult) {
+    let v = result
+        .hourly_temperatures
+        .as_ref()
+        .unwrap_or_else(|| panic!("[{case_id}] hourly_temperatures must be Some for FF case"));
+    assert_eq!(
+        v.len(),
+        8760,
+        "[{case_id}] hourly_temperatures length must be exactly 8760, got {}",
+        v.len()
+    );
+
+    let cum_min = v.iter().copied().fold(f64::INFINITY, f64::min);
+    let cum_max = v.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+    assert!(
+        (cum_min - result.free_float_min_temp).abs() < 1e-9,
+        "[{case_id}] returned min {} must match profile min {}",
+        result.free_float_min_temp,
+        cum_min
+    );
+    assert!(
+        (cum_max - result.free_float_max_temp).abs() < 1e-9,
+        "[{case_id}] returned max {} must match profile max {}",
+        result.free_float_max_temp,
+        cum_max
+    );
+
+    // Diurnal-swing sanity: not a constant series.
+    let mut saw_increase = false;
+    let mut saw_decrease = false;
+    for w in v.windows(2) {
+        if w[1] > w[0] {
+            saw_increase = true;
+        }
+        if w[1] < w[0] {
+            saw_decrease = true;
+        }
+        if saw_increase && saw_decrease {
+            break;
+        }
+    }
+    assert!(
+        saw_increase && saw_decrease,
+        "[{case_id}] hourly_temperatures must show real diurnal swing (saw \
+         increase = {saw_increase}, decrease = {saw_decrease})"
+    );
+}
+
+#[test]
+fn hourly_profile_populated_for_600ff() {
+    let spec = ASHRAE140Case::Case600FF.spec();
+    let result = validate_ashrae_140(&spec);
+    assert_ff_profile_shape("600FF", &result);
+}
+
+#[test]
+fn hourly_profile_populated_for_650ff() {
+    let spec = ASHRAE140Case::Case650FF.spec();
+    let result = validate_ashrae_140(&spec);
+    assert_ff_profile_shape("650FF", &result);
+}
+
+#[test]
+fn hourly_profile_populated_for_900ff() {
+    let spec = ASHRAE140Case::Case900FF.spec();
+    let result = validate_ashrae_140(&spec);
+    assert_ff_profile_shape("900FF", &result);
+}
+
+#[test]
+fn hourly_profile_none_for_non_ff_case() {
+    // Case 600 (HVAC-controlled, not FF) must NOT allocate the per-hour vector.
+    let spec = ASHRAE140Case::Case600.spec();
+    let result = validate_ashrae_140(&spec);
+    assert!(
+        result.hourly_temperatures.is_none(),
+        "non-FF Case 600: hourly_temperatures must be None (zero-overhead path), \
+         got Some(len={})",
+        result
+            .hourly_temperatures
+            .as_ref()
+            .map(|v| v.len())
+            .unwrap_or(0)
+    );
+}


### PR DESCRIPTION
> *This was generated by AI during triage.*

## Summary

Closes #827. Adds `Option<Vec<f64>> hourly_temperatures` to the ASHRAE 140 validator result structs so downstream consumers (validation reports, peer-review tooling, blind-validation harnesses) can read the hourly zone-0 air temperature trace **without scraping the `pr821-diag` CSV from disk and without requiring the `pr821-diag` cargo feature**.

## API surface

```rust
// in fluxion::validation::ashrae_140_validator
pub struct FreeFloatValidationResult {
    pub free_float_min_temp: f64,
    pub free_float_max_temp: f64,
    /// Issue #827 — opt-in 8760-element profile, Some only for FF cases.
    pub hourly_temperatures: Option<Vec<f64>>,
}

pub struct CaseResults {
    // ... existing fields ...
    /// Issue #827 — opt-in 8760-element profile, Some only for FF cases.
    pub hourly_temperatures: Option<Vec<f64>>,
}
```

Both fields are populated only for free-floating cases (`case_id` ending in `FF`). For HVAC-controlled cases the field stays `None` and **no `Vec` is allocated** — zero overhead by default.

## Cost

| case kind | per-hour vector | allocation per simulate call |
|-----------|-----------------|------------------------------|
| FF        | `Some(Vec<f64>)` of length 8760 | one `Vec::with_capacity(8760)` (~70 KB) |
| non-FF    | `None`                          | zero                                    |

## Where the push lives

The `Vec::push` is wired into the same `is_free_floating` branch that already updates `min_temp_celsius / max_temp_celsius` in all five 8760-step loops:

- `validate_ashrae_140` (free function + method on `ASHRAE140Validator`)
- `simulate_case` (two paths — one with detailed energy tracking, one with internal kWh tracking)
- `simulate_case_with_diagnostics`

Because the push is colocated with the min/max update, the recorded extrema are guaranteed to equal the cumulative extrema of the vector. The new test asserts this invariant explicitly.

## Acceptance criteria from #827

- [x] Add an opt-in `hourly_temperatures: Option<Vec<f64>>` to `CaseResults` / `ValidationResult` populated only for FF cases — implemented on **both** `FreeFloatValidationResult` (the public-API surface tests already use) and `CaseResults` (the larger validator struct).
- [x] No allocation for non-FF cases (zero-overhead by default) — `Option` stays `None`, no `Vec` constructed.
- [x] Regression test consumes the in-memory hourly profile without touching the filesystem — `tests/validation/hourly_ff_profile.rs` (new test target `validation_hourly_ff_profile`).
- [x] `pr821-diag` CSV remains available as a separate offline artefact — unchanged.

## Test

`tests/validation/hourly_ff_profile.rs` (4 tests):

| test                                       | assertion |
|--------------------------------------------|-----------|
| `hourly_profile_populated_for_600ff`       | 600FF — `Some`, len == 8760, min/max round-trip, diurnal swing present |
| `hourly_profile_populated_for_650ff`       | 650FF — same |
| `hourly_profile_populated_for_900ff`       | 900FF — same |
| `hourly_profile_none_for_non_ff_case`      | non-FF Case 600 — `None` (zero-overhead invariant) |

The diurnal-swing check (at least one adjacent-hour increase AND one adjacent-hour decrease somewhere in the 8760-element series) guards against a future regression that collapses the profile to a constant — len + min/max alone would falsely satisfy a flat series.

## Verification

```text
cargo build --tests                                 # ok (one pre-existing unrelated warning)
cargo clippy --lib -- -D warnings                   # CI Clippy bar — passes
cargo fmt --all -- --check                          # passes
cargo test --lib                                    # 2425/2425 unchanged
cargo test --test validation_hourly_ff_profile      # 4/4 ok
cargo test --test ashrae_140_case_600_series \
          free_float_hvac_guard                     # 3/3 ok
cargo test --test ashrae_140_case_900               # 9/17 unchanged from main
```

Pre-existing 600-series `test_max_temperature` / `test_min_temperature` failures (20/26) are out of scope here — they belong to #831 (h_tr_ms recalibration) and #826 (FF winter minima). PR count unchanged from `main`.

## Files changed

| file | what |
|---|---|
| `src/validation/ashrae_140_validator.rs` | Add `hourly_temperatures` to both `FreeFloatValidationResult` and `CaseResults`; allocate-and-push in all 5 simulate loops |
| `tests/validation/hourly_ff_profile.rs` | New test target — 4 assertions on the in-memory profile shape |
| `Cargo.toml` | Register the new `validation_hourly_ff_profile` test target |
| `docs/PR_821_DEBUG_FINDINGS.md` | Document the new API surface and zero-overhead cost table |

## Refs

- Issue #827 — original triage and acceptance list.
- Issue #763 — umbrella for FF hourly reporting; this PR is the API counterpart called for in #827.
- PR #821 — added the `pr821-diag` cargo feature and `DiagCollector`; CSV remains the offline artefact.
- PR #835 — completed `phi_*` heat-balance terms in the same CSV (Issue #825).