### PR TITLE
fix: resolve pre-existing CI failures (#853)

### DIFF
--- a/.agents/results/result-debug.md
+++ b/.agents/results/result-debug.md
@@ -1,71 +1,42 @@
-# Debug Result: Case 600 Reference Comparison — Root Cause Analysis
+# Debug Result: Issue #853 - Pre-existing CI Failures
 
-## Status: COMPLETE
+## Status: FIXED
 
 ## Summary
-
-Identified root cause of 600-series low-mass heating overestimation (~2.6x reference). The 5R1C sensitivity-based HVAC superposition formula produces an effective conductance of 672 W/K instead of the correct ~108 W/K for Case 600, causing HVAC power to be overestimated by 6.1x. The free-floating temperature partially compensates, yielding the observed 2.6x heating excess.
-
-**Root cause confirmed: H1 (Sensitivity miscalibration for low-mass constructions).**
+Fixed 3 of 4 pre-existing CI failure categories identified in issue #853. The 4th category (format trait errors) was already fixed on main.
 
 ## Files Changed
-
-| File | Action |
+| File | Change |
 |------|--------|
-| `.planning/debug/case600-comparison-report.md` | Created — Fluxion vs ASHRAE 140 comparison |
-| `.planning/debug/case600-root-cause.md` | Created — Detailed root cause with source locations and fix direction |
-| `.planning/debug/case600-components.csv` | Created — Component energy breakdown from Fluxion |
+| `src/validation/analyzer.rs` | Fixed `test_quality_metrics_mae_calculation` test data: single result with `(6.5, 5.5, 7.5)` replaced with two results `(22.5, 10.0, 20.0)` and `(13.5, 10.0, 20.0)` to match documented MAE=30% expectations |
+| `benches/orchestration_decisions/tdqs.rs` | Added `#![allow(dead_code)]` to suppress 28 dead-code warnings for benchmark utility types |
+| `benches/orchestration_decisions/decision_recorder.rs` | Added `#![allow(dead_code)]` to suppress dead-code warnings for benchmark recording types |
 
-No source code changes were made (diagnosis only).
+## Root Cause Analysis
+
+### 1. `test_quality_metrics_mae_calculation` (analyzer.rs)
+- **Root cause**: Test data (`value=6.5, ref_min=5.5, ref_max=7.5`) produced MAE=0.0% (value equals midpoint), but assertions expected MAE=30.0% and max_deviation=50.0%. The test comments documented different data than what was in the code.
+- **Fix**: Updated test data to use two metrics matching the documented scenario: `(22.5, [10,20])` gives 50% error (Fail), `(13.5, [10,20])` gives 10% error (Warning). MAE=(50+10)/2=30%.
+
+### 2. Format trait errors (`{:.3f}` / `{:8.3f}`)
+- **Status**: Already fixed on main (no occurrences found in grep).
+- **No action needed.**
+
+### 3. Dead-code warnings in benches
+- **Root cause**: `tdqs.rs` and `decision_recorder.rs` define types for future orchestration decision integration. These are benchmark utilities not yet consumed.
+- **Fix**: Added `#![allow(dead_code)]` at module level for both files.
+
+### 4. CI matrix test failures
+- **Expected resolution**: Format trait errors (item 2) were the likely cause of feature-gated compilation failures. These are already fixed.
 
 ## Acceptance Criteria Checklist
+- [x] `test_quality_metrics_mae_calculation` passes
+- [x] All 664 validation tests pass
+- [x] `cargo clippy --all-targets` reports 0 warnings
+- [x] Format trait errors already fixed on main
+- [x] Dead-code warnings in benches suppressed
+- [x] Minimal changes only - no refactoring
 
-- [x] `.planning/debug/case600-components.csv` exists with energy breakdown
-- [x] ASHRAE 140 reference ranges documented (from `data/ashrae140_reference.json`)
-- [x] `.planning/debug/case600-comparison-report.md` exists with comparison tables
-- [x] `.planning/debug/case600-root-cause.md` exists with identified divergent term
-- [x] Root cause maps to H1 (sensitivity miscalibration)
-- [x] Specific source code lines and formula discrepancy documented
-
-## Key Findings
-
-### Metric Comparison
-
-| Metric | Fluxion | ASHRAE 140 Ref (mean) | Ratio |
-|--------|---------|----------------------|-------|
-| Heating | 11.104 MWh | 4.213 MWh | **2.64x** |
-| Cooling | 4.394 MWh | 5.856 MWh | **0.75x** |
-| 600FF Max Temp | 50.3°C | 64.6°C | 0.78x |
-| 600FF Min Temp | -8.25°C | -11.8°C | 0.70x |
-
-### Root Cause
-
-The sensitivity formula at `thermal_model_solvers.rs:152-153`:
-```rust
-self.0.derived_sensitivity = self.0.derived_term_rest_1 / self.0.derived_den;
-```
-
-For low-mass Case 600:
-- `h_tr_ms = 1092 W/K` (very high — mass is tightly coupled to air)
-- `h_tr_is = 1251 W/K`
-- `sensitivity = 0.001489 K/W` → `1/sensitivity = 672 W/K`
-- Correct value should be ~`1/108 = 0.009266 K/W`
-
-The superposition `t_i_actual = t_i_free + sens × phi_HVAC` assumes thermal mass temperature is unchanged by HVAC. For low-mass buildings with high h_tr_ms, this assumption is invalid because HVAC heat flows easily to the mass node, changing its temperature.
-
-### Source Code Locations
-
-1. **`src/sim/thermal_model_solvers.rs:152-153`** — Sensitivity calculation
-2. **`src/sim/thermal_model_physics.rs:43-76`** — HVAC power using `(deficit / sensitivity)`
-3. **`src/sim/thermal_model_physics.rs:1203-1223`** — Temperature superposition
-4. **`src/sim/thermal_model_core.rs:945-994`** — h_tr_ms = 9.1 × A_m (correct per ISO 13790)
-
-### Recommended Fix
-
-Use the existing `hvac_demand_from_ideal_loads()` (thermodynamic `mass_flow × cp × delta_T` formula) for all cases instead of the sensitivity-based formula. This path already exists in the code but is only activated when `ideal_loads_system` is initialized (currently only for 900-series).
-
-## Out-of-Scope Findings
-
-- EnergyPlus reference JSON (`600_reference.json`) has unrealistic annual totals (15M+ kWh) — likely corrupted or in Joules, not kWh
-- Energy balance residual of -1.33 MWh suggests additional accounting issues
-- `validate-case 600` CLI command doesn't work (600-series not in case range)
+## Out of Scope
+- `thermal_mass_energy_accounting.rs` warnings inside `#[cfg(feature = "pr821-diag")]` blocks (feature-gated, not in default CI)
+- CI matrix test failures may need separate verification after this PR merges

--- a/benches/orchestration_decisions/decision_recorder.rs
+++ b/benches/orchestration_decisions/decision_recorder.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 //! Decision recording middleware.
 //!
 //! Wraps each orchestration decision call site to:

--- a/benches/orchestration_decisions/tdqs.rs
+++ b/benches/orchestration_decisions/tdqs.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 //! Temporal Decision Quality Score (TDQS) — Formal Implementation
 //!
 //! # Formula

--- a/src/validation/analyzer.rs
+++ b/src/validation/analyzer.rs
@@ -508,15 +508,13 @@ mod tests {
     #[test]
     fn test_quality_metrics_mae_calculation() {
         // Use ValidationResult::new() to compute status and percent_error automatically
+        // Two metrics for case 600: one fails (22.5 outside tolerance), one warns (13.5 inside range but >=10% error)
         let report = BenchmarkReport {
             report_header: None,
-            results: vec![ValidationResult::new(
-                "600",
-                MetricType::AnnualHeating,
-                6.5,
-                5.5,
-                7.5,
-            )],
+            results: vec![
+                ValidationResult::new("600", MetricType::AnnualHeating, 22.5, 10.0, 20.0),
+                ValidationResult::new("600", MetricType::AnnualCooling, 13.5, 10.0, 20.0),
+            ],
             benchmark_data: HashMap::new(),
             interpretations: HashMap::new(),
             start_time: None,
@@ -529,10 +527,10 @@ mod tests {
 
         let metrics = QualityMetrics::from_benchmark_report(&report);
 
-        // MAE should be (|50%| + |10%|) / 2 = 30%
-        // Note: The exact values depend on ref_min/ref_max. We used [10,20] giving midpoint 15.
-        // For 22.5: error = (22.5-15)/15 *100 = 50%
-        // For 13.5: error = (13.5-15)/15 *100 = -10%
+        // MAE = (|50%| + |10%|) / 2 = 30%
+        // ref [10,20] → midpoint=15
+        // 22.5: error = |22.5-15|/15 * 100 = 50% → outside tolerance [9.5,21] → Fail
+        // 13.5: error = |13.5-15|/15 * 100 = 10% → inside ref range but >=10% error → Warning
         assert!((metrics.mae - 30.0).abs() < 0.01);
         assert_eq!(metrics.max_deviation, 50.0);
         // Case 600 fails (one metric fails, one warns) => case fails overall


### PR DESCRIPTION
## Summary

Fixes 3 of 4 pre-existing CI failure categories from #853. The 4th (format trait errors) was already fixed on main.

## Changes

### 1. `test_quality_metrics_mae_calculation` test fix
- **Root cause**: Test data `(value=6.5, ref_min=5.5, ref_max=7.5)` produced MAE=0.0% since value equals the midpoint, but assertions expected MAE=30.0%
- **Fix**: Updated to two metrics matching documented scenario:
  - `(22.5, [10,20])` → 50% error → Fail
  - `(13.5, [10,20])` → 10% error → Warning
  - MAE = (50+10)/2 = 30.0% ✓

### 2. Dead-code warnings in benches
- **Root cause**: `tdqs.rs` and `decision_recorder.rs` define types for future orchestration integration, not yet consumed
- **Fix**: Added `#![allow(dead_code)]` at module level

### 3. Format trait errors (`{:.3f}`)
- Already fixed on main — no occurrences found

## Verification
- ✅ `test_quality_metrics_mae_calculation` passes
- ✅ All 664 validation tests pass
- ✅ `cargo clippy --all-targets` → 0 warnings

Fixes #853