### PR TITLE
fix: resolve #761 — add peak load timestamp to ValidationResult

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -707,6 +707,8 @@ pub struct ValidationResult {
     pub per_program: Option<HashMap<String, ValidationStatus>>,  // Per-program statuses
     pub peak_date: Option<String>, // Date of peak value occurrence (e.g., "Jan 15")
     pub peak_hour: Option<u32>,    // Hour of peak value occurrence (0-23)
+    // Issue #761: ASHRAE 140-2023 Section 8.2.2 - peak timestamp (month, day, hour)
+    pub peak_timestamp: Option<(u32, u32, u32)>,
 }
 ```
 
@@ -724,10 +726,11 @@ pub struct ValidationResult {
 | `per_program` | `Option<HashMap<String, ValidationStatus>>` | Per-program validation statuses |
 | `peak_date` | `Option<String>` | Date of peak value occurrence (e.g., "Jan 15") for peak metrics |
 | `peak_hour` | `Option<u32>` | Hour of peak value occurrence (0-23) for peak metrics |
+| `peak_timestamp` | `Option<(u32, u32, u32)>` | Peak timestamp (month, day, hour) for peak metrics, per ASHRAE 140-2023 Section 8.2.2 |
 
 **ASHRAE 140 Section 8 Compliance:**
 
-The `peak_date` and `peak_hour` fields capture when peak heating or cooling loads occur, supporting ASHRAE 140 Section 8 gap analysis for peak load timestamp validation.
+The `peak_date`, `peak_hour`, and `peak_timestamp` fields capture when peak heating or cooling loads occur, supporting ASHRAE 140 Section 8.2.2 gap analysis for peak load timestamp validation. The `peak_timestamp` field provides the month, day, and hour as a tuple `(month, day, hour)`.
 
 ### Incident Solar Radiation per Surface (Issue #762)
 

--- a/docs/OUTPUT_SCHEMA.md
+++ b/docs/OUTPUT_SCHEMA.md
@@ -219,7 +219,7 @@ pub struct ValidationResult {
     pub percent_error: f64,       // Percent error from reference midpoint
     pub status: ValidationStatus, // PASS or FAIL
     pub per_program: Option<HashMap<String, f64>>,  // Per-program breakdown
-    pub peak_timestamp: Option<DateTime<Utc>>,  // Timestamp of peak value (for peak metrics)
+    pub peak_timestamp: Option<(u32, u32, u32)>,  // Timestamp (month, day, hour) of peak value per ASHRAE 140-2023 Section 8.2.2
 }
 ```
 

--- a/tests/validation_report.rs
+++ b/tests/validation_report.rs
@@ -446,3 +446,74 @@ fn test_benchmark_report_empty_outputs() {
     assert!(!report.to_csv().is_empty());
     assert!(!report.to_markdown().is_empty());
 }
+
+#[test]
+fn test_add_result_with_peak_timestamp() {
+    let mut report = BenchmarkReport::new();
+    // Issue #761: ASHRAE 140-2023 Section 8.2.2 requires peak timestamp tracking
+    report.add_result_with_peak_timestamp(
+        "case_600",
+        MetricType::PeakHeating,
+        12.5,
+        10.0,
+        15.0,
+        Some((1, 15, 8)), // January 15, 8AM
+    );
+    assert_eq!(report.results.len(), 1);
+    let result = &report.results[0];
+    assert_eq!(result.case_id, "case_600");
+    assert!(matches!(result.metric, MetricType::PeakHeating));
+    assert_eq!(result.fluxion_value, 12.5);
+    assert_eq!(result.peak_timestamp, Some((1, 15, 8)));
+}
+
+#[test]
+fn test_add_result_with_peak_timestamp_cooling() {
+    let mut report = BenchmarkReport::new();
+    report.add_result_with_peak_timestamp(
+        "case_900",
+        MetricType::PeakCooling,
+        25.0,
+        20.0,
+        30.0,
+        Some((7, 22, 14)), // July 22, 2PM
+    );
+    assert_eq!(report.results.len(), 1);
+    let result = &report.results[0];
+    assert_eq!(result.peak_timestamp, Some((7, 22, 14)));
+}
+
+#[test]
+fn test_add_result_with_peak_timestamp_none() {
+    let mut report = BenchmarkReport::new();
+    // Non-peak metrics should have None timestamp
+    report.add_result_with_peak_timestamp(
+        "case_600",
+        MetricType::AnnualHeating,
+        50.0,
+        40.0,
+        60.0,
+        None,
+    );
+    assert_eq!(report.results.len(), 1);
+    let result = &report.results[0];
+    assert_eq!(result.peak_timestamp, None);
+}
+
+#[test]
+fn test_validation_result_with_peak_timestamp_serialization() {
+    let mut report = BenchmarkReport::new();
+    report.add_result_with_peak_timestamp(
+        "case_600",
+        MetricType::PeakHeating,
+        12.5,
+        10.0,
+        15.0,
+        Some((3, 20, 10)), // March 20, 10AM
+    );
+    let json = report.to_json();
+    // Verify JSON contains the peak_timestamp field
+    // Tuples serialize as arrays in JSON with values on separate lines
+    assert!(json.contains("peak_timestamp"));
+    assert!(json.contains("\"peak_timestamp\": [\n        3,\n        20,\n        10\n      ]"));
+}


### PR DESCRIPTION
- **[Issue #779] OpenStudio OSM import/export support (#1130)**
- **[Issue #914] Fix adaptive timestep for high-mass construction (#1131)**
- **[Issue #762] Add IncidentSolar metric type for per-surface solar radiation (#1132)**
- **[Issue #731] Replace placeholder thermal conductances with physics-based calculations (#1133)**
- **[Issue #714] Fix ASHRAE 140 simplified 5R1C h_tr_is coefficient (#1134)**
- **fix: resolve #761 — add peak load timestamp to ValidationResult**
