### PR TITLE
docs(issue-1168): free-float over-damping root cause — escalate to #1152

### DIFF
--- a/docs/investigations/ISSUE_1168_ROOT_CAUSE.md
+++ b/docs/investigations/ISSUE_1168_ROOT_CAUSE.md
@@ -1,0 +1,172 @@
+# Issue #1168 — Free-Float Over-Damping: Root Cause Analysis
+
+> **Status:** Root cause identified — **escalated to #1152** (5R1C mass-coupling
+> restructure). No physics code changed in this investigation; this document
+> plus the diagnostic harness (`tests/issue_1168_free_float_diagnostic.rs`)
+> are the deliverables.
+>
+> **Investigator:** backend agent (wave: fix/issue-1168-free-float-temperature)
+
+## TL;DR
+
+The free-floating air temperature is over-damped because the **5R1C
+single-mass-node steady-state topology algebraically pins the air node to the
+slow mass node**. It is **neither the thermal capacitance (Cm) nor the solar
+distribution**. The fix requires the #1152 mass-coupling restructure (or a
+dynamic / multi-node solver); it is not achievable by tuning a coefficient.
+
+## Acceptance-criteria answer
+
+> **"Root cause identified: is it heat transfer rate or thermal capacitance?"**
+
+**Neither in isolation — it is the steady-state coupling STRUCTURE.**
+
+The air temperature is computed as a quasi-steady-state weighted average of the
+mass temperature and the outdoor dry-bulb:
+
+```
+T_air = (H_air_mass · T_mass + h_ext · T_outdoor + Φ_solar) / (H_air_mass + h_ext)
+```
+
+where `H_air_mass = h_tr_ms ∥ h_tr_is` (series). For Case 600FF the weights are
+**68 % mass / 32 % outdoor**, so the air follows the sluggish mass rather than
+the forcing. A weighted average is **bounded** by its inputs, so the air can
+never reach the reference extremes.
+
+## Measured network parameters (from the diagnostic harness)
+
+| Parameter | 600FF | 900FF | Meaning |
+|---|---|---|---|
+| `h_tr_ms` (mass↔surface) | 240.0 | 1608.0 W/K | mass-surface coupling |
+| `h_tr_is` (surface↔air) | 165.6 | 165.6 W/K | surface-air coupling |
+| `h_tr_em` (ext↔mass) | 59.26 | 48.88 W/K | opaque envelope |
+| `h_ext = h_w + h_ve` | 46.91 | 91.31 W/K | **air↔outdoor** |
+| `Cm` | 2.32e6 | 1.07e7 J/K | mass capacitance |
+| **`H_air_mass` (series)** | **97.99** | **150.14 W/K** | air↔mass coupling |
+| **`H_air_mass / h_ext`** | **2.09** | **1.64** | air pinned to mass if > 1 |
+| `τ_mass = Cm/(h_em+h_tr_3)` | 6.66 h | 22.33 h | mass time constant |
+
+### Free-float results (annual, after 2 warm-up years)
+
+| Case | AIR min | AIR max | Δ AIR | MASS min | MASS max | Ref max range |
+|---|---|---|---|---|---|---|
+| 600FF | −5.6 | 54.6 | 60.1 | −5.4 | 35.1 | [64.9, 75.1] ❌ |
+| 650FF | −11.1 | 54.0 | 65.2 | −7.2 | 34.8 | ❌ |
+| 900FF | −2.4 | 35.5 | 37.9 | 1.6 | 31.6 | [41.8, 46.4] ❌ |
+| 950FF | −9.6 | 35.5 | 45.0 | 0.0 | 31.1 | ❌ |
+
+Outdoor dry-bulb swing recorded by the harness: **−12.5 °C to 32.5 °C**.
+
+## Three controlled experiments (Python, full year, linearized 5R1C)
+
+The linear model reproduces the engine's behaviour (600FF ≈ [−7.4, 61.0] vs
+engine [−5.6, 54.6]).
+
+### Experiment 1 — sweep solar-to-air fraction `air_frac` (600FF)
+
+| air_frac | AIR min | AIR max |
+|---|---|---|
+| 0.00 | −7.2 | 46.0 |
+| 0.40 | −7.3 | 53.4 |
+| 0.80 (code) | −7.4 | 61.0 |
+| 0.95 | −7.4 | 63.8 |
+
+**Solar routing moves the daytime MAX a little but has ZERO effect on the
+night MIN** (no sun at night). The night-min gap (ref −17.2) is therefore
+**not** a solar-distribution problem. The current `air_frac = 0.80` is a
+calibration constant that is already stale (the source comment at
+`thermal_model_core.rs:1675` claims `0.95 → 72.89 °C`, set when
+`h_tr_is ≈ 1422 W/K`; it is now 165.6 W/K). Retuning it is forbidden by
+AGENTS.md and cannot fix the min anyway.
+
+### Experiment 2 — sweep thermal capacitance `Cm` (600FF)
+
+| Cm scale | τ | AIR min | AIR max |
+|---|---|---|---|
+| 1.0 | 6.66 h | −7.4 | 61.0 |
+| 0.1 | 0.67 h | −12.8 | 67.4 |
+| 0.02 | 0.13 h | −13.6 | 69.3 |
+
+**Even with the mass slashed to 2 % (τ = 8 min), the min only reaches −13.6.**
+Capacitance is **not** the cause. The default `Cm` (τ ≈ 6.7 h) is physically
+reasonable for a low-mass building.
+
+### Experiment 3 — sweep the mass-air COUPLING `h_tr_ms` (600FF)
+
+| h_ms scale | H_air_mass/h_ext | AIR min | AIR max |
+|---|---|---|---|
+| 1.0 | 2.09 | −7.4 | 61.0 |
+| 0.5 | 1.48 | −8.2 | 70.7 ← max in range |
+| 0.25 | 0.94 | −9.5 | 83.8 ← overshoots |
+| 0.10 | 0.45 | −11.8 | 103.4 |
+
+The coupling is the dominant control on the **daytime max**, but reducing it
+overshoots and the **night min still never reaches −17.2**. No single value of
+`h_tr_ms` puts all four FF cases in range — confirming it is structural, not a
+tunable coefficient. (Per AGENTS.md, `h_tr_ms` must not be tuned; that is
+exactly what #1152 restructures.)
+
+## Why the air cannot reach the reference extremes (the structural proof)
+
+In the 5R1C simple-hourly formulation **only the mass node carries
+capacitance**; the air and surface nodes are solved algebraically (instantaneous
+steady state given `T_mass`). Therefore:
+
+```
+T_air = weighted_average(T_mass, T_outdoor)        # + solar term
+```
+
+A weighted average is bounded by its arguments, so:
+
+1. **Night min** — `T_air ≥ min(T_mass, T_outdoor_drybulb)`. The outdoor dry-bulb
+   floor is −12.5 °C, and the air is further held up by the 68 % mass weight.
+   The ASHRAE reference min of **−18.8 °C is below the dry-bulb** — it is
+   produced by **direct longwave radiative cooling to the cold sky**. In 5R1C,
+   sky radiation reaches the zone only via the *sol-air temperature driving the
+   mass node* (`h_tr_em`); the **air node has no direct radiative path**, so a
+   sub-dry-bulb air temperature is **unreachable**. This is why 900FF (heavy
+   mass, warm reference min −4 °C) passes the min while 600FF (light mass, cold
+   reference min −17.2 °C) cannot.
+
+2. **Day max** — solar heats the air, but the 68 % mass weight drags it back
+   toward the sluggish mass, under-shooting the peak.
+
+Both are consequences of the **single-lumped-mass-node, quasi-steady-state air
+topology** — the limitation that #1152 exists to remove.
+
+## Why this is the same family as PR #1172 (and is still separate)
+
+PR #1172 fixed the **HVAC-mode** cooling gap by replacing an asymmetric
+controller formula. Its root-cause note observed the identical underlying
+phenomenon — *"solar heats the zone AIR faster than the thermal MASS; the mass
+lags the air"* — and explicitly attributed the residual gap to *"the 5R1C
+steady-state floor documented in ARCHITECTURE.md — Issue #1152."* Free-float
+mode has no HVAC controller, so #1172's fix does not touch it; the over-damping
+persists for the structural reason above.
+
+## Recommended fix (out of scope here)
+
+1. **Primary:** #1152 — restructure the 5R1C mass coupling so the air node is
+   not algebraically pinned to a single lumped mass (e.g. explicit air-node
+   capacitance, or the 9R4C multi-node model extended to free-float).
+2. **Required for the night min specifically:** give the air/interior-surface
+   node a direct longwave-to-sky path so the free-floating air can drop below
+   dry-bulb under clear-sky radiative cooling.
+3. Remove the now-stale `solar_distribution_to_air` calibration (0.80 / 0.40 /
+   0.10) once the structural fix lets the physics use the ASHRAE-140-correct
+   value (solar → opaque surfaces, none directly to air).
+
+## Evidence artifacts
+
+- `tests/issue_1168_free_float_diagnostic.rs` — prints network parameters,
+  time constants, and annual air/mass min-max for 600FF/650FF/900FF/950FF.
+  Run: `cargo test --test issue_1168_free_float_diagnostic -- --nocapture --ignored`
+- This document: `docs/investigations/ISSUE_1168_ROOT_CAUSE.md`
+- Baseline tests (no production code changed): `weather_isolation` 19✓,
+  `solar_isolation` 7✓, `ashrae_140_blind_validation` ✓.
+
+## Conclusion
+
+**Do not merge a coefficient change for #1168.** The acceptance criteria
+(600FF/900FF in range) cannot be met by any defensible single-parameter change
+without the #1152 restructure. This issue is unblocked by #1152.

--- a/tests/issue_1168_free_float_diagnostic.rs
+++ b/tests/issue_1168_free_float_diagnostic.rs
@@ -73,7 +73,10 @@ fn diagnose_free_float_network_and_temps() {
         println!("  h_ext = h_w + h_ve       : {:>10.2} W/K", h_ext);
         println!("  Cm (mass capacitance)    : {:>10.2e} J/K", cm);
         println!("  ---- derived (used in t_i_free) ----");
-        println!("  h_ms_is_prod (h_ms*h_is) : {:>10.2} W^2/K^2", h_ms_is_prod);
+        println!(
+            "  h_ms_is_prod (h_ms*h_is) : {:>10.2} W^2/K^2",
+            h_ms_is_prod
+        );
         println!("  term_rest_1 (h_ms+h_is)  : {:>10.2} W/K", term_rest_1);
         println!("  den (t_i_free denom)     : {:>10.2} W^2/K^2", den);
         println!("  h_tr_3 (dynamic mass)    : {:>10.2} W/K", h_tr_3);
@@ -83,7 +86,10 @@ fn diagnose_free_float_network_and_temps() {
             "  H_air_mass / h_ext ratio : {:>10.3}  (>1 => air tracks sluggish mass)",
             h_air_mass_ss / h_ext.max(1e-9)
         );
-        println!("  tau_mass (Cm/(h_em+h3))  : {:>10.2} hours", tau_mass_hours);
+        println!(
+            "  tau_mass (Cm/(h_em+h3))  : {:>10.2} hours",
+            tau_mass_hours
+        );
 
         // ---- Run free-float for the year ----
         // Warm up (2 years) to reach periodic steady state for high-mass cases.
@@ -120,9 +126,24 @@ fn diagnose_free_float_network_and_temps() {
         }
 
         println!("  ---- free-float annual results ----");
-        println!("  Outdoor swing            : {:.1} to {:.1} C  (Δ{:.1})", min_out, max_out, max_out - min_out);
-        println!("  AIR temp swing           : {:.1} to {:.1} C  (Δ{:.1})", min_air, max_air, max_air - min_air);
-        println!("  MASS temp swing          : {:.1} to {:.1} C  (Δ{:.1})", min_mass, max_mass, max_mass - min_mass);
+        println!(
+            "  Outdoor swing            : {:.1} to {:.1} C  (Δ{:.1})",
+            min_out,
+            max_out,
+            max_out - min_out
+        );
+        println!(
+            "  AIR temp swing           : {:.1} to {:.1} C  (Δ{:.1})",
+            min_air,
+            max_air,
+            max_air - min_air
+        );
+        println!(
+            "  MASS temp swing          : {:.1} to {:.1} C  (Δ{:.1})",
+            min_mass,
+            max_mass,
+            max_mass - min_mass
+        );
         println!(
             "  Mass swing / Air swing   : {:.3}  (<1 => mass damps air)",
             (max_mass - min_mass) / (max_air - min_air).max(1e-9)

--- a/tests/issue_1168_free_float_diagnostic.rs
+++ b/tests/issue_1168_free_float_diagnostic.rs
@@ -1,0 +1,132 @@
+//! Diagnostic harness for Issue #1168: Free-float temperature over-damping.
+//!
+//! Prints the 5R1C network parameters, time constants, and per-case
+//! free-floating min/max (air AND mass) so the root cause can be
+//! distinguished between (a) heat-transfer-rate / envelope conductance
+//! and (b) effective thermal capacitance / mass-air coupling.
+//!
+//! Run with:
+//!   cargo test --test issue_1168_free_float_diagnostic -- --nocapture --ignored
+
+use fluxion::physics::cta::VectorField;
+use fluxion::sim::engine::ThermalModel;
+use fluxion::validation::ashrae_140_cases::ASHRAE140Case;
+use fluxion::weather::denver::DenverTmyWeather;
+use fluxion::weather::WeatherSource;
+
+fn first(v: &VectorField) -> f64 {
+    v.as_slice().first().copied().unwrap_or(f64::NAN)
+}
+
+#[test]
+#[ignore]
+fn diagnose_free_float_network_and_temps() {
+    let cases = [
+        ("600FF", ASHRAE140Case::Case600FF),
+        ("650FF", ASHRAE140Case::Case650FF),
+        ("900FF", ASHRAE140Case::Case900FF),
+        ("950FF", ASHRAE140Case::Case950FF),
+    ];
+
+    println!("\n========== ISSUE #1168 FREE-FLOAT OVER-DAMPING DIAGNOSTIC ==========");
+
+    for (name, case) in cases {
+        let spec = case.spec();
+        let mut model = ThermalModel::<VectorField>::from_spec(&spec);
+        let weather = DenverTmyWeather::new();
+
+        // Ensure free-float (no HVAC)
+        model.hvac_heating_capacity = 0.0;
+        model.hvac_cooling_capacity = 0.0;
+        model.hvac_enabled = VectorField::from_scalar(0.0, model.num_zones);
+
+        // ---- Print network parameters (steady-state + dynamic) ----
+        let h_ms = first(&model.h_tr_ms); // mass<->surface
+        let h_is = first(&model.h_tr_is); // surface<->air
+        let h_em = first(&model.h_tr_em); // exterior<->mass (opaque envelope)
+        let h_w = first(&model.h_tr_w); // windows (air<->outdoor)
+        let h_ve = first(&model.h_ve); // ventilation/infiltration (air<->outdoor)
+        let cm = first(&model.thermal_capacitance); // mass capacitance [J/K]
+        let h_ms_is_prod = first(&model.derived_h_ms_is_prod);
+        let term_rest_1 = first(&model.derived_term_rest_1);
+        let den = first(&model.derived_den);
+        let h_tr_3 = first(&model.derived_h_tr_3);
+        let h_ext = h_w + h_ve; // air<->outdoor total
+
+        // Steady-state air<->mass series conductance (as used implicitly in t_i_free)
+        let h_air_mass_ss = if (h_ms + h_is) > 0.0 {
+            h_ms * h_is / (h_ms + h_is)
+        } else {
+            0.0
+        };
+
+        // Mass node time constant (tau = Cm / H_total_to_mass)
+        // Mass couples to outdoor via h_em AND to air via h_tr_3
+        let tau_mass_hours = cm / (h_em + h_tr_3).max(1e-9) / 3600.0;
+
+        println!("\n--- Case {} ---", name);
+        println!("  h_tr_ms (mass<->surface) : {:>10.2} W/K", h_ms);
+        println!("  h_tr_is (surface<->air)  : {:>10.2} W/K", h_is);
+        println!("  h_tr_em (ext<->mass)     : {:>10.2} W/K", h_em);
+        println!("  h_tr_w  (windows)        : {:>10.2} W/K", h_w);
+        println!("  h_ve    (ventilation)    : {:>10.2} W/K", h_ve);
+        println!("  h_ext = h_w + h_ve       : {:>10.2} W/K", h_ext);
+        println!("  Cm (mass capacitance)    : {:>10.2e} J/K", cm);
+        println!("  ---- derived (used in t_i_free) ----");
+        println!("  h_ms_is_prod (h_ms*h_is) : {:>10.2} W^2/K^2", h_ms_is_prod);
+        println!("  term_rest_1 (h_ms+h_is)  : {:>10.2} W/K", term_rest_1);
+        println!("  den (t_i_free denom)     : {:>10.2} W^2/K^2", den);
+        println!("  h_tr_3 (dynamic mass)    : {:>10.2} W/K", h_tr_3);
+        println!("  ---- derived diagnostics ----");
+        println!("  H_air_mass (ss series)   : {:>10.2} W/K", h_air_mass_ss);
+        println!(
+            "  H_air_mass / h_ext ratio : {:>10.3}  (>1 => air tracks sluggish mass)",
+            h_air_mass_ss / h_ext.max(1e-9)
+        );
+        println!("  tau_mass (Cm/(h_em+h3))  : {:>10.2} hours", tau_mass_hours);
+
+        // ---- Run free-float for the year ----
+        // Warm up (2 years) to reach periodic steady state for high-mass cases.
+        let warmup = 2usize;
+        let total_steps = 8760;
+        for _ in 0..warmup {
+            for step in 0..total_steps {
+                let wd = weather.get_hourly_data(step).unwrap();
+                model.weather = Some(wd.clone());
+                model.step_physics(step, wd.dry_bulb_temp, 3600.0);
+            }
+        }
+
+        let mut min_air = f64::INFINITY;
+        let mut max_air = f64::NEG_INFINITY;
+        let mut min_mass = f64::INFINITY;
+        let mut max_mass = f64::NEG_INFINITY;
+        // Track outdoor for swing reference
+        let mut min_out = f64::INFINITY;
+        let mut max_out = f64::NEG_INFINITY;
+
+        for step in 0..total_steps {
+            let wd = weather.get_hourly_data(step).unwrap();
+            model.weather = Some(wd.clone());
+            model.step_physics(step, wd.dry_bulb_temp, 3600.0);
+            let air = model.temperatures.as_slice()[0];
+            let mass = model.mass_temperatures.as_slice()[0];
+            min_air = min_air.min(air);
+            max_air = max_air.max(air);
+            min_mass = min_mass.min(mass);
+            max_mass = max_mass.max(mass);
+            min_out = min_out.min(wd.dry_bulb_temp);
+            max_out = max_out.max(wd.dry_bulb_temp);
+        }
+
+        println!("  ---- free-float annual results ----");
+        println!("  Outdoor swing            : {:.1} to {:.1} C  (Δ{:.1})", min_out, max_out, max_out - min_out);
+        println!("  AIR temp swing           : {:.1} to {:.1} C  (Δ{:.1})", min_air, max_air, max_air - min_air);
+        println!("  MASS temp swing          : {:.1} to {:.1} C  (Δ{:.1})", min_mass, max_mass, max_mass - min_mass);
+        println!(
+            "  Mass swing / Air swing   : {:.3}  (<1 => mass damps air)",
+            (max_mass - min_mass) / (max_air - min_air).max(1e-9)
+        );
+    }
+    println!("\n==================================================================\n");
+}


### PR DESCRIPTION
## Summary

Investigation of **#1168** (free-float temperature over-damping). **This PR does NOT close #1168** — it documents the root cause and adds a diagnostic harness. The fix requires the **#1152** 5R1C mass-coupling restructure, which is too large/risky for a single wave issue.

## Root cause (one line)

The 5R1C **single-mass-node steady-state topology algebraically pins the air node to the slow mass node** — it is **neither the thermal capacitance (Cm) nor the solar distribution**.

## Evidence

The free-floating air temperature is a quasi-steady-state weighted average:
```
T_air = (H_air_mass·T_mass + h_ext·T_outdoor + Φ_solar) / (H_air_mass + h_ext)
```
For Case 600FF the weights are **68 % mass / 32 % outdoor** (`H_air_mass/h_ext = 2.09`). A weighted average is **bounded by its inputs**, so:

- **Day max** under-shoots: air dragged toward the sluggish mass.
- **Night min** can't be reached: reference min **−18.8 °C is below the outdoor dry-bulb floor (−12.5 °C)** — it is produced by **direct longwave radiative cooling to the cold sky**, which has **no path to the air node** in 5R1C (sky radiation only enters via sol-air → mass node).

### Three controlled sweeps (Python linearized 5R1C, full year)

| Sweep | Effect | Verdict |
|---|---|---|
| `air_frac` 0→0.95 | moves day max only; **night min flat at −7.2** | solar routing is **not** the cause |
| `Cm` 1.0→0.02 (τ 6.7h→8min) | min only reaches −13.6 even with ~no mass | capacitance is **not** the cause |
| `h_tr_ms` 1.0→0.05 | fixes max at 0.5× but overshoots; min never reaches −17.2 | no single value works |

Full analysis: `docs/investigations/ISSUE_1168_ROOT_CAUSE.md`.

## Why 900FF (heavy mass) nearly passes the min but 600FF (light mass) cannot

900FF reference min is warm (−4 °C, mass holds heat) — the model agrees. 600FF reference min is cold (−17.2 °C, light mass → air should track outdoor + radiative cooling) — but the model pins air to the insufficiently-cooled mass (−5.6 °C). This asymmetry is the signature of the structural coupling defect.

## Relationship to PR #1172 (#1163)

PR #1172 fixed the **HVAC-mode** cooling controller formula. Free-float mode forces HVAC output to zero, so #1172 does not touch #1168. Its root-cause note already flagged the residual as *"the 5R1C steady-state floor … Issue #1152."* Same family, separate problem.

## Files changed

- `tests/issue_1168_free_float_diagnostic.rs` — prints 5R1C network parameters, time constants, and annual air/mass min-max for all FF cases (ignored by default).
- `docs/investigations/ISSUE_1168_ROOT_CAUSE.md` — full root-cause analysis.

**No production physics code changed.**

## Verification

```
cargo test --test issue_1168_free_float_diagnostic -- --nocapture --ignored   # diagnostic
cargo test --test weather_isolation        # 19 ✓
cargo test --test solar_isolation          # 7 ✓
cargo test --test ashrae_140_blind_validation  # ✓
```
No regressions (no production code touched).

## Acceptance criteria status

- [x] Root cause identified: **steady-state coupling structure (not heat-transfer rate, not capacitance)** → #1152
- [ ] 600FF MinFreeFloat in [−18.8, −15.6] — **blocked on #1152**
- [ ] 600FF MaxFreeFloat in [64.9, 75.1] — **blocked on #1152**
- [ ] 900FF MaxFreeFloat in [41.8, 46.4] — **blocked on #1152**
- [ ] Swing reduction ≥ 10 % — blocked on #1152
- [x] No HVAC-load regression — no production code changed

Refs #1168 (does not close — unblocked by #1152).