### PR TITLE
⚡ Bolt: [performance improvement] Accumulate HVAC energy and track peak power without cloning.

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,6 @@
 ## 2026-05-19 - Avoided intermediate Vector allocations in hvac_demand_from_ideal_loads (Take 2)
 **Learning:** Slices of uniform values can be created from single variables as slices rather than by allocating memory dynamically.
 **Action:** Replaced `vec![val; N]` with `&[val]` when the loop logic passes only single element slices down.
+## 2026-05-23 - Optimized HVAC Power Accumulation
+**Learning:** Replaced the allocation and clone from `.clone()` by keeping the accumulation of peak power inside the summation block without allocating a new buffer (`let hvac_cloned = hvac_output.clone(); let hvac_power_watts = hvac_cloned.as_ref().iter()...`).
+**Action:** When a `.clone()` operation produces an iterator directly consumed by `.sum()`, evaluate if it can be combined with another iteration loop on the same reference or avoided completely by aggregating manually inside an existing block of similar iterators.

--- a/src/sim/thermal_model_physics.rs
+++ b/src/sim/thermal_model_physics.rs
@@ -19,9 +19,9 @@ use crate::sim::profiles;
 use crate::sim::sky_radiation::SolAirTemperature;
 use crate::sim::solar::{calculate_solar_position, calculate_surface_irradiance};
 use crate::sim::thermal_integration::{
-    backward_euler_update, backward_euler_update_2cond, backward_euler_update_2cond_h_tr3,
-    crank_nicolson_iso13790, crank_nicolson_update, crank_nicolson_update_3cond,
-    select_integration_method, ThermalIntegrationMethod,
+    backward_euler_update_2cond, backward_euler_update_2cond_h_tr3, crank_nicolson_iso13790,
+    crank_nicolson_update, crank_nicolson_update_3cond, select_integration_method,
+    ThermalIntegrationMethod,
 };
 use crate::sim::thermal_model_core::{get_daily_cycle, ThermalModel};
 use crate::sim::timestep_solver::StepParameters;
@@ -2820,15 +2820,9 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
 
         // Calculate and return total HVAC output (energy)
         let hvac_output = hvac_for_temp_calc;
-        let hvac_cloned = hvac_output.clone();
-        let hvac_power_watts = hvac_cloned
-            .as_ref()
-            .iter()
-            .zip(self.0.hvac_enabled.as_ref().iter())
-            .map(|(output, &enabled)| if enabled > 0.5 { *output } else { 0.0 })
-            .sum::<f64>();
 
-        // Accumulate annual energy and track peak power
+        // Accumulate annual energy and track peak power without cloning
+        let mut hvac_power_watts = 0.0;
         {
             let mut heating_sum = 0.0_f64;
             let mut cooling_sum = 0.0_f64;
@@ -2838,6 +2832,8 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
                 .zip(self.0.hvac_enabled.as_ref().iter())
             {
                 let val = if enabled > 0.5 { output } else { 0.0 };
+                hvac_power_watts += val;
+
                 if val > 0.0 {
                     heating_sum += val;
                 } else if val < 0.0 {


### PR DESCRIPTION
💡 What: Modified `hvac_power_watts` computation in `src/sim/thermal_model_physics.rs` to aggregate the total output inside the existing loop computing `heating_sum` and `cooling_sum`.
🎯 Why: Previously, `hvac_output` was `.clone()`'d into a new vector, iterated, zipped with `hvac_enabled`, evaluated for a conditional check, and summed into a scalar. Because an identical loop immediately followed to calculate heating and cooling energy, this incurred redundant cloning, memory allocation (on an already hot path), and a duplicated iteration.
📊 Impact: Saves an unnecessary heap vector allocation (`.clone()`) and an entire `O(N)` mapping and folding iteration inside the `step_physics` calculation, executed millions of times.
🔬 Measurement: Verify via `cargo bench --bench engine_bench` (though `solve_timesteps_1year_10zones` already takes minimal time, removing O(N) allocation per-step adds up significantly across long runs). Validate functionally via `cargo test --lib`.

---
*PR created automatically by Jules for task [10156963946990369145](https://jules.google.com/task/10156963946990369145) started by @anchapin*

## Summary by Sourcery

Optimize HVAC power accumulation in the thermal physics simulation to avoid redundant cloning and iteration.

Enhancements:
- Accumulate total HVAC power within the existing heating/cooling aggregation loop instead of using a cloned buffer and separate summation.
- Update internal Bolt notes to document the HVAC power accumulation optimization and the guideline to avoid unnecessary clones before reductions.