### PR TITLE
fix(726): promote FD solver to primary for high-mass constructions

### DIFF
--- a/src/physics/method_selector.rs
+++ b/src/physics/method_selector.rs
@@ -344,10 +344,13 @@ impl ThermalMethodSelector {
         let tau = self.calculate_time_constant(wall);
 
         // Select method based on thermal mass
+        // Issue #726: CTF is architecturally wrong for high-mass constructions
+        // (900-series). For high thermal mass, FD is more appropriate because
+        // the thermal wave penetrates deeply into the construction.
         let method = if tau < self.threshold_hours {
             ThermalMethod::FiveR1C // Low mass: use fast 5R1C
         } else {
-            ThermalMethod::CTF // High mass: use accurate CTF (Issue #726: should be FD for heavy-mass)
+            ThermalMethod::FiniteDifference // High mass: use FD (Issue #726)
         };
 
         tracing::info!(
@@ -637,7 +640,8 @@ mod tests {
 
         let method = selector.select_method(&wall);
 
-        assert_eq!(method, ThermalMethod::CTF);
+        // Issue #726: FD should be used for high-mass constructions
+        assert_eq!(method, ThermalMethod::FiniteDifference);
     }
 
     #[test]
@@ -653,16 +657,20 @@ mod tests {
 
     #[test]
     fn test_fallback_invalid_ctf() {
+        // Use a heavyweight wall to test CTF→FD fallback
+        // Issue #726: For heavyweight walls, select_method now returns FD directly,
+        // so we test the fallback path by verifying behavior when ctf_valid=false.
         let selector = ThermalMethodSelector::default();
         let wall = create_heavyweight_wall();
 
-        // CTF invalid → should fall back to FD
+        // When CTF is invalid and fallback enabled, should get FD
         let method = selector.select_with_fallback(&wall, false);
         assert_eq!(method, ThermalMethod::FiniteDifference);
 
-        // CTF valid → should use CTF
+        // When ctf_valid=true but select_method returns FD (heavyweight after fix),
+        // the fallback logic is not triggered - select_with_fallback returns FD
         let method = selector.select_with_fallback(&wall, true);
-        assert_eq!(method, ThermalMethod::CTF);
+        assert_eq!(method, ThermalMethod::FiniteDifference);
     }
 
     #[test]
@@ -673,9 +681,10 @@ mod tests {
         };
         let wall = create_heavyweight_wall();
 
-        // CTF invalid but fallback disabled → should still return CTF
+        // After Issue #726 fix: heavyweight walls return FD directly,
+        // so fallback disabled doesn't affect the result
         let method = selector.select_with_fallback(&wall, false);
-        assert_eq!(method, ThermalMethod::CTF);
+        assert_eq!(method, ThermalMethod::FiniteDifference);
     }
 
     #[test]
@@ -722,7 +731,8 @@ mod tests {
 
         assert!(report.contains("Total walls: 3"));
         assert!(report.contains("5R1C: 1 walls"));
-        assert!(report.contains("CTF:  2 walls"));
+        // Issue #726: Heavyweight walls now use FD instead of CTF
+        assert!(report.contains("FD:   2 walls"));
     }
 
     #[test]
@@ -842,9 +852,10 @@ mod tests {
         };
         let wall = create_heavyweight_wall();
 
-        // Even with CTF invalid, fallback disabled should return CTF
+        // Issue #726: Heavyweight walls now use FD directly from select_method,
+        // so fallback disabled doesn't change the result
         let method = selector.select_with_fallback(&wall, false);
-        assert_eq!(method, ThermalMethod::CTF);
+        assert_eq!(method, ThermalMethod::FiniteDifference);
     }
 
     #[test]

--- a/src/physics/solver_manager.rs
+++ b/src/physics/solver_manager.rs
@@ -512,7 +512,8 @@ mod tests {
         let solver = manager.get_solver_mut(0);
         assert!(solver.is_some());
         let solver_name = solver.unwrap().name();
-        assert!(solver_name == "5R1C" || solver_name == "CTF");
+        // Issue #726: heavyweight wall (200mm concrete) should now use FD
+        assert!(solver_name == "5R1C" || solver_name == "CTF" || solver_name == "FD");
     }
 
     #[test]

--- a/src/sim/thermal_model_core.rs
+++ b/src/sim/thermal_model_core.rs
@@ -1010,9 +1010,14 @@ impl ThermalModel<VectorField> {
             // For low-mass buildings, thermal mass is primarily furniture/internal elements,
             // not the building envelope. Using reduced h_ms = 2.0 W/(m²·K) gives
             // h_tr_ms ≈ 240 W/K instead of 1092 W/K, producing proper thermal coupling.
+            //
+            // REVERT: h_ms_coeff=0.33 was tried to get proper ~69 hour time constant via
+            // derived_h_tr_3, but it decoupled the thermal mass too much, causing 900FF to
+            // show LARGER swings than 600FF (wrong physics). Restoring to 9.1 for proper
+            // mass coupling; time constant will be addressed separately via derived_h_tr_3.
             let h_ms_coeff = match spec.construction_type {
                 crate::validation::ashrae_140_cases::ConstructionType::LowMass => 2.0,
-                crate::validation::ashrae_140_cases::ConstructionType::HighMass => 0.33,
+                crate::validation::ashrae_140_cases::ConstructionType::HighMass => 9.1,
                 crate::validation::ashrae_140_cases::ConstructionType::Special => 9.1,
             };
             let h_ms_iso_13790 = h_ms_coeff * a_m;


### PR DESCRIPTION
Fixes GitHub Issue #726