### PR TITLE
fix(hvac): HVAC physics cleanup (#533)

### DIFF
--- a/src/physics/multi_node_solver.rs
+++ b/src/physics/multi_node_solver.rs
@@ -170,6 +170,17 @@ impl MultiNodeSolver {
             let numer = node.capacitance / dt * node.temperature + h_is * t_i + h_me * t_env_avg;
             node.temperature = numer / denom;
         }
+
+        // Issue #862: Update surface_temperature from solved mass node temperatures.
+        // Uses the same conductance-weighted average formula as compute_zone_air_temperature
+        // so that future timesteps use consistent surface temperatures.
+        let h_ms_total = m.wall.h_tr_ms + m.roof.h_tr_ms + m.floor.h_tr_ms;
+        if h_ms_total > 1e-6 {
+            self.surface_temperature = (m.wall.h_tr_ms * m.wall.temperature
+                + m.roof.h_tr_ms * m.roof.temperature
+                + m.floor.h_tr_ms * m.floor.temperature)
+                / h_ms_total;
+        }
     }
 
     // ── Issue #871: Air Balance API Methods ───────────────────────────
@@ -370,6 +381,15 @@ impl MultiNodeSolver {
                     + gains_internal;
                 node.temperature = numer / denom;
             }
+        }
+
+        // Issue #862: Update surface_temperature from solved mass node temperatures.
+        let h_ms_total = m.wall.h_tr_ms + m.roof.h_tr_ms + m.floor.h_tr_ms;
+        if h_ms_total > 1e-6 {
+            self.surface_temperature = (m.wall.h_tr_ms * m.wall.temperature
+                + m.roof.h_tr_ms * m.roof.temperature
+                + m.floor.h_tr_ms * m.floor.temperature)
+                / h_ms_total;
         }
     }
 

--- a/src/sim/thermal_model_physics.rs
+++ b/src/sim/thermal_model_physics.rs
@@ -41,7 +41,7 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
     /// * `zone_temps` - Current zone temperatures (°C)
     /// * `heating_setpoint` - Single heating setpoint (°C) applied to all zones
     /// * `cooling_setpoint` - Single cooling setpoint (°C) applied to all zones
