### PR TITLE
[Issue #720] Perf: Surrogate vs physics benchmarking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,6 +184,11 @@ name = "orchestration_decisions"
 path = "benches/orchestration_decisions/benchmark_runner.rs"
 harness = false
 
+[[bench]]
+name = "surrogate_vs_physics"
+path = "benches/surrogate_vs_physics_bench.rs"
+harness = false
+
 [[bin]]
 name = "fluxion-delta"
 path = "tools/fluxion_delta.rs"

--- a/benches/surrogate_vs_physics_bench.rs
+++ b/benches/surrogate_vs_physics_bench.rs
@@ -1,0 +1,197 @@
+//! Surrogate vs Physics Benchmark for Fluxion
+//!
+//! This benchmark compares ONNX surrogate inference speed against
+//! physics-based thermal solver to verify the 10-100x speedup claim.
+//!
+//! Run with: cargo bench --release --bench surrogate_vs_physics
+//!
+//! Issue #720: Formal benchmarking of surrogate speedup
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use fluxion::ai::surrogate::SurrogateManager;
+use fluxion::physics::cta::VectorField;
+use fluxion::sim::engine::ThermalModel;
+
+const DUMMY_ONNX_MODEL: &str = "assets/dummy_surrogate.onnx";
+
+fn bench_surrogate_onnx_single_inference(c: &mut Criterion) {
+    let surrogate = match SurrogateManager::load_onnx(DUMMY_ONNX_MODEL) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("Warning: Could not load ONNX model for benchmarking: {}", e);
+            eprintln!("Surrogate benchmarks will be skipped.");
+            return;
+        }
+    };
+
+    let temps = vec![20.0, 21.0, 22.0, 23.0, 24.0, 25.0];
+
+    let mut group = c.benchmark_group("surrogate_onnx");
+    group.throughput(Throughput::Elements(temps.len() as u64));
+    group.sample_size(1000);
+
+    group.bench_function("single_inference_6zones", |b| {
+        b.iter(|| {
+            let _ = surrogate
+                .predict_loads_onnx(black_box(&temps))
+                .expect("ONNX inference failed");
+        })
+    });
+
+    group.finish();
+}
+
+fn bench_surrogate_onnx_batched_inference(c: &mut Criterion) {
+    let surrogate = match SurrogateManager::load_onnx(DUMMY_ONNX_MODEL) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("Warning: Could not load ONNX model for benchmarking: {}", e);
+            return;
+        }
+    };
+
+    let batch_sizes = [1, 10, 100];
+
+    for &batch_size in &batch_sizes {
+        let mut group = c.benchmark_group(format!("surrogate_onnx_batch_{}", batch_size));
+        group.throughput(Throughput::Elements(batch_size as u64 * 6));
+        group.sample_size(100);
+
+        let batch: Vec<Vec<f64>> = (0..batch_size)
+            .map(|_| vec![20.0, 21.0, 22.0, 23.0, 24.0, 25.0])
+            .collect();
+
+        group.bench_function("batched_inference", |b| {
+            b.iter(|| {
+                let _ = surrogate
+                    .predict_loads_batched(black_box(&batch));
+            })
+        });
+
+        group.finish();
+    }
+}
+
+fn bench_physics_step_single_zone(c: &mut Criterion) {
+    let mut model = ThermalModel::<VectorField>::new(1);
+
+    c.bench_function("physics_step_single_zone", |b| {
+        b.iter(|| {
+            model.step_physics(black_box(0), black_box(20.0), black_box(3600.0));
+        })
+    });
+}
+
+fn bench_physics_step_multi_zone(c: &mut Criterion) {
+    let zone_counts = [1, 5, 10];
+
+    for &zones in &zone_counts {
+        let mut model = ThermalModel::<VectorField>::new(zones);
+
+        let mut group =
+            c.benchmark_group(format!("physics_step_{}_zones", zones));
+        group.throughput(Throughput::Elements(zones as u64));
+        group.sample_size(1000);
+
+        group.bench_function("step", |b| {
+            b.iter(|| {
+                model.step_physics(black_box(0), black_box(20.0), black_box(3600.0));
+            })
+        });
+
+        group.finish();
+    }
+}
+
+fn bench_comparison_8760_timesteps(c: &mut Criterion) {
+    let zones = 10;
+    let timesteps = 8760;
+    let surrogates = SurrogateManager::new().expect("Failed to create SurrogateManager");
+
+    let mut group = c.benchmark_group("comparison_8760_timesteps");
+    group.sample_size(10);
+
+    group.bench_function("physics_analytical_10zones_8760", |b| {
+        b.iter(|| {
+            let mut model = ThermalModel::<VectorField>::new(zones);
+            model.solve_timesteps(
+                black_box(timesteps),
+                &surrogates,
+                black_box(false),
+                None,
+                None,
+                None,
+            );
+        })
+    });
+
+    group.bench_function("physics_with_surrogate_10zones_8760", |b| {
+        b.iter(|| {
+            let mut model = ThermalModel::<VectorField>::new(zones);
+            model.solve_timesteps(
+                black_box(timesteps),
+                &surrogates,
+                black_box(true),
+                None,
+                None,
+                None,
+            );
+        })
+    });
+
+    group.finish();
+}
+
+fn bench_surrogate_inference_timing(c: &mut Criterion) {
+    let surrogate = match SurrogateManager::load_onnx(DUMMY_ONNX_MODEL) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("Warning: Could not load ONNX model for benchmarking: {}", e);
+            return;
+        }
+    };
+
+    let mut group = c.benchmark_group("surrogate_timing");
+    group.sample_size(1000);
+
+    group.bench_function("onnx_inference_6input", |b| {
+        let temps = vec![20.0, 21.0, 22.0, 23.0, 24.0, 25.0];
+        b.iter(|| {
+            let _ = surrogate
+                .predict_loads_onnx(black_box(&temps))
+                .expect("ONNX inference failed");
+        })
+    });
+
+    group.finish();
+}
+
+fn bench_analytical_loads_timing(c: &mut Criterion) {
+    let surrogate = SurrogateManager::new().expect("Failed to create SurrogateManager");
+    let temps = vec![20.0, 21.0, 22.0, 23.0, 24.0, 25.0];
+
+    let mut group = c.benchmark_group("analytical_timing");
+    group.sample_size(1000);
+
+    group.bench_function("analytical_loads_6zones", |b| {
+        b.iter(|| {
+            let _ = surrogate
+                .analytical_loads(black_box(&temps))
+                .expect("Analytical loads failed");
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_surrogate_onnx_single_inference,
+    bench_surrogate_onnx_batched_inference,
+    bench_physics_step_single_zone,
+    bench_physics_step_multi_zone,
+    bench_comparison_8760_timesteps,
+    bench_surrogate_inference_timing,
+    bench_analytical_loads_timing
+);
+criterion_main!(benches);

--- a/docs/SURROGATE_BENCHMARK_RESULTS.md
+++ b/docs/SURROGATE_BENCHMARK_RESULTS.md
@@ -1,0 +1,113 @@
+# Surrogate vs Physics Benchmarking Results
+
+**Issue**: #720 - Perf: Surrogate vs. physics benchmarking
+**Date**: 2026-06-16
+**Benchmark Suite**: `benches/surrogate_vs_physics_bench.rs`
+
+## Benchmark Configuration
+
+- **Hardware**: Standard x86_64 development machine
+- **Rust**: Release mode (`--release`)
+- **ONNX Model**: `assets/dummy_surrogate.onnx` (pass-through model)
+- **Criterion Sample Size**: 1000 samples (timing), 100 samples (batched), 10 samples (8760-step)
+
+## Raw Benchmark Results
+
+### 1. ONNX Surrogate Inference Timing
+
+| Benchmark | Time (µs) | Throughput |
+|-----------|-----------|------------|
+| `surrogate_onnx/single_inference_6zones` | 3.33 - 3.57 | ~1.74 M elem/s |
+| `surrogate_timing/onnx_inference_6input` | 2.59 - 2.62 | ~2.2 M elem/s |
+
+### 2. Batched ONNX Inference
+
+| Batch Size | Time (µs) | Throughput |
+|------------|-----------|------------|
+| 1 | 3.59 - 4.30 | ~1.5 M elem/s |
+| 10 | 5.79 - 7.37 | ~9.1 M elem/s |
+| 100 | 7.51 - 7.63 | ~79 M elem/s |
+
+**Key Finding**: Batch inference amortizes overhead - 100x batch is only ~2x slower than single inference.
+
+### 3. Physics Step Timing (per zone)
+
+| Configuration | Time (ns) | Throughput |
+|--------------|-----------|------------|
+| 1 zone | 328 - 332 | ~3.0 M elem/s |
+| 5 zones | 505 - 510 | ~9.8 M elem/s |
+| 10 zones | 649 - 657 | ~15.3 M elem/s |
+
+### 4. Analytical Loads (fallback path)
+
+| Benchmark | Time (ns) | Throughput |
+|-----------|-----------|------------|
+| `analytical_loads_6zones` | 57.7 - 58.2 | ~99 M elem/s |
+
+### 5. 8760-Timestep Full Simulation (10 zones)
+
+| Mode | Time (ms) |
+|------|-----------|
+| Physics analytical | 6.56 - 6.63 |
+| Physics with surrogate | 6.64 - 6.81 |
+
+## Analysis
+
+### Key Finding: ONNX Overhead vs Physics
+
+The benchmark reveals important insights about the current surrogate implementation:
+
+1. **ONNX inference overhead** (~3 µs per call) is approximately **10x higher** than a single physics `step_physics` call (~330 ns per zone).
+
+2. **Analytical fallback** (~58 ns for 6 zones) is **~50x faster** than ONNX inference.
+
+3. **8760-step simulation**: When no real ONNX model is loaded (mock mode), the surrogate infrastructure adds negligible overhead because the mock fallback (`vec![1.2; temps.len()]`) is extremely fast.
+
+### On the 10-100x Speedup Claim
+
+The README in `examples/packs/surrogate_benchmarking/` claims a "10-100x speedup vs physics simulation." This benchmark verifies:
+
+1. The **surrogate infrastructure** is in place and integrated into the Criterion bench suite.
+
+2. **Without a real ONNX model** (current benchmark conditions), the surrogate adds minimal overhead because the mock fallback is essentially a no-op.
+
+3. **With a real ONNX model**, the speedup would depend on:
+   - The complexity of the physics being replaced (CFD/ray-tracing can be extremely expensive)
+   - The ONNX model complexity and input size
+   - Whether batched inference is used
+
+### Benchmark Coverage
+
+This benchmark suite covers:
+- [x] ONNX surrogate inference timing (single and batched)
+- [x] Physics step timing (single and multi-zone)
+- [x] Analytical fallback timing
+- [x] 8760-timestep full simulation comparison
+- [ ] Real ONNX model vs CFD comparison (requires production surrogate model)
+
+## Recommendations
+
+1. **For accurate speedup verification**: A real production surrogate model (not the dummy pass-through) should be benchmarked against the actual physics it replaces.
+
+2. **For production use**: The batch inference results show significant throughput improvements (79 M elem/s for batch=100), suggesting batched inference should be used when possible.
+
+3. **CI Integration**: This benchmark is now wired into `cargo bench` and can be run in CI. The key metric to track is `surrogate_timing/onnx_inference_6input` which should remain below 10 µs.
+
+## Files
+
+- `benches/surrogate_vs_physics_bench.rs` - Criterion benchmark suite
+- `examples/packs/surrogate_benchmarking/` - Pack with configuration and scripts
+- `src/ai/surrogate.rs` - SurrogateManager implementation
+
+## Running the Benchmarks
+
+```bash
+# Run all surrogate vs physics benchmarks
+cargo bench --bench surrogate_vs_physics
+
+# Run specific benchmark group
+cargo bench --bench surrogate_vs_physics --group surrogate_onnx
+
+# Run with profiling
+cargo bench --bench surrogate_vs_physics --profile-time=10
+```


### PR DESCRIPTION
## Summary

Implements Issue #720 by adding Criterion-backed benchmarks comparing ONNX surrogate inference speed against the physics-based thermal solver.

## Changes

### New Benchmark Suite (benches/surrogate_vs_physics_bench.rs)
- ONNX inference timing: Measures single and batched surrogate inference latency
- Physics step timing: Measures step_physics performance for 1, 5, and 10 zones
- Analytical fallback timing: Measures the baseline analytical path
- 8760-timestep comparison: Full-year simulation comparing analytical vs surrogate paths

### Benchmark Results

| Component | Timing |
|-----------|--------|
| ONNX inference (6 inputs) | ~3 us |
| Physics step (per zone) | ~330 ns |
| Analytical fallback (6 zones) | ~58 ns |
| 8760-step simulation (10 zones) | ~6.6 ms |

### Documentation (docs/SURROGATE_BENCHMARK_RESULTS.md)
- Full benchmark methodology and results
- Analysis of the 10-100x speedup claim
- Recommendations for production use

## Notes

The 10-100x speedup claim refers to surrogates replacing expensive CFD/ray-tracing calculations. The current benchmark uses a dummy pass-through ONNX model to verify infrastructure only. Real speedup measurements require a production surrogate model.

Fixes #720

## Summary by Sourcery

Add a Criterion benchmark suite to compare ONNX surrogate inference performance with the physics-based thermal solver and document benchmark methodology and results.

New Features:
- Introduce a surrogate vs physics Criterion benchmark covering ONNX single and batched inference, physics stepping, analytical fallback, and full-year simulations.

Enhancements:
- Wire the new surrogate vs physics benchmark target into the Cargo bench configuration.

Documentation:
- Document surrogate vs physics benchmark configuration, raw results, analysis, and recommendations in a new SURROGATE_BENCHMARK_RESULTS.md file.