### PR TITLE
fix(ashrae-140): use Table B1-3 heavyweight concrete for 900-series floor (closes #730)

### DIFF
--- a/src/sim/construction.rs
+++ b/src/sim/construction.rs
@@ -942,8 +942,38 @@ impl Materials {
     }
 
     /// Concrete slab (heavy mass)
+    ///
+    /// **Note:** these are normal-weight slab properties (k=1.13, ρ=1400, cp=1000).
+    /// For ASHRAE 140-2023 Case 900-series construction, use
+    /// [`Materials::concrete_heavyweight`] instead, which carries the medium-density
+    /// values from Table B1-3 (Issue #730).
     pub fn concrete_slab(thickness: f64) -> ConstructionLayer {
         ConstructionLayer::new("Concrete Slab", 1.13, 1400.0, 1000.0, thickness)
+    }
+
+    /// Heavyweight (medium-density) concrete per ASHRAE 140-2023 Table B1-3.
+    ///
+    /// Used for the 900-series high-mass floor slab and (eventually) other
+    /// BESTEST heavyweight constructions. Values are the BESTEST medium-density
+    /// concrete spec — NOT normal-weight structural concrete.
+    ///
+    /// | Property | Value | Source |
+    /// |----------|-------|--------|
+    /// | k        | 0.51 W/m·K | ASHRAE 140-2023 Table B1-3 |
+    /// | ρ        | 1400 kg/m³ | ASHRAE 140-2023 Table B1-3 |
+    /// | cp       | 840 J/kg·K | ASHRAE 140-2023 Table B1-3 |
+    ///
+    /// Reference: Judkoff & Neymark (1995), NREL/TP-472-6231, §4.2.2.
+    /// Closes Issue #730 (medium-density vs normal-weight concrete confusion).
+    pub fn concrete_heavyweight(thickness: f64) -> ConstructionLayer {
+        // ASHRAE 140-2023 Table B1-3, BESTEST heavyweight (medium-density) concrete.
+        ConstructionLayer::new(
+            "Concrete (ASHRAE 140 heavyweight)",
+            0.51,
+            1400.0,
+            840.0,
+            thickness,
+        )
     }
 
     /// Insulation for floor/walls
@@ -1021,9 +1051,12 @@ impl Assemblies {
     }
 
     /// High mass floor construction (ASHRAE 140 Case 900).
+    ///
+    /// Slab uses [`Materials::concrete_heavyweight`] per ASHRAE 140-2023 Table B1-3
+    /// (k=0.51, ρ=1400, cp=840). Closes Issue #730.
     pub fn high_mass_floor() -> Construction {
         Construction::new(vec![
-            Materials::concrete_slab(0.080),
+            Materials::concrete_heavyweight(0.080),
             Materials::insulation_high_mass(0.201), // Adjusted for U=0.190
         ])
     }
@@ -1950,7 +1983,8 @@ mod tests {
     fn test_high_mass_floor() {
         let floor = Assemblies::high_mass_floor();
         assert_eq!(floor.layer_count(), 2);
-        assert_eq!(floor.layers[0].name, "Concrete Slab");
+        // Issue #730: ASHRAE 140-2023 Table B1-3 heavyweight (medium-density) concrete.
+        assert_eq!(floor.layers[0].name, "Concrete (ASHRAE 140 heavyweight)");
         assert_eq!(floor.layers[1].name, "Insulation");
     }
 
@@ -1999,6 +2033,43 @@ mod tests {
         assert_eq!(layer.conductivity, 1.13);
         assert_eq!(layer.density, 1400.0);
         assert_eq!(layer.specific_heat, 1000.0);
+    }
+
+    #[test]
+    fn test_materials_concrete_heavyweight_matches_ashrae_140_table_b1_3() {
+        // ASHRAE 140-2023 Table B1-3 — BESTEST heavyweight (medium-density) concrete.
+        // Reference: Judkoff & Neymark (1995), NREL/TP-472-6231, §4.2.2.
+        let layer = Materials::concrete_heavyweight(0.200);
+        assert_eq!(layer.conductivity, 0.51, "k must match Table B1-3");
+        assert_eq!(layer.density, 1400.0, "rho must match Table B1-3");
+        assert_eq!(layer.specific_heat, 840.0, "cp must match Table B1-3");
+        assert_eq!(layer.thickness, 0.200);
+        // Areal heat capacity per Table B1-3: kappa = rho * cp * d = 1400 * 840 * 0.200
+        let kappa = layer.density * layer.specific_heat * layer.thickness;
+        assert!(
+            (kappa - 235_200.0).abs() < 1.0,
+            "kappa must be 235.2 kJ/m^2K"
+        );
+    }
+
+    #[test]
+    fn test_high_mass_floor_uses_ashrae_140_heavyweight_concrete() {
+        // Issue #730: high_mass_floor() must source its slab from
+        // Materials::concrete_heavyweight, not normal-weight Materials::concrete_slab.
+        let floor = Assemblies::high_mass_floor();
+        let slab = &floor.layers[0];
+        assert_eq!(
+            slab.conductivity, 0.51,
+            "slab k must be ASHRAE 140 Table B1-3 value"
+        );
+        assert_eq!(
+            slab.density, 1400.0,
+            "slab rho must be ASHRAE 140 Table B1-3 value"
+        );
+        assert_eq!(
+            slab.specific_heat, 840.0,
+            "slab cp must be ASHRAE 140 Table B1-3 value"
+        );
     }
 
     #[test]


### PR DESCRIPTION
> *This was generated by AI during triage.*

## Summary

The 900-series high-mass floor slab was sourcing its concrete from `Materials::concrete_slab` (k=1.13 W/m·K, cp=1000 J/kg·K) — normal-weight structural concrete properties — instead of the BESTEST medium-density concrete spec from **ASHRAE 140-2023 Table B1-3** (k=0.51 W/m·K, ρ=1400 kg/m³, cp=840 J/kg·K).

This PR adds `Materials::concrete_heavyweight()` carrying the Table B1-3 spec verbatim, and switches `Assemblies::high_mass_floor()` to use it. `Materials::concrete_slab` is untouched (still used by inter-zone partitions and other generic-concrete callers, where normal-weight values are correct).

## References

- ASHRAE 140-2023 Table B1-3 (Opaque Construction Properties).
- Judkoff & Neymark (1995), NREL/TP-472-6231, *International Energy Agency Building Energy Simulation Test (BESTEST) and Diagnostic Method*, §4.2.2.

## Effect

| Metric | Before | After | Δ |
|---|---:|---:|---:|
| 900FF max temperature | 25.26 °C | 25.28 °C | +0.02 (noise) |
| 900-series test pass count | 9/17 | 9/17 | 0 |
| 600-series test pass count | 6/26 | 6/26 | 0 (no 900 materials on this path) |
| Library tests | 2425/2425 | 2427/2427 | +2 (new spec assertions) |
| FF zero-HVAC guards | 3/3 | 3/3 | 0 |
| `validation_hourly_ff_profile` | 4/4 | 4/4 | 0 |
| `validation_night_ventilation_air_side` | 2/2 | 2/2 | 0 |

The remaining 900FF gap to the reference band [41.8, 46.4] °C is structural per the closed Issue #831 (5R1C lumped τ ≈ 7 h cannot reproduce the BESTEST diurnal swing on canonical weather; closing it requires the multi-node CTF/9R4C workstream of #715/#726/#730 — and #730 is the material-properties prerequisite this PR addresses).

## Why this is safe (and not a wash)

- **No regression on any tracked metric.** Pass counts identical, all guard tests still green.
- **The CTF wiring at `src/sim/thermal_model_core.rs:1692` routes 900FF/950FF by `case_id` string, NOT by κ/τ threshold**, so there is no rerouting risk from #730's implementation note. Cases 900 (with HVAC), 910, 920, 930, 940 keep their existing 5R1C path; only the floor slab's material spec changes.
- Single-direction win: every change is correctness-positive, none are numerical-fit.

## Out of scope (deliberately)

- `Assemblies::high_mass_roof` still uses `Materials::concrete(0.080)`. Per ASHRAE 140 Case 900, the roof is the same lightweight construction as Case 600 (plasterboard + insulation + roof deck) — no concrete in the roof at all. That is a layer-composition error, not a material-spec error, and belongs to a separate issue.
- `ConcreteMaterial::new()` in `src/sim/assembly.rs` (k=1.4, ρ=2300) is also a wrong-defaults issue, but is not on the 900-series ASHRAE 140 simulation path. It powers `solver_manager.rs` test fixtures and similar; flipping it risks rippling into untracked test paths and is best handled in its own PR.

## Test plan executed locally

```
cargo fmt --all -- --check               # clean
cargo clippy --lib   -- -D warnings      # CI gate, green
cargo clippy --tests -- -D warnings      # broader bar, green
cargo test --lib                          # 2427/2427
cargo test --test ashrae_140_case_900            -- --test-threads=1   # 9/17 (unchanged)
cargo test --test ashrae_140_case_600_series     -- --test-threads=1   # 6/26 (unchanged)
cargo test --test ashrae_140_case_600_series free_float_hvac_guard -- --test-threads=1  # 3/3
cargo test --test validation_hourly_ff_profile          -- --test-threads=1  # 4/4
cargo test --test validation_night_ventilation_air_side -- --test-threads=1  # 2/2
```

Closes #730.
