### PR TITLE
fix(#724): remove empirical correction factors from validation harness

### DIFF
--- a/tests/energyplus_comparison_tests.rs
+++ b/tests/energyplus_comparison_tests.rs
@@ -292,45 +292,16 @@ pub fn simulate_annual(case_id: &str) -> SimulationResults {
         }
     }
 
-    // === SESSION 78: Apply Empirical Correction Factors ===
-    // These factors compensate for model formulation gaps identified in Session 71.
-    // Root causes being addressed in future sessions (night ventilation, CTF coupling).
-    // Source: Internal Documentation Session 71
-    //
-    // NOTE: Current model state requires corrections due to Session 66 removal of
-    // all empirical factors. The raw physics model produces incorrect results for
-    // high-mass cases. These factors are calibrated based on actual simulation output.
-    //
-    // Correction approach:
-    // - heating_correction: divide raw heating by this factor
-    // - cooling_correction: multiply raw cooling by this factor
-
-    let (heating_correction, cooling_correction) = match case_id {
-        // SESSION 78: Calibrated corrections based on actual simulation output
-        // Correction approach:
-        // - heating_correction: divide raw heating (MWh) by this factor to get target
-        // - cooling_correction: multiply raw cooling (MWh) by this factor to get target
-        //
-        // Case 900: South windows, unshaded
-        // Raw: Heating=5.44 MWh, Cooling=5.93 MWh (current simulation output)
-        // Target: Heating=1.66 MWh, Cooling=2.49 MWh
-        "900" => (5.44 / 1.66, 2.49 / 5.93), // heating /3.28x, cooling *0.42x
-        "910" => (8.32 / 1.90, 1.0),         // Similar to 900
-        "920" => (1.0, 1.0),                 // E/W unshaded - needs investigation
-        "930" => (1.0, 1.0),                 // E/W shaded - needs investigation
-        "940" => (8.32 / 1.10, 1.0),         // Setback case
-        "950" => (1.0, 0.35),                // Night vent - cooling only
-        // Session 70: Case 960 COP correction
-        "960" => (0.95, 1.0 / 2.2), // heating /0.95 (efficiency), cooling /2.2 (COP)
-        _ => (1.0, 1.0),            // No correction for 600-series or FF cases
-    };
-
+    // Raw physics results - no empirical correction factors applied.
+    // Issue #724: Validation harness must not use empirical corrections.
+    // Any discrepancies from reference data indicate physics model errors that must be fixed
+    // in the underlying physics, not hidden with correction factors.
     let raw_heating_mwh = total_heating / 1000.0;
     let raw_cooling_mwh = total_cooling / 1000.0;
 
     SimulationResults {
-        annual_heating_mwh: raw_heating_mwh / heating_correction, // kWh to MWh with correction
-        annual_cooling_mwh: raw_cooling_mwh * cooling_correction,
+        annual_heating_mwh: raw_heating_mwh,
+        annual_cooling_mwh: raw_cooling_mwh,
         peak_heating_kw: model.peak_power_heating / 1000.0,
         peak_cooling_kw: model.peak_power_cooling / 1000.0,
         min_temp_c: min_temp,


### PR DESCRIPTION
## Summary

The validation harness was applying empirical correction factors to make simulation results match EnergyPlus reference data. These corrections hid underlying physics model errors and prevented meaningful comparison with ASHRAE 140 reference data.

## Fix Applied

Removed all empirical correction factors from the simulate_annual() function. The function now returns raw physics-based results without any empirical adjustments.

## Impact

After removing corrections, the tests expose real physics model errors that must be fixed in the underlying simulation code. This is correct behavior for ASHRAE 140 compliance - the model must be purely physics-based without empirical corrections.

Fixes #724