### PR TITLE
fix: resolve #1167 — scorecard generator data source fix

### DIFF
--- a/scripts/generate_scorecard.py
+++ b/scripts/generate_scorecard.py
@@ -4,6 +4,14 @@ Fluxion Release Scorecard Generator
 
 Generates SCORECARD.md with pass rates, benchmark status, and release readiness.
 
+Data sources (in priority order):
+  1. validation_results.json  -- canonical JSON written by the validation suite.
+  2. validation_report.md     -- markdown report; its ``## Summary`` table is parsed.
+
+If neither source is available the generator prints a clear error and exits with
+a non-zero status. It will NOT silently fall back to ``docs/QUALITY_METRICS.md``,
+which is a historical dashboard that can hold stale or corrupt data (issue #1167).
+
 Usage:
     python scripts/generate_scorecard.py
     python scripts/generate_scorecard.py --output SCORECARD.md
@@ -64,6 +72,10 @@ class ScorecardGenerator:
         self.benchmark = BenchmarkMetrics()
         self.tests = TestSummary()
         self.issues = IssueSummary()
+        # Human-readable path of the validation data source actually used.
+        # Remains None when no authoritative source was found, which causes
+        # main() to refuse generating a scorecard (no silent stale fallback).
+        self.validation_source: Optional[str] = None
 
     def log(self, msg: str):
         if self.verbose:
@@ -85,30 +97,165 @@ class ScorecardGenerator:
         except Exception as e:
             return f"Error: {e}", -1
 
+    def _resolve_validation_source(self) -> Optional[Path]:
+        """Return the first available authoritative validation data source.
+
+        Priority:
+          1. ``validation_results.json`` (canonical JSON written by the
+             validation suite).
+          2. ``validation_report.md`` (markdown report; its Summary table is
+             parsed as a fallback).
+
+        ``docs/QUALITY_METRICS.md`` is intentionally **not** consulted. It is a
+        historical dashboard that can hold stale or corrupt values (e.g.
+        ``-inf%`` MAE) and must never be used as a silent fallback. See
+        issue #1167.
+        """
+        json_path = self.project_root / "validation_results.json"
+        if json_path.exists():
+            return json_path
+        md_path = self.project_root / "validation_report.md"
+        if md_path.exists():
+            return md_path
+        return None
+
     def load_validation_results(self) -> bool:
-        results_path = self.project_root / "validation_results.json"
-        if results_path.exists():
-            self.log("Loading validation_results.json")
-            try:
-                with open(results_path) as f:
-                    data = json.load(f)
-                summary = data.get("summary", {})
-                self.validation.total = summary.get("passed", 0) + summary.get(
-                    "failed", 0
-                )
-                self.validation.passed = summary.get("passed", 0)
-                self.validation.failed = summary.get("failed", 0)
-                self.validation.pass_rate = summary.get("pass_rate", 0.0)
-                self.validation.mae = summary.get("mae", 0.0)
-                self.log(
-                    f"Loaded: {self.validation.passed}/{self.validation.total} passed, {self.validation.pass_rate}% pass rate"
-                )
-                return True
-            except (json.JSONDecodeError, IOError) as e:
-                self.log(f"Error loading: {e}")
-        else:
-            self.log("validation_results.json not found")
-        return False
+        """Load validation metrics from the first available authoritative source.
+
+        Returns True when a valid source was loaded, False otherwise. The
+        chosen source path is recorded in ``self.validation_source`` for
+        logging and for the generated scorecard.
+        """
+        source = self._resolve_validation_source()
+        if source is None:
+            self.log("No validation data source found (json or report)")
+            return False
+        if source.suffix == ".json":
+            return self._load_validation_from_json(source)
+        return self._load_validation_from_report(source)
+
+    def _load_validation_from_json(self, json_path: Path) -> bool:
+        self.log(f"Loading validation_results.json from {json_path}")
+        try:
+            with open(json_path) as f:
+                data = json.load(f)
+        except (json.JSONDecodeError, IOError) as e:
+            self.log(f"Error loading {json_path}: {e}")
+            return False
+        summary = data.get("summary", {})
+        self.validation.total = summary.get("passed", 0) + summary.get("failed", 0)
+        self.validation.passed = summary.get("passed", 0)
+        self.validation.failed = summary.get("failed", 0)
+        self.validation.warnings = summary.get("warnings", 0)
+        self.validation.pass_rate = summary.get("pass_rate", 0.0)
+        self.validation.mae = summary.get("mae", 0.0)
+        self.validation.max_deviation = summary.get("max_deviation", 0.0)
+        self.validation_source = str(json_path)
+        self.log(
+            f"Loaded from JSON: {self.validation.passed}/{self.validation.total} "
+            f"passed, {self.validation.pass_rate}% pass rate"
+        )
+        return True
+
+    def _load_validation_from_report(self, report_path: Path) -> bool:
+        """Parse the ``## Summary`` markdown table from validation_report.md."""
+        self.log(f"Loading validation_report.md from {report_path}")
+        try:
+            content = report_path.read_text()
+        except OSError as e:
+            self.log(f"Error reading {report_path}: {e}")
+            return False
+
+        metrics = self._parse_report_summary(content)
+        if not metrics:
+            self.log(f"Could not parse a Summary table from {report_path}")
+            return False
+
+        self.validation.total = int(
+            metrics.get("total", metrics.get("passed", 0) + metrics.get("failed", 0))
+        )
+        self.validation.passed = int(metrics.get("passed", 0))
+        self.validation.failed = int(metrics.get("failed", 0))
+        self.validation.warnings = int(metrics.get("warnings", 0))
+        self.validation.pass_rate = metrics.get("pass_rate", 0.0)
+        self.validation.mae = metrics.get("mae", 0.0)
+        self.validation.max_deviation = metrics.get("max_deviation", 0.0)
+        self.validation_source = str(report_path)
+        self.log(
+            f"Loaded from report: {self.validation.passed}/{self.validation.total} "
+            f"passed, {self.validation.pass_rate}% pass rate, "
+            f"{self.validation.mae}% MAE"
+        )
+        return True
+
+    @staticmethod
+    def _parse_report_summary(content: str) -> dict:
+        """Parse the ``## Summary`` table of ``validation_report.md``.
+
+        Returns a dict with keys: ``total``, ``passed``, ``failed``,
+        ``warnings``, ``pass_rate``, ``mae``, ``max_deviation``. Returns an
+        empty dict if the Summary table cannot be located or parsed.
+        """
+        in_summary = False
+        raw_values: dict = {}
+        for line in content.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("## "):
+                # Entering a new section; only the "Summary" section is parsed.
+                in_summary = stripped.lower().startswith("## summary")
+                continue
+            if not in_summary or not stripped.startswith("|"):
+                continue
+            if set(stripped.replace("|", "").strip()) <= {"-", ":"}:
+                # Skip the markdown table separator row (e.g. |---|---|).
+                continue
+            cells = [c.strip() for c in stripped.strip("|").split("|")]
+            if len(cells) < 2:
+                continue
+            key = cells[0].lower()
+            num = ScorecardGenerator._parse_numeric(cells[1])
+            if num is not None:
+                raw_values[key] = num
+
+        if not raw_values:
+            return {}
+
+        def pick(*keys, default=0.0):
+            for k in keys:
+                if k in raw_values:
+                    return raw_values[k]
+            return default
+
+        return {
+            "total": pick("total results", "total"),
+            "passed": pick("passed"),
+            "failed": pick("failed"),
+            "warnings": pick("warnings"),
+            "pass_rate": pick("pass rate", "pass_rate"),
+            "mae": pick("mean absolute error", "mae"),
+            "max_deviation": pick("max deviation", "max_deviation"),
+        }
+
+    @staticmethod
+    def _parse_numeric(raw: str) -> Optional[float]:
+        """Parse a leading numeric value from a markdown table cell.
+
+        Strips surrounding whitespace, ``%`` signs, thousands separators and
+        trailing unit text (e.g. ``"6.2%"`` -> 6.2, ``"64"`` -> 64.0).
+        Returns None if no number can be extracted.
+        """
+        if raw is None:
+            return None
+        text = raw.replace("%", "").strip()
+        if not text:
+            return None
+        # Take the first whitespace-delimited token so values like
+        # "0 / 18 cases" resolve to the leading number.
+        token = text.split()[0].replace(",", "")
+        try:
+            return float(token)
+        except ValueError:
+            return None
 
     def run_rust_tests(self) -> bool:
         self.log("Running cargo test --release --lib")
@@ -238,41 +385,37 @@ class ScorecardGenerator:
         return False
 
     def load_quality_metrics(self) -> bool:
-        metrics_path = self.project_root / "docs" / "QUALITY_METRICS.md"
-        if metrics_path.exists():
-            self.log("Loading QUALITY_METRICS.md")
-            with open(metrics_path) as f:
-                content = f.read()
+        """Deprecated: QUALITY_METRICS.md is no longer used for validation metrics.
 
-            for line in content.split("\n"):
-                if "Pass Rate:" in line:
-                    try:
-                        rate = line.split("**Pass Rate:**")[1].split("%")[0].strip()
-                        qm_rate = float(rate)
-                        if self.validation.pass_rate == 0.0:
-                            self.validation.pass_rate = qm_rate
-                            self.log(f"Using QUALITY_METRICS pass_rate: {qm_rate}%")
-                        elif qm_rate > self.validation.pass_rate:
-                            self.validation.pass_rate = qm_rate
-                            self.log(
-                                f"Updated to QUALITY_METRICS pass_rate: {qm_rate}%"
-                            )
-                    except (IndexError, ValueError):
-                        pass
-                if "MAE:" in line and self.validation.mae == 0.0:
-                    try:
-                        mae = line.split("**MAE:**")[1].split("%")[0].strip()
-                        self.validation.mae = float(mae)
-                        self.log(f"Using QUALITY_METRICS MAE: {mae}%")
-                    except (IndexError, ValueError):
-                        pass
-            return True
+        Historically this method silently overwrote validation metrics with
+        values from ``docs/QUALITY_METRICS.md``. That file is a historical
+        dashboard and can hold stale or corrupt data (``0.0%`` pass rate,
+        ``-inf%`` MAE), which produced misleading scorecards (issue #1167).
+
+        This stub is retained (unused) to keep the public surface stable and
+        to document *why* the fallback was removed. It always returns False.
+        """
+        self.log(
+            "load_quality_metrics() is deprecated and intentionally unused; "
+            "QUALITY_METRICS.md is not a valid validation data source"
+        )
         return False
 
     def collect_all(self) -> bool:
+        """Resolve data sources and collect all metrics.
+
+        Returns False (and skips the expensive cargo/benchmark steps) when no
+        authoritative validation source is available, so main() can fail fast
+        with a clear error instead of stalling on ``cargo test``.
+        """
         self.log("Collecting all metrics...")
+        # Validation data is loaded from validation_results.json or
+        # validation_report.md. If neither is present, validation_source stays
+        # None and main() refuses to emit a scorecard (no stale fallback).
         self.load_validation_results()
-        self.load_quality_metrics()
+        if self.validation_source is None:
+            self.log("Skipping cargo/benchmark collection: no validation source")
+            return False
         self.run_rust_tests()
         self.estimate_benchmark()
         self.count_issues()
@@ -287,6 +430,14 @@ class ScorecardGenerator:
         )
 
         test_pass_rate = self.tests.pass_rate if self.tests.total > 0 else 99.65
