### PR TITLE
feat: wire sol-air temperatures into multi-node HVAC runner (#863)

### DIFF
--- a/src/physics/multi_node_solver.rs
+++ b/src/physics/multi_node_solver.rs
@@ -36,6 +36,34 @@
 
 use crate::sim::multi_node_thermal::{MultiNodeThermalMass, ThermalMassNode};
 
+/// Per-surface exterior boundary temperatures for the multi-node solver.
+///
+/// Each envelope node (wall, roof, floor) can have its own exterior boundary
+/// temperature, computed from sol-air temperature calculations.
+///
+/// - Wall/Roof: sol-air temperature (accounts for solar irradiance, longwave radiation)
+/// - Floor: ground temperature (ground-coupled)
+#[derive(Debug, Clone)]
+pub struct SurfaceExteriorTemperatures {
+    /// Sol-air temperature for the wall exterior boundary (°C)
+    pub t_ext_wall: f64,
+    /// Sol-air temperature for the roof exterior boundary (°C)
+    pub t_ext_roof: f64,
+    /// Ground temperature for the floor exterior boundary (°C)
+    pub t_ext_floor: f64,
+}
+
+impl SurfaceExteriorTemperatures {
+    /// Create with a uniform exterior temperature (legacy fallback).
+    pub fn uniform(t: f64) -> Self {
+        Self {
+            t_ext_wall: t,
+            t_ext_roof: t,
+            t_ext_floor: t,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct MultiNodeSolver {
     pub mass: MultiNodeThermalMass,
@@ -43,6 +71,10 @@ pub struct MultiNodeSolver {
     pub zone_temperature: f64,
     pub surface_temperature: f64,
     pub exterior_temperature: f64,
+    /// Per-surface exterior boundary temperatures (Issue #863).
+    /// When set, each envelope node uses its respective boundary temp
+    /// instead of the uniform `exterior_temperature`.
+    pub exterior_temperatures: Option<SurfaceExteriorTemperatures>,
     pub timestep_seconds: f64,
 }
 
@@ -60,6 +92,7 @@ impl MultiNodeSolver {
             zone_temperature: 20.0,
             surface_temperature: 20.0,
             exterior_temperature: 10.0,
+            exterior_temperatures: None,
             timestep_seconds: 3600.0,
         }
     }
@@ -81,6 +114,23 @@ impl MultiNodeSolver {
         let t_ext = self.exterior_temperature;
         let h_is = self.h_tr_is;
 
+        // Per-surface exterior temperatures (Issue #863).
+        // When available, each envelope node uses its own boundary temp
+        // (sol-air for wall/roof, ground for floor) instead of the uniform
+        // `exterior_temperature` average.
+        let t_ext_wall = self
+            .exterior_temperatures
+            .as_ref()
+            .map_or(t_ext, |et| et.t_ext_wall);
+        let t_ext_roof = self
+            .exterior_temperatures
+            .as_ref()
+            .map_or(t_ext, |et| et.t_ext_roof);
+        let t_ext_floor = self
+            .exterior_temperatures
+            .as_ref()
+            .map_or(t_ext, |et| et.t_ext_floor);
+
         let m = &mut self.mass;
 
         // Update wall node (envelope mass)
@@ -92,7 +142,7 @@ impl MultiNodeSolver {
             // Backward Euler: (Cm/dt + h_em + h_ms) * T_new = Cm/dt * T_old + h_em * T_ext + h_ms * T_s
             let denom = node.capacitance / dt + h_em + h_ms;
             let numer = node.capacitance / dt * node.temperature
-                + h_em * t_ext
+                + h_em * t_ext_wall
                 + h_ms * self.surface_temperature;
             node.temperature = numer / denom;
         }
@@ -105,7 +155,7 @@ impl MultiNodeSolver {
 
             let denom = node.capacitance / dt + h_em + h_ms;
             let numer = node.capacitance / dt * node.temperature
-                + h_em * t_ext
+                + h_em * t_ext_roof
                 + h_ms * self.surface_temperature;
             node.temperature = numer / denom;
         }
@@ -118,7 +168,7 @@ impl MultiNodeSolver {
 
             let denom = node.capacitance / dt + h_em + h_ms;
             let numer = node.capacitance / dt * node.temperature
-                + h_em * t_ext
+                + h_em * t_ext_floor
                 + h_ms * self.surface_temperature;
             node.temperature = numer / denom;
         }
@@ -172,6 +222,16 @@ impl MultiNodeSolver {
 
     pub fn set_exterior_temperature(&mut self, t: f64) {
         self.exterior_temperature = t;
+    }
+
+    /// Set per-surface exterior boundary temperatures (Issue #863).
+    ///
+    /// Stores per-surface sol-air/ground temperatures and updates the
+    /// legacy `exterior_temperature` field to the average for backward
+    /// compatibility with code that reads it directly.
+    pub fn set_surface_exterior_temperatures(&mut self, temps: SurfaceExteriorTemperatures) {
+        self.exterior_temperature = (temps.t_ext_wall + temps.t_ext_roof + temps.t_ext_floor) / 3.0;
+        self.exterior_temperatures = Some(temps);
     }
 
     pub fn set_wall_conductances(&mut self, h_tr_em: f64, h_tr_ms: f64) {

--- a/src/sim/thermal_model_physics.rs
+++ b/src/sim/thermal_model_physics.rs
@@ -8,6 +8,7 @@ use log::{error, info, warn};
 
 use crate::ai::surrogate::SurrogateManager;
 use crate::physics::cta::{ContinuousTensor, VectorField};
+use crate::physics::multi_node_solver::SurfaceExteriorTemperatures;
 use crate::sim::adaptive_timestep::TimestepMode;
 use crate::sim::equipment::Equipment;
 use crate::sim::hvac::{HVACMode as EquipmentHVACMode, VariableCapacityEquipment};
@@ -15,12 +16,15 @@ use crate::sim::interzone::{calculate_stack_effect_ach, calculate_ventilation_he
 use crate::sim::lighting::LightingSchedule;
 use crate::sim::occupancy::OccupancyProfile;
 use crate::sim::profiles;
+use crate::sim::sky_radiation::SolAirTemperature;
+use crate::sim::solar::{calculate_solar_position, calculate_surface_irradiance};
 use crate::sim::thermal_integration::{
     backward_euler_update, backward_euler_update_2cond, crank_nicolson_update,
     crank_nicolson_update_3cond, select_integration_method, ThermalIntegrationMethod,
 };
 use crate::sim::thermal_model_core::{get_daily_cycle, ThermalModel};
 use crate::sim::timestep_solver::StepParameters;
+use crate::validation::ashrae_140_cases::Orientation;
 use crate::weather::HourlyWeatherData;
 
 impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>> ThermalModel<T> {
@@ -2410,7 +2414,78 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
 
             solver.set_zone_temperature(t_zone);
             solver.set_surface_temperature(t_surface);
-            solver.set_exterior_temperature(t_ext);
+
+            // Issue #863: Compute per-surface sol-air temperatures from weather data.
+            // Each envelope node (wall, roof, floor) receives its own exterior boundary
+            // temperature based on solar irradiance and longwave radiation exchange,
+            // rather than using a uniform outdoor air temperature for all surfaces.
+            let surface_ext_temps = if let Some(ref weather) = self.0.weather {
+                // Derive date/time from timestep for solar position calculation
+                let hour_of_year = timestep % 8760;
+                let month_days: [usize; 12] =
+                    [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334];
+                let day_of_year = hour_of_year / 24;
+                let hour = (hour_of_year % 24) as f64 + 0.5;
+                let month = month_days
+                    .iter()
+                    .position(|&d| d > day_of_year)
+                    .unwrap_or(12)
+                    .saturating_sub(1)
+                    .max(0) as u32;
+                let day =
+                    (day_of_year - month_days.get(month as usize).copied().unwrap_or(0)) as u32 + 1;
+
+                let sun_pos = calculate_solar_position(
+                    self.0.latitude_deg,
+                    self.0.longitude_deg,
+                    2024, // Reference year for solar position (leap year)
+                    month,
+                    day.min(28), // Clamp to avoid invalid day-of-month
+                    hour,
+                );
+
+                // Compute irradiance for wall (south-facing, vertical) and roof (horizontal)
+                let ground_reflectance = 0.2; // Standard ground reflectance
+                let wall_irr = calculate_surface_irradiance(
+                    &sun_pos,
+                    weather.dni,
+                    weather.dhi,
+                    Some(weather.ghi),
+                    Orientation::South,
+                    ground_reflectance,
+                    day_of_year + 1,
+                );
+                let roof_irr = calculate_surface_irradiance(
+                    &sun_pos,
+                    weather.dni,
+                    weather.dhi,
+                    Some(weather.ghi),
+                    Orientation::Up,
+                    ground_reflectance,
+                    day_of_year + 1,
+                );
+
+                // Compute sol-air temperatures using ASHRAE 140 default surface properties
+                let sol_air = SolAirTemperature::ashrae_140_default();
+                SurfaceExteriorTemperatures {
+                    t_ext_wall: sol_air.for_wall(
+                        outdoor_temp,
+                        wall_irr.total_wm2,
+                        wall_irr.ground_reflected_wm2,
+                    ),
+                    t_ext_roof: sol_air.for_roof(outdoor_temp, roof_irr.total_wm2, sky_temp),
+                    t_ext_floor: t_g,
+                }
+            } else {
+                // Fallback: use uniform exterior temperature when no weather data available
+                SurfaceExteriorTemperatures {
+                    t_ext_wall: t_ext,
+                    t_ext_roof: t_ext,
+                    t_ext_floor: t_g,
+                }
+            };
+
+            solver.set_surface_exterior_temperatures(surface_ext_temps);
 
             // Advance solver by one timestep
             solver.step(dt);


### PR DESCRIPTION
## Summary

Closes #863

Replaces uniform outdoor_temp as the exterior boundary temperature for all multi-node solver envelope nodes (wall, roof, floor) with per-surface sol-air temperatures computed from weather data.

## Changes

### src/physics/multi_node_solver.rs
- Add SurfaceExteriorTemperatures struct for per-surface exterior boundary temps
- Add set_surface_exterior_temperatures() method
- Modify step_backward_euler() to use per-surface boundary temperatures

### src/sim/thermal_model_physics.rs
- Compute solar position, wall/roof irradiance, and sol-air temperatures
- Pass SurfaceExteriorTemperatures to solver instead of uniform outdoor_temp
- Fallback to uniform outdoor_temp when no weather data available

## Test Results
- cargo check: clean
- cargo test --lib: 2430 passed, 1 pre-existing failure (unrelated)
- All 11 multi-node solver tests pass
- All 50 thermal model tests pass