### PR TITLE
chore(clippy): make cargo clippy --tests -D warnings green (closes #837)

### DIFF
--- a/src/validation/reference_loader.rs
+++ b/src/validation/reference_loader.rs
@@ -200,12 +200,19 @@ mod tests {
 
     #[test]
     fn test_has_case() {
-        let has_195 = has_case("195");
-        let has_600 = has_case("600");
-        let has_invalid = has_case("INVALID");
-        assert!(has_195 || !has_195);
-        assert!(has_600 || !has_600);
-        assert!(!has_invalid || !has_invalid);
+        // Issue #837: An identifier that does not exist in the reference DB
+        // (or any identifier when the DB is missing entirely) must report `false`.
+        // This is the only environment-independent invariant of `has_case`.
+        assert!(
+            !has_case("INVALID"),
+            "has_case must return false for an identifier not in the reference DB"
+        );
+
+        // The reference file may or may not be bundled in this environment;
+        // call the function on a few real case IDs only to exercise the lookup
+        // path without panicking. The return value is intentionally not asserted.
+        let _ = has_case("195");
+        let _ = has_case("600");
     }
 
     #[test]

--- a/tests/solar_gain_tests.rs
+++ b/tests/solar_gain_tests.rs
@@ -17,6 +17,11 @@
 
 #[derive(Debug)]
 struct EnergyPlusReference {
+    /// Issue #837: Loaded from the reference JSON for completeness but not
+    /// currently consumed by any test in this file (solar-specific assertions
+    /// only exercise heating/cooling/solar fields). Allowing dead_code to keep
+    /// the JSON deserialization shape stable for future tests.
+    #[allow(dead_code)]
     zone_air_temp_c: Vec<f64>,
     heating_energy_wh: Vec<f64>,
     cooling_energy_wh: Vec<f64>,


### PR DESCRIPTION
> *This was generated by AI during triage.*

## Summary

Closes #837. Two pre-existing failures were blocking the broader Clippy bar (`cargo clippy --tests -- -D warnings`); the project's CI bar is `--lib` only so neither was visible to CI, but both blocked any developer running the full lint locally. Fixed both in a single small chore PR.

## Changes

| file | failure | fix |
|---|---|---|
| `src/validation/reference_loader.rs:207-208` | three `assert!(x \|\| !x)` tautologies (`clippy::nonminimal_bool` / `overly_complex_bool_expr`) | rewrote `test_has_case` to enforce the only environment-independent invariant — `has_case("INVALID")` must be `false` — and exercise the lookup path on real case IDs without asserting on the environment-dependent return value |
| `tests/solar_gain_tests.rs:20` | `EnergyPlusReference.zone_air_temp_c` is loaded from JSON but never read by any test (`clippy::dead_code`) | annotated with `#[allow(dead_code)]` plus a comment explaining the deliberate retention so the JSON deserialization shape stays stable for future tests |

## Why two fixes in one PR

#837 was filed for the tautology asserts only, but the dead-code field is the **only** other blocker between us and a green `cargo clippy --tests -- -D warnings`. Fixing both in the same chore keeps the goal of the issue (broader Clippy bar green) achievable in one round-trip rather than two.

## Verification

```text
cargo clippy --lib   -- -D warnings   -> ok (CI bar — was already green)
cargo clippy --tests -- -D warnings   -> ok (NEW — was failing on main)
cargo fmt --all -- --check            -> ok
cargo test --lib                      -> 2425/2425 unchanged
cargo test --test solar_gain_tests --no-run -> ok
```

## What this enables

A future PR can promote the CI Clippy job from `cargo clippy --lib -- -D warnings` to `cargo clippy --tests -- -D warnings` (or `cargo clippy --all-targets -- -D warnings` after a wider audit) without immediately failing on these two pre-existing issues. That is **not** done in this PR — out of scope.

## Refs

- Issue #837 — original triage.
- PR #835 (`feat(pr821-diag): expose phi_*`) and PR #836 (`feat(validation): hourly FF profile`) — both surfaced these locally while running the broader Clippy bar.