+
+        # Human-readable label + status for the Data Sources section.
+        source_label = (
+            Path(self.validation_source).name
+            if self.validation_source
+            else "(none — no authoritative source)"
+        )
+        validation_status = "parsed" if self.validation_source else "missing"
 
         release_ready = (
             "✅ Ready" if self.validation.pass_rate >= 12.5 else "❌ Not Ready"
@@ -382,17 +533,27 @@ Root cause: Solar gain issues (SOLAR-01, SOLAR-02) and high-mass thermal modelin
 
 ---
 
-## Conflicting Metrics Resolution
+## Data Sources
 
-The following metrics show conflicting trends between different measurement approaches:
+Validation metrics are read from a single authoritative source. The generator
+never falls back to ``QUALITY_METRICS.md`` because that dashboard can hold
+stale or corrupt data (e.g. ``-inf%`` MAE) and previously produced misleading
+scorecards (issue #1167).
 
-| Metric | validation_results.json | QUALITY_METRICS.md | Resolution |
-|--------|-------------------------|-------------------|------------|
-| Case 900 Annual Heating | 1.35 MWh | 1.17-2.04 range | Use validation_results.json as authoritative |
-| High-Mass Pass Rate | 16.7% | 0.0% | Different counting methods - standardization needed |
+| Metric Category | Source | Status |
+|-----------------|--------|--------|
+| ASHRAE 140 Validation | {source_label} | {validation_status} |
+| Unit Tests | `cargo test --lib` | live |
+| Benchmark Throughput | `throughput_benchmark` test | live |
+| Known Issues | docs/KNOWN_ISSUES.md | parsed |
 
-**Action:** Standardize on `validation_results.json` as authoritative source.
-Update `QUALITY_METRICS.md` to use consistent reference data and counting.
+**Validation source used:** `{self.validation_source}`
+
+Source resolution order:
+1. `validation_results.json` (canonical JSON from the validation suite)
+2. `validation_report.md` (parsed ``## Summary`` table)
+
+If neither source is found, generation aborts with a non-zero exit code.
 
 ---
 
@@ -442,6 +603,21 @@ def main():
     generator = ScorecardGenerator(verbose=args.verbose)
     generator.collect_all()
 
+    # Refuse to emit a scorecard when no authoritative validation data was
+    # found. We must NOT silently fall back to stale QUALITY_METRICS.md data
+    # (issue #1167).
+    if generator.validation_source is None:
+        print(
+            "ERROR: No validation data source found.\n"
+            "Expected one of:\n"
+            "  - validation_results.json  (canonical JSON from the validation suite)\n"
+            "  - validation_report.md     (parsed markdown summary)\n"
+            "Refusing to generate SCORECARD.md from stale QUALITY_METRICS.md data.\n"
+            "Run the ASHRAE 140 validation suite to produce a data source.",
+            file=sys.stderr,
+        )
+        return 2
+
     scorecard = generator.generate_scorecard()
 
     output_path = Path(args.output)
@@ -449,6 +625,7 @@ def main():
         f.write(scorecard)
 
     print(f"✓ Scorecard generated: {output_path}")
+    print(f"  - Validation data source: {generator.validation_source}")
     print(f"  - ASHRAE 140 Pass Rate: {generator.validation.pass_rate:.1f}%")
     print(f"  - Test Pass Rate: {generator.tests.pass_rate:.1f}%")
     print(f"  - Benchmark Throughput: {generator.benchmark.throughput:.0f} configs/sec")

--- a/tests/python/test_generate_scorecard.py
+++ b/tests/python/test_generate_scorecard.py
@@ -1,0 +1,262 @@
+"""
+Unit tests for the release scorecard generator (scripts/generate_scorecard.py).
+
+Covers the data-source resolution that was the subject of issue #1167:
+the generator must read authoritative validation data from
+``validation_results.json`` or ``validation_report.md`` and must NEVER silently
+fall back to stale ``QUALITY_METRICS.md`` data (which held ``0.0%`` pass rate
+and ``-inf%`` MAE).
+
+These tests intentionally avoid invoking ``cargo``; they exercise the pure
+parsing / resolution logic and the CLI's error path directly.
+"""
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "generate_scorecard.py"
+
+
+def _load_module():
+    """Load scripts/generate_scorecard.py as an isolated module by path."""
+    spec = importlib.util.spec_from_file_location("generate_scorecard", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def gen_module():
+    return _load_module()
+
+
+# A realistic validation_report.md ## Summary block.
+REPORT_SUMMARY = """\
+# ASHRAE Standard 140 Validation Results
+
+*Generated: 2026-04-14 17:28 UTC*
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Total Results | 64 |
+| Pass Rate | 6.2% |
+| Passed | 4 |
+| Warnings | 2 |
+| Failed | 58 |
+| Mean Absolute Error | 35.35% |
+| Max Deviation | 346.87% |
+
+## Performance Summary
+
+| Metric | Value |
+|--------|-------|
+| Throughput | 8.51 cases/sec |
+"""
+
+# Stale dashboard data that must never be used as a validation source.
+STALE_QUALITY_METRICS = """\
+# Quality Metrics Tracker
+
+## Current Status
+
+- **Pass Rate:** 0.0% (0 / 18 cases)
+- **MAE:** -inf%
+- **Max Deviation:** 156689872.00%
+"""
+
+
+# ---------------------------------------------------------------------------
+# Numeric parser
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "cell, expected",
+    [
+        ("6.2%", 6.2),
+        ("64", 64.0),
+        ("35.35%", 35.35),
+        ("346.87%", 346.87),
+        ("0 / 18 cases", 0.0),
+        ("1,234.5", 1234.5),
+        ("", None),
+        ("n/a", None),
+    ],
+)
+def test_parse_numeric(gen_module, cell, expected):
+    assert gen_module.ScorecardGenerator._parse_numeric(cell) == expected
+
+
+# ---------------------------------------------------------------------------
+# Report summary parser
+# ---------------------------------------------------------------------------
+
+
+def test_parse_report_summary_extracts_all_fields(gen_module):
+    parsed = gen_module.ScorecardGenerator._parse_report_summary(REPORT_SUMMARY)
+    assert parsed == {
+        "total": 64.0,
+        "passed": 4.0,
+        "failed": 58.0,
+        "warnings": 2.0,
+        "pass_rate": 6.2,
+        "mae": 35.35,
+        "max_deviation": 346.87,
+    }
+
+
+def test_parse_report_summary_only_reads_summary_section(gen_module):
+    # "Throughput" lives under a different heading and must be ignored.
+    parsed = gen_module.ScorecardGenerator._parse_report_summary(REPORT_SUMMARY)
+    assert "throughput" not in parsed
+
+
+def test_parse_report_summary_empty_when_no_table(gen_module):
+    assert gen_module.ScorecardGenerator._parse_report_summary("# Title\n\nbody") == {}
+
+
+# ---------------------------------------------------------------------------
+# Source resolution & loading
+# ---------------------------------------------------------------------------
+
+
+def test_load_from_report(gen_module, tmp_path):
+    (tmp_path / "validation_report.md").write_text(REPORT_SUMMARY)
+    g = gen_module.ScorecardGenerator(project_root=tmp_path)
+    assert g.load_validation_results() is True
+    assert g.validation_source.endswith("validation_report.md")
+    assert g.validation.pass_rate == pytest.approx(6.2)
+    assert g.validation.mae == pytest.approx(35.35)
+    assert g.validation.max_deviation == pytest.approx(346.87)
+    assert g.validation.total == 64
+    assert g.validation.passed == 4
+    assert g.validation.failed == 58
+    assert g.validation.warnings == 2
+
+
+def test_load_from_json(gen_module, tmp_path):
+    (tmp_path / "validation_results.json").write_text(
+        json.dumps(
+            {
+                "summary": {
+                    "passed": 10,
+                    "failed": 2,
+                    "warnings": 1,
+                    "pass_rate": 83.3,
+                    "mae": 12.5,
+                    "max_deviation": 40.0,
+                }
+            }
+        )
+    )
+    g = gen_module.ScorecardGenerator(project_root=tmp_path)
+    assert g.load_validation_results() is True
+    assert g.validation_source.endswith("validation_results.json")
+    assert g.validation.pass_rate == pytest.approx(83.3)
+    assert g.validation.mae == pytest.approx(12.5)
+    assert g.validation.total == 12
+    assert g.validation.passed == 10
+
+
+def test_json_preferred_over_report(gen_module, tmp_path):
+    (tmp_path / "validation_results.json").write_text(
+        json.dumps({"summary": {"passed": 7, "failed": 3, "pass_rate": 70.0, "mae": 5.0}})
+    )
+    (tmp_path / "validation_report.md").write_text(REPORT_SUMMARY)
+    g = gen_module.ScorecardGenerator(project_root=tmp_path)
+    assert g.load_validation_results() is True
+    # JSON is canonical; its values win over the markdown report.
+    assert g.validation_source.endswith("validation_results.json")
+    assert g.validation.pass_rate == pytest.approx(70.0)
+
+
+def test_no_source_returns_false(gen_module, tmp_path):
+    g = gen_module.ScorecardGenerator(project_root=tmp_path)
+    assert g.load_validation_results() is False
+    assert g.validation_source is None
+
+
+def test_no_silent_fallback_to_quality_metrics(gen_module, tmp_path):
+    """A stale QUALITY_METRICS.md must never be used as a validation source."""
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "QUALITY_METRICS.md").write_text(STALE_QUALITY_METRICS)
+    g = gen_module.ScorecardGenerator(project_root=tmp_path)
+    assert g.load_validation_results() is False
+    assert g.validation_source is None
+    # Metrics remain at their defaults — NOT the stale -inf / 0.0% values.
+    assert g.validation.mae == 0.0
+    assert g.validation.pass_rate == 0.0
+
+
+def test_load_quality_metrics_is_deprecated_and_unused(gen_module, tmp_path):
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "QUALITY_METRICS.md").write_text(STALE_QUALITY_METRICS)
+    g = gen_module.ScorecardGenerator(project_root=tmp_path)
+    assert g.load_quality_metrics() is False
+    # Even after calling it directly, validation metrics are untouched.
+    assert g.validation.mae == 0.0
+    assert g.validation.pass_rate == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Scorecard output
+# ---------------------------------------------------------------------------
+
+
+def test_generate_scorecard_embeds_real_metrics(gen_module, tmp_path):
+    (tmp_path / "validation_report.md").write_text(REPORT_SUMMARY)
+    g = gen_module.ScorecardGenerator(project_root=tmp_path)
+    g.load_validation_results()
+    out = g.generate_scorecard()
+    assert "6.2%" in out            # pass rate from report
+    assert "35.35%" in out          # MAE from report
+    assert "validation_report.md" in out  # data source is documented
+    # The headline MAE metric must show the real value, never the stale -inf%.
+    mae_line = next(l for l in out.splitlines() if "Mean Absolute Error" in l)
+    assert "35.35%" in mae_line
+    assert "-inf%" not in mae_line
+    # The pass-rate headline must be the real 6.2%, not the stale 0.0%.
+    pass_line = next(l for l in out.splitlines() if "ASHRAE 140 Pass Rate" in l)
+    assert "6.2%" in pass_line
+    assert "(0/0)" not in pass_line
+
+
+# ---------------------------------------------------------------------------
+# CLI error path (end-to-end)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_exits_nonzero_when_no_source(tmp_path):
+    """When no data source exists the CLI must error out, not emit stale data."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--output", str(tmp_path / "out.md")],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode != 0
+    assert "No validation data source found" in result.stderr
+    assert "QUALITY_METRICS" in result.stderr
+    # No scorecard should have been written.
+    assert not (tmp_path / "out.md").exists()
+
+
+def test_collect_all_fails_fast_without_cargo(gen_module, tmp_path, monkeypatch):
+    """With no validation source, collect_all must short-circuit before cargo."""
+    g = gen_module.ScorecardGenerator(project_root=tmp_path)
+
+    def _boom(*_args, **_kwargs):
+        pytest.fail("run_rust_tests() must not run when no validation source")
+
+    monkeypatch.setattr(g, "run_rust_tests", _boom)
+    monkeypatch.setattr(g, "estimate_benchmark", _boom)
+    assert g.collect_all() is False
+    assert g.validation_source is None


### PR DESCRIPTION
## Problem

`scripts/generate_scorecard.py` silently fell back to stale `docs/QUALITY_METRICS.md` data (showing `0.0%` pass rate and `-inf%` MAE) when `validation_results.json` was missing, producing misleading `SCORECARD.md` output. `validation_results.json` does not exist anywhere in the repo, so every generation was using corrupt fallback values.

Closes #1167.

## Approach

Reworked data-source resolution to be explicit and fail-safe:

1. **Authoritative sources only** — The generator now resolves validation data from, in priority order:
   - `validation_results.json` (canonical JSON from the validation suite)
   - `validation_report.md` (markdown report; its `## Summary` table is parsed)

2. **No silent fallback** — `docs/QUALITY_METRICS.md` is intentionally **never** consulted for validation metrics. `load_quality_metrics()` is now a deprecated no-op stub that documents why the fallback was removed.

3. **Clear errors + non-zero exit** — When no valid source is found, the CLI prints a clear error to stderr and exits with code `2`. No scorecard is written.

4. **Fail-fast** — `collect_all()` skips the expensive `cargo`/benchmark steps when no validation source is present, so CI fails immediately instead of stalling.

5. **Documented sources** — The generated scorecard includes a "Data Sources" section naming the source actually used, and the CLI logs it (`Validation data source: ...`).

## Files changed

- `scripts/generate_scorecard.py` — new `_resolve_validation_source`, `_load_validation_from_json`, `_load_validation_from_report`, `_parse_report_summary`, `_parse_numeric`; removed stale `QUALITY_METRICS.md` fallback; fail-fast `collect_all`; clear-error exit-2 path in `main()`; "Data Sources" scorecard section; updated module docstring.
- `tests/python/test_generate_scorecard.py` — **new** (20 tests): numeric parser, markdown summary parser, JSON loading, JSON-over-report priority, no-source resolution, no-silent-fallback-to-QUALITY_METRICS, deprecated-stub behavior, scorecard metric embedding, CLI error path (exit 2), and fail-fast (no cargo) verification.

## Verification

Parsing the real `validation_report.md` yields correct metrics (no stale values):
- Pass Rate `6.2%`, MAE `35.35%`, Max Deviation `346.87%`, Total `64`, Passed `4`, Failed `58`, Warnings `2` (previously `0.0%` / `-inf%`).

```
$ pytest tests/python/test_generate_scorecard.py -v
20 passed

$ cd <empty-dir> && python3 scripts/generate_scorecard.py --output SCORECARD.md
ERROR: No validation data source found.
...
Refusing to generate SCORECARD.md from stale QUALITY_METRICS.md data.
EXIT_CODE=2   # no file written, cargo skipped (fail-fast)
```

## Acceptance criteria

- [x] `generate_scorecard.py` produces correct metrics from current validation data
- [x] No silent fallback to stale data
- [x] Missing data sources produce clear error messages
- [x] SCORECARD.md generation works in CI without manual intervention (auto-parses `validation_report.md`)