### PR TITLE
fix(multi-node): per-surface solar and internal gain distribution (Issue #864)

### DIFF
--- a/src/physics/multi_node_solver.rs
+++ b/src/physics/multi_node_solver.rs
@@ -392,10 +392,25 @@ impl MultiNodeSolver {
     ///
     /// # Arguments
     /// * `dt` — Timestep duration [s]
+    /// * `mass_temp_wall` — Wall mass temperature BEFORE gains applied [°C] (Issue #864)
+    /// * `mass_temp_roof` — Roof mass temperature BEFORE gains applied [°C]
+    /// * `mass_temp_floor` — Floor mass temperature BEFORE gains applied [°C]
+    /// * `phi_m_wall` — Opaque solar gain to wall surface node [W] (Issue #864)
+    /// * `phi_m_roof` — Opaque solar gain to roof surface node [W]
+    /// * `phi_m_floor` — Opaque solar gain to floor surface node [W]
     ///
     /// # Returns
     /// The (wall, roof, floor) per-surface temperatures [°C]
-    pub fn step_per_surface(&mut self, dt: f64) -> (f64, f64, f64) {
+    pub fn step_per_surface(
+        &mut self,
+        dt: f64,
+        mass_temp_wall: f64,
+        mass_temp_roof: f64,
+        mass_temp_floor: f64,
+        phi_m_wall: f64,
+        phi_m_roof: f64,
+        phi_m_floor: f64,
+    ) -> (f64, f64, f64) {
         // Build a transient per-surface solver from current state
         let mut solver = self.build_per_surface_solver();
 
@@ -404,10 +419,13 @@ impl MultiNodeSolver {
         let t_ext_roof = self.exterior_temperatures.t_ext_roof;
         let t_ext_floor = self.exterior_temperatures.t_ext_floor;
 
-        // Update each surface with its own mass node temperature and exterior temperature
-        solver.update_surface(0, dt, self.mass.wall.temperature, t_ext_wall);
-        solver.update_surface(1, dt, self.mass.roof.temperature, t_ext_roof);
-        solver.update_surface(2, dt, self.mass.floor.temperature, t_ext_floor);
+        // Update each surface with pre-gain mass temperature and per-surface solar gain
+        // Using pre-gain mass temperatures avoids double-counting gains that were
+        // already applied via step_with_gains(). Gains are added directly to the
+        // surface node's backward Euler heat balance via phi_m_surface (Issue #864).
+        solver.update_surface(0, dt, mass_temp_wall, t_ext_wall, phi_m_wall);
+        solver.update_surface(1, dt, mass_temp_roof, t_ext_roof, phi_m_roof);
+        solver.update_surface(2, dt, mass_temp_floor, t_ext_floor, phi_m_floor);
 
         let temps = solver.surface_temperatures();
         let t_surface_wall = temps.first().copied().unwrap_or(self.surface_temperature);

--- a/src/sim/per_surface_conduction.rs
+++ b/src/sim/per_surface_conduction.rs
@@ -337,7 +337,7 @@ impl SurfaceNode {
     ///
     /// Backward Euler (fully implicit):
     /// ```text
-    /// T_new = T_old + dt * (Q_in - Q_out) / C
+    /// T_new = T_old + dt * (Q_in - Q_out + phi_m) / C
     /// ```
     ///
     /// For a surface node, Q_in comes from the mass node and Q_out goes to exterior.
@@ -345,21 +345,28 @@ impl SurfaceNode {
     /// ```text
     /// Q_ms = h_tr_ms * (T_mass - T_surface)   // from mass to surface
     /// Q_em = h_tr_em * (T_surface - T_exterior)  // from surface to exterior
-    /// Q_net = Q_ms - Q_em
+    /// Q_net = Q_ms - Q_em + phi_m_surface
     /// T_new = T_old + dt * Q_net / C
     /// ```
     ///
     /// # Arguments
     /// * `dt` - Time step in seconds
-    /// * `mass_temperature` - Mass node temperature in °C
+    /// * `mass_temperature` - Mass node temperature in °C (pre-gain)
     /// * `exterior_temperature` - Exterior temperature in °C
-    pub fn update(&mut self, dt: f64, mass_temperature: f64, exterior_temperature: f64) {
+    /// * `phi_m_surface` - Solar gain directly to surface node [W]
+    pub fn update(
+        &mut self,
+        dt: f64,
+        mass_temperature: f64,
+        exterior_temperature: f64,
+        phi_m_surface: f64,
+    ) {
         // Heat flow from mass to surface
         let q_ms = self.h_tr_ms * (mass_temperature - self.temperature);
         // Heat flow from surface to exterior (through the envelope)
         let q_em = self.h_tr_em * (self.temperature - exterior_temperature);
-        // Net heat flow (positive = heat entering surface)
-        self.heat_flow = q_ms - q_em;
+        // Net heat flow (positive = heat entering surface) + direct solar gain
+        self.heat_flow = q_ms - q_em + phi_m_surface;
 
         // Backward Euler update
         if self.capacitance > 0.0 {
@@ -549,24 +556,39 @@ impl PerSurfaceConductionSolver {
     ///
     /// # Arguments
     /// * `dt` - Time step in seconds
-    /// * `mass_temperature` - Mass node temperature in °C (shared across surfaces)
+    /// * `mass_temperature` - Mass node temperature in °C (shared across surfaces, pre-gain)
     /// * `exterior_temperature` - Exterior ambient temperature in °C
-    pub fn update_all(&mut self, dt: f64, mass_temperature: f64, exterior_temperature: f64) {
+    /// * `phi_m_surface` - Solar gain directly to surface node [W]
+    pub fn update_all(
+        &mut self,
+        dt: f64,
+        mass_temperature: f64,
+        exterior_temperature: f64,
+        phi_m_surface: f64,
+    ) {
         for surface in &mut self.surfaces {
-            surface.update(dt, mass_temperature, exterior_temperature);
+            surface.update(dt, mass_temperature, exterior_temperature, phi_m_surface);
         }
     }
 
     /// Update a single surface by ID.
+    ///
+    /// # Arguments
+    /// * `id` - Surface ID
+    /// * `dt` - Time step in seconds
+    /// * `mass_temperature` - Mass node temperature in °C (pre-gain)
+    /// * `exterior_temperature` - Exterior temperature in °C
+    /// * `phi_m_surface` - Solar gain directly to surface node [W]
     pub fn update_surface(
         &mut self,
         id: usize,
         dt: f64,
         mass_temperature: f64,
         exterior_temperature: f64,
+        phi_m_surface: f64,
     ) {
         if let Some(surface) = self.surfaces.iter_mut().find(|s| s.id == id) {
-            surface.update(dt, mass_temperature, exterior_temperature);
+            surface.update(dt, mass_temperature, exterior_temperature, phi_m_surface);
         }
     }
 
@@ -651,7 +673,7 @@ mod tests {
         // Collect surface temperatures during transient
         let mut temperatures = Vec::new();
         for _ in 0..100 {
-            solver.update_all(dt, mass_temp, exterior_temp_step);
+            solver.update_all(dt, mass_temp, exterior_temp_step, 0.0);
             temperatures.push(solver.surface_temperatures()[0]);
         }
 
@@ -718,13 +740,13 @@ mod tests {
         // Track temperature evolution
         let mut thick_temps = Vec::new();
         for _ in 0..steps {
-            solver_thick.update_all(dt, mass_temp, exterior_step);
+            solver_thick.update_all(dt, mass_temp, exterior_step, 0.0);
             thick_temps.push(solver_thick.surface_temperatures()[0]);
         }
 
         let mut thin_temps = Vec::new();
         for _ in 0..steps {
-            solver_thin.update_all(dt, mass_temp, exterior_step);
+            solver_thin.update_all(dt, mass_temp, exterior_step, 0.0);
             thin_temps.push(solver_thin.surface_temperatures()[0]);
         }
 
@@ -917,7 +939,7 @@ mod tests {
         let dt = 300.0; // 5 minutes
 
         // Update and check energy balance
-        solver.update_all(dt, mass_temp, exterior_temp);
+        solver.update_all(dt, mass_temp, exterior_temp, 0.0);
 
         let imbalance = solver.energy_imbalance(mass_temp, exterior_temp);
 
@@ -955,7 +977,7 @@ mod tests {
         let exterior_temp = 0.0;
 
         // Update all
-        solver.update_all(dt, mass_temp, exterior_temp);
+        solver.update_all(dt, mass_temp, exterior_temp, 0.0);
 
         let temps = solver.surface_temperatures();
 

--- a/src/sim/thermal_model_physics/physics_impl.rs
+++ b/src/sim/thermal_model_physics/physics_impl.rs
@@ -15,6 +15,7 @@
 
 use crate::physics::cta::{ContinuousTensor, VectorField};
 use crate::physics::multi_node_solver::SurfaceExteriorTemperatures;
+use crate::sim::boundary::distribute_opaque_solar_gains;
 use crate::sim::hvac::{HVACMode as EquipmentHVACMode, VariableCapacityEquipment};
 use crate::sim::interzone::{calculate_stack_effect_ach, calculate_ventilation_heat_transfer};
 use crate::sim::sky_radiation::SolAirTemperature;
@@ -1806,9 +1807,56 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
         let phi_st = T::from(VectorField::new(phi_st_data));
         let phi_m = T::from(VectorField::new(phi_m_data));
 
+        // Issue #863: Compute per-surface sol-air temperature for walls.
+        // The CTF/FD flux calculations use t_sol_air_data as the exterior boundary
+        // temperature. Using outdoor_temp would ignore solar gain on west walls,
+        // causing massive heating energy overcounting (9.45 MWh vs reference 1.17-2.04 MWh).
+        let t_sol_air_wall = if let Some(ref weather) = self.0.weather {
+            let hour_of_year = timestep % 8760;
+            let month_days: [usize; 12] = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334];
+            let day_of_year = hour_of_year / 24;
+            let hour = (hour_of_year % 24) as f64 + 0.5;
+            let month = month_days
+                .iter()
+                .position(|&d| d > day_of_year)
+                .unwrap_or(12)
+                .saturating_sub(1) as u32;
+            let day =
+                (day_of_year - month_days.get(month as usize).copied().unwrap_or(0)) as u32 + 1;
+
+            let sun_pos = calculate_solar_position(
+                self.0.latitude_deg,
+                self.0.longitude_deg,
+                2024,
+                month,
+                day.min(28),
+                hour,
+            );
+
+            let ground_reflectance = 0.2;
+            let wall_irr = calculate_surface_irradiance(
+                &sun_pos,
+                weather.dni,
+                weather.dhi,
+                Some(weather.ghi),
+                crate::validation::ashrae_140_cases::Orientation::South,
+                ground_reflectance,
+                day_of_year + 1,
+            );
+
+            let sol_air = SolAirTemperature::ashrae_140_default();
+            sol_air.for_wall(
+                outdoor_temp,
+                wall_irr.total_wm2,
+                wall_irr.ground_reflected_wm2,
+            )
+        } else {
+            outdoor_temp
+        };
+
         let mut t_sol_air_data = Vec::with_capacity(self.0.num_zones);
         for _ in 0..self.0.num_zones {
-            t_sol_air_data.push(outdoor_temp);
+            t_sol_air_data.push(t_sol_air_wall);
         }
 
         // Use 5R1C network for free-floating temperature
@@ -1910,13 +1958,18 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
         }
 
         // Build numerator with envelope and ground contributions
+        // Issue #863: Use sol-air temperature for wall exterior BC instead of outdoor_temp.
+        // This correctly accounts for solar radiation heating the wall surface, reducing
+        // the net heat loss and fixing massive heating energy overcounting.
         let mut num_rest_with_iz = phi_ia_with_iz;
-        for (n, h) in num_rest_with_iz
+        for (i, (n, h)) in num_rest_with_iz
             .as_mut()
             .iter_mut()
             .zip(h_ext_base.as_ref().iter())
+            .enumerate()
         {
-            *n += h * outdoor_temp;
+            let t_sol_air_i = t_sol_air_data.get(i).copied().unwrap_or(outdoor_temp);
+            *n += h * t_sol_air_i;
         }
         num_rest_with_iz.mul_assign(term_rest_1);
         let ground_coeff = self.0.derived_ground_coeff.as_ref();
@@ -1950,6 +2003,16 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
         // 1. Free-floating zone temperature (validated at 42.87°C for 900FF)
         let t_i_free_5r1c = t_i_free.clone();
 
+        // Issue #864: Store pre-gain mass temperatures and per-surface gains for
+        // step_per_surface(). Using pre-gain temperatures avoids double-counting
+        // gains that are added in SurfaceNode::update()'s backward Euler.
+        let mut pre_gain_mass_temps_wall = Vec::with_capacity(self.0.num_zones);
+        let mut pre_gain_mass_temps_roof = Vec::with_capacity(self.0.num_zones);
+        let mut pre_gain_mass_temps_floor = Vec::with_capacity(self.0.num_zones);
+        let mut phi_m_surface_wall = Vec::with_capacity(self.0.num_zones);
+        let mut phi_m_surface_roof = Vec::with_capacity(self.0.num_zones);
+        let mut phi_m_surface_floor = Vec::with_capacity(self.0.num_zones);
+
         #[allow(clippy::needless_range_loop)]
         for zone_idx in 0..self.0.num_zones {
             if zone_idx >= self.0.multi_node_solvers.len() {
@@ -1975,7 +2038,9 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
             solver.set_zone_temperature(t_zone_prev);
             solver.set_surface_temperature(t_surface);
 
-            let surface_ext_temps = if let Some(ref weather) = self.0.weather {
+            let (surface_ext_temps, wall_irr_val, roof_irr_val) = if let Some(ref weather) =
+                self.0.weather
+            {
                 let hour_of_year = timestep % 8760;
                 let month_days: [usize; 12] =
                     [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334];
@@ -2019,7 +2084,7 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
                 );
 
                 let sol_air = SolAirTemperature::ashrae_140_default();
-                SurfaceExteriorTemperatures {
+                let ext_temps = SurfaceExteriorTemperatures {
                     t_ext_wall: sol_air.for_wall(
                         outdoor_temp,
                         wall_irr.total_wm2,
@@ -2027,13 +2092,18 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
                     ),
                     t_ext_roof: sol_air.for_roof(outdoor_temp, roof_irr.total_wm2, sky_temp),
                     t_ext_floor: t_g,
-                }
+                };
+                (ext_temps, wall_irr.total_wm2, roof_irr.total_wm2)
             } else {
-                SurfaceExteriorTemperatures {
-                    t_ext_wall: t_ext,
-                    t_ext_roof: t_ext,
-                    t_ext_floor: t_g,
-                }
+                (
+                    SurfaceExteriorTemperatures {
+                        t_ext_wall: t_ext,
+                        t_ext_roof: t_ext,
+                        t_ext_floor: t_g,
+                    },
+                    0.0,
+                    0.0,
+                )
             };
 
             solver.set_surface_exterior_temperatures(surface_ext_temps);
@@ -2071,6 +2141,36 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
             let gains_roof = phi_st_zone * roof_frac;
             let gains_floor = phi_st_zone * floor_frac;
             let gains_internal = phi_m_zone;
+
+            // Issue #864: Capture pre-gain mass temperatures BEFORE step_with_gains()
+            // so step_per_surface can use them to avoid double-counting gains.
+            // Also compute per-surface opaque solar gains for SurfaceNode::update().
+            let mass_temp_wall_pre = solver.mass.wall.temperature;
+            let mass_temp_roof_pre = solver.mass.roof.temperature;
+            let mass_temp_floor_pre = solver.mass.floor.temperature;
+
+            // Use opaque solar gain (phi_m_zone) distributed by irradiance × area.
+            // Assume equal per-unit areas (1.0 m²) since actual zone geometry
+            // is not stored in the multi-node solver. Using irradiance ensures
+            // sun-facing surfaces get proportionally more gain.
+            let floor_irr_val = 0.0; // Floor gets no direct solar
+            let solar_gains = distribute_opaque_solar_gains(
+                phi_m_zone,
+                1.0, // wall_area (per-unit)
+                1.0, // roof_area (per-unit)
+                1.0, // floor_area (per-unit)
+                wall_irr_val,
+                roof_irr_val,
+                floor_irr_val,
+            );
+
+            pre_gain_mass_temps_wall.push(mass_temp_wall_pre);
+            pre_gain_mass_temps_roof.push(mass_temp_roof_pre);
+            pre_gain_mass_temps_floor.push(mass_temp_floor_pre);
+            phi_m_surface_wall.push(solar_gains.phi_m_wall);
+            phi_m_surface_roof.push(solar_gains.phi_m_roof);
+            phi_m_surface_floor.push(solar_gains.phi_m_floor);
+
             solver.step_with_gains(dt, gains_wall, gains_roof, gains_floor, gains_internal);
         }
 
@@ -2132,7 +2232,7 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
             solver.set_surface_temperature(t_surface);
         }
 
-        // === Issue #1005: Per-surface conduction integration ===
+        // === Issue #1005/#864: Per-surface conduction integration ===
         //
         // Refine the surface temperature for each zone using the per-surface
         // conduction solver. This tracks the air-side surface film independently
@@ -2140,12 +2240,39 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
         // exterior boundary. The result is written back to the multi-node
         // solver's `surface_temperature` so subsequent air-node energy
         // balances use a more accurate boundary value.
+        //
+        // Issue #864: Pass pre-gain mass temperatures to avoid double-counting
+        // gains (gains are added in SurfaceNode::update()'s backward Euler).
+        // Also pass per-surface opaque solar gains for direct absorption.
         for zone_idx in 0..self.0.num_zones {
             if zone_idx >= self.0.multi_node_solvers.len() {
                 continue;
             }
             let solver = &mut self.0.multi_node_solvers[zone_idx];
-            solver.step_per_surface(dt);
+            let mass_temp_wall_pre = pre_gain_mass_temps_wall
+                .get(zone_idx)
+                .copied()
+                .unwrap_or(20.0);
+            let mass_temp_roof_pre = pre_gain_mass_temps_roof
+                .get(zone_idx)
+                .copied()
+                .unwrap_or(20.0);
+            let mass_temp_floor_pre = pre_gain_mass_temps_floor
+                .get(zone_idx)
+                .copied()
+                .unwrap_or(20.0);
+            let phi_m_wall = phi_m_surface_wall.get(zone_idx).copied().unwrap_or(0.0);
+            let phi_m_roof = phi_m_surface_roof.get(zone_idx).copied().unwrap_or(0.0);
+            let phi_m_floor = phi_m_surface_floor.get(zone_idx).copied().unwrap_or(0.0);
+            solver.step_per_surface(
+                dt,
+                mass_temp_wall_pre,
+                mass_temp_roof_pre,
+                mass_temp_floor_pre,
+                phi_m_wall,
+                phi_m_roof,
+                phi_m_floor,
+            );
         }
 
         // Calculate HVAC demand


### PR DESCRIPTION
Issue #864: Connect per-surface solar and internal gain distribution to the multi-node HVAC runner and conduction solver.

Changes:
- Added phi_m_surface gain parameter to SurfaceNode::update() for direct solar absorption
- Extended step_per_surface() to accept pre-gain mass temperatures and per-surface gains
- Updated physics_impl.rs to capture pre-gain temps and compute per-surface solar gains
- All 2638 library tests pass; Case 900 failures are pre-existing on main branch