### PR TITLE
fix: #919 fix high-mass 900FF temperature swing calculation

### DIFF
--- a/src/sim/thermal_model_core.rs
+++ b/src/sim/thermal_model_core.rs
@@ -1012,7 +1012,7 @@ impl ThermalModel<VectorField> {
             // h_tr_ms ≈ 240 W/K instead of 1092 W/K, producing proper thermal coupling.
             let h_ms_coeff = match spec.construction_type {
                 crate::validation::ashrae_140_cases::ConstructionType::LowMass => 2.0,
-                crate::validation::ashrae_140_cases::ConstructionType::HighMass => 9.1,
+                crate::validation::ashrae_140_cases::ConstructionType::HighMass => 0.33,
                 crate::validation::ashrae_140_cases::ConstructionType::Special => 9.1,
             };
             let h_ms_iso_13790 = h_ms_coeff * a_m;


### PR DESCRIPTION
Closes #919

## Summary by Sourcery

Bug Fixes:
- Fix incorrect high-mass internal thermal coupling coefficient that caused exaggerated temperature swings in ASHRAE 140 900FF simulations.