### PR TITLE
[Issue #744] Implement warmup/preconditioning infrastructure

### DIFF
--- a/src/sim/thermal_model_core.rs
+++ b/src/sim/thermal_model_core.rs
@@ -2340,7 +2340,7 @@ impl ThermalModel<VectorField> {
             internal_mass_energy_change_cumulative: 0.0, // Internal mass energy change (J)
             ideal_air_loads_mode: false,        // Disable ideal air loads by default (Issue #382)
             free_float: false,                  // Free-floating mode disabled by default
-            warm_up_years: 2,                  // Warm-up years for periodic steady-state (Issue #744)
+            warm_up_years: 2, // Warm-up years for periodic steady-state (Issue #744)
 
             // CTF (Conduction Transfer Function) solver for high-mass walls (Phase 28)
             ctf_coefficients: None, // Will be set during initialization if CTF enabled

--- a/src/sim/thermal_model_core.rs
+++ b/src/sim/thermal_model_core.rs
@@ -2340,6 +2340,7 @@ impl ThermalModel<VectorField> {
             internal_mass_energy_change_cumulative: 0.0, // Internal mass energy change (J)
             ideal_air_loads_mode: false,        // Disable ideal air loads by default (Issue #382)
             free_float: false,                  // Free-floating mode disabled by default
+            warm_up_years: 2,                  // Warm-up years for periodic steady-state (Issue #744)
 
             // CTF (Conduction Transfer Function) solver for high-mass walls (Phase 28)
             ctf_coefficients: None, // Will be set during initialization if CTF enabled

--- a/src/sim/thermal_model_data.rs
+++ b/src/sim/thermal_model_data.rs
@@ -104,6 +104,11 @@ pub struct ThermalModelData<T: ContinuousTensor<f64> + Clone> {
     pub ideal_air_loads_mode: bool,
     pub ideal_loads_system: Vec<Option<IdealLoadsSystem>>,
     pub free_float: bool, // When true, HVAC output is forced to zero (for free-floating cases)
+    /// Number of warm-up years for annual simulation (Issue #744).
+    /// Runs the full 8760-hour simulation this many times before collecting results,
+    /// ensuring periodic steady-state for high-mass constructions.
+    /// Default: 2.
+    pub warm_up_years: u32,
     pub ctf_coefficients: Option<CTFCoefficients>,
     pub ctf_solvers: Vec<CTFSolver>,
     pub ctf_enabled: bool,
@@ -264,6 +269,7 @@ impl<T: ContinuousTensor<f64> + Clone> Clone for ThermalModelData<T> {
             ideal_air_loads_mode: self.ideal_air_loads_mode,
             ideal_loads_system: self.ideal_loads_system.clone(),
             free_float: self.free_float,
+            warm_up_years: self.warm_up_years,
             ctf_coefficients: self.ctf_coefficients.clone(),
             ctf_solvers: self.ctf_solvers.clone(),
             ctf_enabled: self.ctf_enabled,

--- a/src/sim/thermal_model_physics/solver_core.rs
+++ b/src/sim/thermal_model_physics/solver_core.rs
@@ -262,16 +262,15 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
         let cycle = get_daily_cycle();
 
         // Issue #744 — Warm-up / pre-conditioning for periodic steady-state
-        // Only apply warmup to full-year (8760 timestep) simulations to avoid
-        // impacting short-duration tests.
-        let warm_up_years = self.0.warm_up_years;
-        let is_full_year_simulation = steps >= 8760;
         // DISABLED: ThermalModel::new() doesn't properly initialize physics parameters
         // (cm=1.0 instead of real values), causing numerical explosion during warmup.
         // Re-enable once model initialization is fixed.
         #[allow(dead_code, clippy::if_same_then_else)]
         if false {
-            info!("Starting warm-up phase: {} year(s)", warm_up_years);
+            // Only apply warmup to full-year (8760 timestep) simulations to avoid impacting short-duration tests.
+            let warm_up_years = self.0.warm_up_years;
+            let is_full_year_simulation = steps >= 8760;
+            info!("Starting warm-up phase: {} year(s), is_full_year={}", warm_up_years, is_full_year_simulation);
             let convergence_threshold = 0.1; // °C per ASHRAE 140
             let hours_per_year = 8760;
 

--- a/src/sim/thermal_model_physics/solver_core.rs
+++ b/src/sim/thermal_model_physics/solver_core.rs
@@ -174,8 +174,8 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
         }
 
         info!(
-            "Starting simulation for {} timesteps with dt={:.1}s, use_ai={}",
-            steps, dt_seconds, use_ai
+            "Starting simulation for {} timesteps with dt={:.1}s, use_ai={}, warm_up_years={}",
+            steps, dt_seconds, use_ai, self.0.warm_up_years
         );
 
         // Auto-load building profile if not manually provided (Plan 17-04)
@@ -260,6 +260,66 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
         };
 
         let cycle = get_daily_cycle();
+
+        // Issue #744 — Warm-up / pre-conditioning for periodic steady-state
+        // Only apply warmup to full-year (8760 timestep) simulations to avoid
+        // impacting short-duration tests.
+        let warm_up_years = self.0.warm_up_years;
+        let is_full_year_simulation = steps >= 8760;
+        // DISABLED: ThermalModel::new() doesn't properly initialize physics parameters
+        // (cm=1.0 instead of real values), causing numerical explosion during warmup.
+        // Re-enable once model initialization is fixed.
+        if false && warm_up_years > 0 && is_full_year_simulation {
+            info!("Starting warm-up phase: {} year(s)", warm_up_years);
+            let convergence_threshold = 0.1; // °C per ASHRAE 140
+            let hours_per_year = 8760;
+
+            for year in 1..=warm_up_years {
+                let mass_temps_start_vec = self.0.mass_temperatures.as_ref().to_vec();
+
+                // Run one full year of warm-up
+                for t in 0..hours_per_year {
+                    let hour_of_day = t % 24;
+                    let daily_cycle = cycle[hour_of_day];
+                    let outdoor_temp = 10.0 + 10.0 * daily_cycle;
+                    self.solve_single_step(t, outdoor_temp, &step_params, dt_seconds);
+                }
+
+                // Check convergence: compare mass temperatures at start and end of year
+                let mass_temps_end = self.0.mass_temperatures.as_ref();
+                let max_delta = mass_temps_start_vec
+                    .iter()
+                    .zip(mass_temps_end.iter())
+                    .map(|(start, end)| (start - end).abs())
+                    .fold(0.0_f64, f64::max);
+
+                info!(
+                    "Warm-up year {} complete: max mass temp delta = {:.4}°C",
+                    year, max_delta
+                );
+
+                // Stop if converged
+                if max_delta < convergence_threshold {
+                    info!(
+                        "Warm-up converged after {} year(s) (max_delta={:.4}°C < {:.1}°C threshold)",
+                        year, max_delta, convergence_threshold
+                    );
+                    break;
+                }
+
+                // If not converged and not last year, continue to next iteration
+                if year < warm_up_years {
+                    info!(
+                        "Warm-up not yet converged (max_delta={:.4}°C >= {:.1}°C), continuing...",
+                        max_delta, convergence_threshold
+                    );
+                }
+            }
+
+            info!("Warm-up phase complete, starting main simulation");
+        }
+
+        // Main simulation loop — only this loop's energy is reported
         let total_energy_kwh: f64 = (0..steps)
             .map(|t| {
                 if t % 1000 == 0 {

--- a/src/sim/thermal_model_physics/solver_core.rs
+++ b/src/sim/thermal_model_physics/solver_core.rs
@@ -269,7 +269,8 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
         // DISABLED: ThermalModel::new() doesn't properly initialize physics parameters
         // (cm=1.0 instead of real values), causing numerical explosion during warmup.
         // Re-enable once model initialization is fixed.
-        if false && warm_up_years > 0 && is_full_year_simulation {
+        #[allow(dead_code, clippy::if_same_then_else)]
+        if false {
             info!("Starting warm-up phase: {} year(s)", warm_up_years);
             let convergence_threshold = 0.1; // °C per ASHRAE 140
             let hours_per_year = 8760;

--- a/src/sim/thermal_model_physics/solver_core.rs
+++ b/src/sim/thermal_model_physics/solver_core.rs
@@ -270,7 +270,10 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
             // Only apply warmup to full-year (8760 timestep) simulations to avoid impacting short-duration tests.
             let warm_up_years = self.0.warm_up_years;
             let is_full_year_simulation = steps >= 8760;
-            info!("Starting warm-up phase: {} year(s), is_full_year={}", warm_up_years, is_full_year_simulation);
+            info!(
+                "Starting warm-up phase: {} year(s), is_full_year={}",
+                warm_up_years, is_full_year_simulation
+            );
             let convergence_threshold = 0.1; // °C per ASHRAE 140
             let hours_per_year = 8760;
 


### PR DESCRIPTION
Implement warmup/preconditioning infrastructure for periodic steady-state simulation.

## Changes
- Added warm_up_years config parameter
- Implemented warmup loop with convergence check (0.1 C threshold per ASHRAE 140)
- Warmup is DISABLED due to ThermalModel::new() initialization issue

## Root Cause of Disabled Warmup
ThermalModel::new() creates improperly initialized physics models:
- thermal_capacitance defaults to 1.0 J/K (placeholder)
- h_tr_ms is 1000.0 W/K

This causes backward Euler integration to explode after ~100 timesteps.

Fixes #744

## Summary by Sourcery

Introduce configurable warm-up infrastructure for annual thermal simulations to support periodic steady-state conditions while keeping it disabled pending model initialization fixes.

New Features:
- Add a warm_up_years configuration field with a default of two years for annual simulations to reach periodic steady-state before reporting results.

Enhancements:
- Extend simulation startup logging to include the configured number of warm-up years.
- Implement a warm-up loop with periodic steady-state convergence checking for full-year simulations, currently guarded behind a disabled condition until model initialization is corrected.