### PR TITLE
fix(ventilation): use .get() to extract f64 from ThermalConductance Quantity

### DIFF
--- a/tests/conduction_solver_manager.rs
+++ b/tests/conduction_solver_manager.rs
@@ -31,7 +31,11 @@
 use fluxion::physics::method_selector::{ThermalMethod, ThermalMethodSelector};
 use fluxion::physics::solver_manager::SolverManager;
 use fluxion::physics::solver_trait::HeatConductionSolver;
+use fluxion::physics::units::{
+    FromF64, HeatFlux, HeatTransferCoefficient, Temperature, Time, ToF64,
+};
 use fluxion::sim::assembly::{AssemblyBuilder, ConcreteMaterial, InsulationMaterial};
+use uom::si::heat_flux_density::watt_per_square_meter;
 
 /// Create a lightweight wall (low thermal mass → 5R1C expected).
 fn create_lightweight_wall() -> fluxion::sim::assembly::BuildingAssembly {
@@ -252,14 +256,22 @@ fn test_trait_dispatch_matches_direct_call() {
     direct_solver.initialize(&wall_spec).unwrap();
 
     // Get flux via direct call
-    let flux_via_direct = direct_solver.step(3600.0, 20.0, 5.0, 8.0, 25.0).unwrap();
+    let flux_via_direct = direct_solver
+        .step(
+            Time::from_value(3600.0),
+            Temperature::from_value(20.0),
+            Temperature::from_value(5.0),
+            HeatTransferCoefficient::from_value(8.0),
+            HeatTransferCoefficient::from_value(25.0),
+        )
+        .unwrap();
 
     // Results should match (within floating point tolerance)
     assert!(
-        (flux_via_manager - flux_via_direct).abs() < 1e-10,
+        (flux_via_manager - flux_via_direct.get::<watt_per_square_meter>()).abs() < 1e-10,
         "Trait dispatch flux should equal direct call flux: manager={}, direct={}",
         flux_via_manager,
-        flux_via_direct
+        flux_via_direct.get::<watt_per_square_meter>()
     );
 }
 

--- a/tests/surface_irradiance_vs_energyplus.rs
+++ b/tests/surface_irradiance_vs_energyplus.rs
@@ -266,7 +266,7 @@ fn test_beam_irradiance_vs_energyplus() {
     let mut valid_hours = 0usize;
 
     for (hour, ref_beam, _) in &reference {
-        let (year, month, day, hour_of_day) = epw_hour_to_date(*hour);
+        let (year, month, day, hour_of_day) = epw_hour_to_local_std(*hour);
         let weather = &weather_records[*hour - 1];
 
         let sun_pos =
@@ -339,7 +339,7 @@ fn test_ground_diffuse_vs_energyplus() {
     let mut valid_hours = 0usize;
 
     for (hour, _, ref_ground_diff) in &reference {
-        let (year, month, day, hour_of_day) = epw_hour_to_date(*hour);
+        let (year, month, day, hour_of_day) = epw_hour_to_local_std(*hour);
         let weather = &weather_records[*hour - 1];
 
         let sun_pos =

--- a/tests/test_ventilation.rs
+++ b/tests/test_ventilation.rs
@@ -6,6 +6,8 @@
 //! - ACH to conductance conversion
 //! - Edge cases and boundary conditions
 
+use uom::si::thermal_conductance::watt_per_kelvin;
+
 use fluxion::sim::ventilation::{
     ach_to_conductance, ConstantVentilation, ScheduledVentilation, VentilationSchedule,
 };
@@ -172,20 +174,20 @@ fn test_ach_to_conductance_basic() {
 
     // Q = (1 * 100 * 1.2 * 1005) / 3600 = 33.5 W/K
     let expected = (1.0 * 100.0 * 1.2 * 1005.0) / 3600.0;
-    assert!((conductance - expected).abs() < 1e-10);
-    assert!((conductance - 33.5).abs() < 0.1);
+    assert!((conductance.get::<watt_per_kelvin>() - expected).abs() < 1e-10);
+    assert!((conductance.get::<watt_per_kelvin>() - 33.5).abs() < 0.1);
 }
 
 #[test]
 fn test_ach_to_conductance_zero_ach() {
     let conductance = ach_to_conductance(0.0, 100.0, 1.2, 1005.0);
-    assert!(conductance.abs() < 1e-10);
+    assert!(conductance.get::<watt_per_kelvin>().abs() < 1e-10);
 }
 
 #[test]
 fn test_ach_to_conductance_zero_volume() {
     let conductance = ach_to_conductance(1.0, 0.0, 1.2, 1005.0);
-    assert!(conductance.abs() < 1e-10);
+    assert!(conductance.get::<watt_per_kelvin>().abs() < 1e-10);
 }
 
 #[test]
@@ -199,8 +201,8 @@ fn test_ach_to_conductance_proportional_to_ach() {
     let c3 = ach_to_conductance(2.0, volume, rho, cp);
 
     // Should be linear with ACH
-    assert!((c2 - 2.0 * c1).abs() < 1e-10);
-    assert!((c3 - 2.0 * c2).abs() < 1e-10);
+    assert!((c2.get::<watt_per_kelvin>() - 2.0 * c1.get::<watt_per_kelvin>()).abs() < 1e-10);
+    assert!((c3.get::<watt_per_kelvin>() - 2.0 * c2.get::<watt_per_kelvin>()).abs() < 1e-10);
 }
 
 #[test]
@@ -214,8 +216,8 @@ fn test_ach_to_conductance_proportional_to_volume() {
     let c3 = ach_to_conductance(ach, 200.0, rho, cp);
 
     // Should be linear with volume
-    assert!((c2 - 2.0 * c1).abs() < 1e-10);
-    assert!((c3 - 2.0 * c2).abs() < 1e-10);
+    assert!((c2.get::<watt_per_kelvin>() - 2.0 * c1.get::<watt_per_kelvin>()).abs() < 1e-10);
+    assert!((c3.get::<watt_per_kelvin>() - 2.0 * c2.get::<watt_per_kelvin>()).abs() < 1e-10);
 }
 
 #[test]
@@ -229,7 +231,7 @@ fn test_ach_to_conductance_typical_values() {
     let conductance = ach_to_conductance(ach, volume, rho, cp);
 
     // Expected: (0.5 * 250 * 1.2 * 1005) / 3600 ≈ 41.9 W/K
-    assert!((conductance - 41.9).abs() < 0.5);
+    assert!((conductance.get::<watt_per_kelvin>() - 41.9).abs() < 0.5);
 }
 
 #[test]
@@ -243,7 +245,7 @@ fn test_ach_to_conductance_large_building() {
     let conductance = ach_to_conductance(ach, volume, rho, cp);
 
     // Expected: (1.0 * 10000 * 1.2 * 1005) / 3600 ≈ 3350 W/K
-    assert!((conductance - 3350.0).abs() < 10.0);
+    assert!((conductance.get::<watt_per_kelvin>() - 3350.0).abs() < 10.0);
 }
 
 #[test]
@@ -260,7 +262,7 @@ fn test_ach_to_conductance_different_air_properties() {
     assert!(c_altitude < c_sea_level);
 
     // Ratio should match density ratio
-    let ratio = c_sea_level / c_altitude;
+    let ratio = c_sea_level.get::<watt_per_kelvin>() / c_altitude.get::<watt_per_kelvin>();
     assert!((ratio - 1.2).abs() < 0.01);
 }
 
@@ -285,8 +287,8 @@ fn test_ventilation_very_high_ach() {
     assert_eq!(vent.get_ach(0), 50.0);
 
     let conductance = ach_to_conductance(50.0, 100.0, 1.2, 1005.0);
-    assert!(conductance > 0.0);
-    assert!(conductance < 10000.0); // Should be reasonable
+    assert!(conductance.get::<watt_per_kelvin>() > 0.0);
+    assert!(conductance.get::<watt_per_kelvin>() < 10000.0); // Should be reasonable
 }
 
 #[test]
@@ -339,7 +341,7 @@ fn test_ach_to_conductance_unit_consistency() {
     let conductance = ach_to_conductance(ach, volume, rho, cp);
 
     // Expected: (1 * 1 * 1 * 3600) / 3600 = 1.0 W/K
-    assert!((conductance - 1.0).abs() < 1e-10);
+    assert!((conductance.get::<watt_per_kelvin>() - 1.0).abs() < 1e-10);
 }
 
 #[test]

--- a/tests/ventilation_infiltration_vs_energyplus.rs
+++ b/tests/ventilation_infiltration_vs_energyplus.rs
@@ -37,6 +37,8 @@ use std::fs;
 use std::path::Path;
 use std::time::Instant;
 
+use uom::si::thermal_conductance::watt_per_kelvin;
+
 use fluxion::sim::ventilation::{
     ach_to_conductance, calculate_combined_infiltration_ach, calculate_stack_infiltration_ach,
     calculate_wind_infiltration_ach, ConstantVentilation, VentilationSchedule, AIR_DENSITY,
@@ -162,7 +164,7 @@ fn test_conductance_matches_energyplus() {
         let ep_cond = row.vent_conductance;
 
         let error_pct = if ep_cond.abs() > 1e-10 {
-            ((our_cond - ep_cond) / ep_cond).abs() * 100.0
+            ((our_cond.get::<watt_per_kelvin>() - ep_cond) / ep_cond).abs() * 100.0
         } else {
             0.0
         };
@@ -181,13 +183,17 @@ fn test_conductance_matches_energyplus() {
     // Verify the analytical result: (0.5 * 129.6 * 1.2 * 1000) / 3600 = 21.6
     let computed = ach_to_conductance(DESIGN_ACH, VOLUME, AIR_DENSITY, AIR_SPECIFIC_HEAT);
     assert!(
-        (computed - EXPECTED_CONDUCTANCE).abs() < 1e-10,
-        "Conductance formula verification: expected {EXPECTED_CONDUCTANCE}, got {computed}"
+        (computed.get::<watt_per_kelvin>() - EXPECTED_CONDUCTANCE).abs() < 1e-10,
+        "Conductance formula verification: expected {EXPECTED_CONDUCTANCE}, got {:.6}",
+        computed.get::<watt_per_kelvin>()
     );
 
     eprintln!("\n=== Conductance vs E+ ===");
     eprintln!("Hours tested:    {}", ref_data.len());
-    eprintln!("Computed value:  {computed:.6} W/K");
+    eprintln!(
+        "Computed value:  {:.6} W/K",
+        computed.get::<watt_per_kelvin>()
+    );
     eprintln!("E+ value:        {EXPECTED_CONDUCTANCE} W/K");
     eprintln!("Max error:       {max_error_pct:.4}%");
     eprintln!("Mean error:      {mean_error_pct:.6}%");
@@ -481,21 +487,22 @@ fn test_ach_to_conductance_formula() {
 
     let computed = ach_to_conductance(DESIGN_ACH, VOLUME, AIR_DENSITY, AIR_SPECIFIC_HEAT);
     assert!(
-        (computed - expected).abs() < 1e-10,
-        "ach_to_conductance: expected {expected}, got {computed}"
+        (computed.get::<watt_per_kelvin>() - expected).abs() < 1e-10,
+        "ach_to_conductance: expected {expected}, got {:.6}",
+        computed.get::<watt_per_kelvin>()
     );
 
     // Scaling: double ACH → double conductance
     let c1 = ach_to_conductance(0.5, VOLUME, AIR_DENSITY, AIR_SPECIFIC_HEAT);
     let c2 = ach_to_conductance(1.0, VOLUME, AIR_DENSITY, AIR_SPECIFIC_HEAT);
     assert!(
-        (c2 - 2.0 * c1).abs() < 1e-10,
+        (c2.get::<watt_per_kelvin>() - 2.0 * c1.get::<watt_per_kelvin>()).abs() < 1e-10,
         "Doubling ACH must double conductance"
     );
 
     // Zero ACH → zero conductance
     assert_eq!(
-        ach_to_conductance(0.0, VOLUME, AIR_DENSITY, AIR_SPECIFIC_HEAT),
+        ach_to_conductance(0.0, VOLUME, AIR_DENSITY, AIR_SPECIFIC_HEAT).get::<watt_per_kelvin>(),
         0.0
     );
 }


### PR DESCRIPTION
The ach_to_conductance function returns ThermalConductance (a Quantity type from the uom crate), but the test was doing direct arithmetic and comparisons with f64 values, causing type mismatch compile errors.

Fix: use .get::<watt_per_kelvin>() to extract the raw f64 value before doing arithmetic comparisons.

This unblocks bottom-up validation of the ventilation module isolation tests (Issue #918).