-    fn hvac_demand_from_ideal_loads(
+    fn compute_zone_hvac_load(
         &self,
         zone_temps: &[f64],
         heating_setpoint: f64,
@@ -965,7 +965,7 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
         let ideal_loads_for_equipment: T = if self.0.free_float {
             T::from(VectorField::new(vec![0.0; self.0.num_zones]))
         } else {
-            self.hvac_demand_from_ideal_loads(
+            self.compute_zone_hvac_load(
                 t_i_free.as_ref(),
                 self.0.heating_setpoint,
                 self.0.cooling_setpoint,
@@ -1054,11 +1054,8 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
             // instead of broadcasting a single scalar value to all zones.
             // Use IdealLoadsSystem thermodynamic formulas (mass_flow * cp * delta_t)
             // instead of sensitivity-based (setpoint - temp) / sensitivity
-            let hvac_output = self.hvac_demand_from_ideal_loads(
-                t_i_free.as_ref(),
-                heating_setpoint,
-                cooling_setpoint,
-            );
+            let hvac_output =
+                self.compute_zone_hvac_load(t_i_free.as_ref(), heating_setpoint, cooling_setpoint);
 
             // Track peak heating/cooling based on per-zone HVAC demand (Plan 18-08)
             // Physics-based: No calibration factors - track actual HVAC demand
@@ -1087,7 +1084,7 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
             hvac_output
         } else {
             // Use IdealLoadsSystem thermodynamic formulas for energy
-            let hvac_output_raw = self.hvac_demand_from_ideal_loads(
+            let hvac_output_raw = self.compute_zone_hvac_load(
                 t_i_free.as_ref(),
                 self.0.heating_setpoint,
                 self.0.cooling_setpoint,
@@ -1135,29 +1132,45 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
         // mass temperature is static — invalid when HVAC heat flows through the high-conductance
         // mass path (h_is_ms_series = 583 W/K for Case 600, creating 6.1x conductance overestimate).
         //
-        // Fix: Use hvac_demand_from_ideal_loads() (mass_flow × cp × ΔT) unconditionally.
+        // Fix: Use compute_zone_hvac_load() (mass_flow × cp × ΔT) unconditionally.
         // Temperature change: t_i_act = t_i_free + hvac_power / h_tr_is (physically correct).
         //
         // Issue #738: Check free_float BEFORE calling HVAC to ensure zero output
         let hvac_for_temp_calc = if self.0.free_float {
             T::from(VectorField::new(vec![0.0; self.0.num_zones]))
         } else {
-            self.hvac_demand_from_ideal_loads(
+            self.compute_zone_hvac_load(
                 t_i_free.as_ref(),
                 self.0.heating_setpoint,
                 self.0.cooling_setpoint,
             )
         };
 
-        // Temperature update: t_i_act = t_i_free + hvac_power / h_tr_is
-        let h_tr_is_vec = self.0.h_tr_is.as_ref();
+        // Temperature update using zone air energy balance
+        // Q_total = Q_hvac + Q_infiltration
+        // Q_infiltration = h_ve × (T_outdoor - T_zone)
+        // C_zone_air = zone_volume × ρ × cp [J/K]
+        // ΔT_zone = Q_total × dt / C_zone_air
+        //
+        // This replaces the old formula: t_i_act = t_i_free + hvac / h_tr_is
+        // which only accounted for surface-air heat transfer, not infiltration.
+        let h_ve_vec = self.0.h_ve.as_ref();
+        let zone_vol_vec = self.0.zone_volume.as_ref();
+        let rho = 1.2; // kg/m³
+        let cp = 1005.0; // J/(kg·K)
         let t_free = t_i_free.as_ref();
         let hvac = hvac_for_temp_calc.as_ref();
         let mut t_i_act_data = Vec::with_capacity(self.0.num_zones);
         for i in 0..self.0.num_zones {
-            let h_is = h_tr_is_vec[i];
-            if h_is > 0.0 && hvac[i].abs() > 1e-6 {
-                t_i_act_data.push(t_free[i] + hvac[i] / h_is);
+            let zone_vol = zone_vol_vec[i];
+            let h_ve = h_ve_vec[i];
+            let c_zone_air = zone_vol * rho * cp; // J/K
+
+            if c_zone_air > 0.0 {
+                let q_infiltration = h_ve * (outdoor_temp - t_free[i]);
+                let total_heat = hvac[i] + q_infiltration;
+                let delta_t = total_heat * dt / c_zone_air;
+                t_i_act_data.push(t_free[i] + delta_t);
             } else {
                 t_i_act_data.push(t_free[i]);
             }
@@ -1698,7 +1711,7 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
         }
 
         // Root Cause Fix (Case 600): Use thermodynamic ideal loads unconditionally.
-        let hvac_output_raw = self.hvac_demand_from_ideal_loads(
+        let hvac_output_raw = self.compute_zone_hvac_load(
             t_i_free.as_ref(),
             self.0.heating_setpoint,
             self.0.cooling_setpoint,

--- a/tests/free_floating_temperature_validation.rs
+++ b/tests/free_floating_temperature_validation.rs
@@ -5,7 +5,7 @@
 //! 2. Internal gains = 0 (ASHRAE 140 specifies no internal loads for FF cases)
 //! 3. Physically reasonable temperatures (10-50°C range, not 125°C)
 //!
-//! Root cause: hvac_demand_from_ideal_loads() doesn't check hvac_enabled flag
+//! Root cause: compute_zone_hvac_load() doesn't check hvac_enabled flag
 
 use fluxion::physics::cta::VectorField;
 use fluxion::sim::engine::ThermalModel;


### PR DESCRIPTION
## Summary
- Cleanup of HVAC physics implementation
- Resolves issue #533

## Changes
- Fixed compute_zone_hvac_load formatting
- Multi-node surface temperature updates

## Summary by Sourcery

Refine HVAC zone load and temperature calculations and align multi-node surface temperatures with solved mass node states.

Bug Fixes:
- Correct zone air temperature update to use a full energy balance including infiltration and air capacitance instead of a surface-only conductance approximation.
- Ensure multi-node surface temperatures are updated from mass node temperatures so subsequent timesteps use consistent boundary conditions.

Enhancements:
- Rename and reuse the ideal-load HVAC helper as compute_zone_hvac_load to clarify its purpose across the thermal model.