### PR TITLE
docs(quickstart): add EUI uncalibrated and pre-release pip caveats (closes #767, partial #766)

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -2,6 +2,21 @@
 
 Get started with Fluxion in minutes.
 
+> **⚠️ Pre-release notes**
+>
+> - The `pip install fluxion` recipe below is **aspirational**; the package
+>   is not yet on PyPI ([#766](https://github.com/anchapin/fluxion/issues/766)).
+>   Until then, install from source as shown in
+>   [From source](#from-source).
+> - The `eui` returned by `model.simulate(...)` in the examples below is
+>   currently a **raw cumulative temperature-departure metric**, not a
+>   calibrated `kWh/m²/year` value. The label `kWh/m²/year` in the
+>   examples is a placeholder that will become accurate after the
+>   ASHRAE 140 physics calibration work in
+>   [#749-G2](https://github.com/anchapin/fluxion/issues/749) lands. Do
+>   not benchmark the raw metric against ASHRAE 90.1 / RESNET HERS until
+>   then ([#767](https://github.com/anchapin/fluxion/issues/767)).
+
 ## Installation
 
 ### From PyPI (recommended)
@@ -35,8 +50,11 @@ from fluxion import Model
 model = Model("config.json")
 
 # Run physics-based simulation
+# NOTE: `eui` is currently a raw cumulative temperature-departure
+# metric, not calibrated kWh/m²/year. See the pre-release notes at the
+# top of this document and issue #767 for context.
 eui = model.simulate(years=1, use_surrogates=False)
-print(f"EUI: {eui:.2f} kWh/m²/year")
+print(f"EUI (uncalibrated, see #767): {eui:.2f}")
 ```
 
 ### 2. Using Surrogates
@@ -50,8 +68,9 @@ model = Model("config.json")
 model.load_surrogate("loads_predictor.onnx")
 
 # Run with AI surrogates (~100x faster)
+# Same uncalibrated-metric caveat applies (see #767).
 eui = model.simulate(years=1, use_surrogates=True)
-print(f"EUI: {eui:.2f} kWh/m²/year")
+print(f"EUI (uncalibrated, see #767): {eui:.2f}")
 ```
 
 ### 3. Population Optimization


### PR DESCRIPTION
> *This was generated by AI during triage.*

## Summary

`docs/QUICKSTART.md` had two long-standing accuracy gaps that this PR closes documentary-style:

1. The `pip install fluxion` recipe is **aspirational** — the package is not yet on PyPI ([#766](https://github.com/anchapin/fluxion/issues/766)).
2. The `eui` returned by `model.simulate(...)` is currently a **raw cumulative temperature-departure metric**, not calibrated `kWh/m²/year` ([#767](https://github.com/anchapin/fluxion/issues/767)). The label in the examples was misleading enough that a building scientist reading the file could compare it to ASHRAE 90.1 benchmarks and reach wrong conclusions.

Prior PR [#757](https://github.com/anchapin/fluxion/pull/757) claimed to add this disclaimer but `git show docs/QUICKSTART.md` shows the disclaimer never landed in this file — most likely the change was applied to a different draft and lost. This PR is the real fix.

## What changed

A 15-line call-out box at the top of `docs/QUICKSTART.md` linking to #766 / #767 / #749-G2, and inline `# NOTE` annotations on each of the two `model.simulate()` examples whose `print(f"EUI: {eui:.2f} kWh/m²/year")` labels become `print(f"EUI (uncalibrated, see #767): {eui:.2f}")`.

Pure documentation change. No source files touched.

## Verification

- `cargo build --lib` not affected (no source edits).
- Library, FF guards, validation profile tests unchanged.

## Closes / refs

- Closes #767.
- Partial #766 (PyPI install path remains aspirational; this PR only documents the gap, does not fix it — full fix needs a publishing pipeline).
- References #757 (the prior PR that intended this fix).
- References #749-G2 (the long-term work that makes `kWh/m²/year` accurate).

## Summary by Sourcery

Document pre-release caveats in the QUICKSTART guide regarding installation and EUI interpretation.

Documentation:
- Add a pre-release warning box explaining that the PyPI installation command is aspirational and that the package must currently be installed from source.
- Clarify that `eui` values from `model.simulate(...)` are an uncalibrated temperature-departure metric rather than kWh/m²/year and should not be benchmarked against standards yet.
- Update example code in the QUICKSTART guide to relabel printed EUI output as uncalibrated and reference the relevant tracking issue.