### PR TITLE
feat(campaign): Cloud-hosted campaign manager with Direct-to-S3 (fixes #1192)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,28 @@ CARGO_REGISTRY_TOKEN=your_crates_io_token_here
 
 # PyPI API token for Python package publishing (optional)
 PYPI_TOKEN=your_pypi_token_here
+
+# ---------------------------------------------------------------------------
+# AWS Configuration (for Cloud Campaign Manager)
+# ---------------------------------------------------------------------------
+# AWS credentials for S3/SNS operations
+AWS_ACCESS_KEY_ID=your_aws_access_key_id
+AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key
+AWS_SESSION_TOKEN=your_aws_session_token  # Optional, for temporary credentials
+AWS_REGION=us-east-1
+
+# S3 bucket for campaign data
+FLUXION_S3_BUCKET=fluxion-campaigns
+
+# S3 prefix for campaign data (without leading/trailing slashes)
+FLUXION_S3_PREFIX=fluxion-campaigns
+
+# SNS topic ARN for campaign notifications
+# Format: arn:aws:sns:region:account-id:topic-name
+FLUXION_SNS_TOPIC_ARN=arn:aws:sns:us-east-1:123456789:fluxion-campaign-notifications
+
+# DynamoDB table for campaign state (optional - S3 fallback is used if not set)
+FLUXION_CAMPAIGN_TABLE=fluxion-campaigns
+
+# Lambda function name for result aggregation (optional)
+FLUXION_AGGREGATOR_FUNCTION=fluxion-aggregator

--- a/.github/workflows/cloud_campaign.yml
+++ b/.github/workflows/cloud_campaign.yml
@@ -1,0 +1,140 @@
+name: Cloud Campaign Runner
+
+on:
+  workflow_dispatch:
+    inputs:
+      campaign_type:
+        description: 'Campaign type'
+        required: true
+        default: 'ashrae_sweep'
+        type: choice
+        options:
+          - ashrae_sweep
+          - monte_carlo
+          - sensitivity_analysis
+      case_id:
+        description: 'ASHRAE case ID'
+        required: true
+        default: '600'
+      params:
+        description: 'Comma-separated parameters to sweep'
+        required: false
+        default: 'R_value,wall_thickness'
+      sweep_type:
+        description: 'Sweep type'
+        required: true
+        default: 'random'
+        type: choice
+        options:
+          - random
+          - grid
+          - latin_hypercube
+      samples:
+        description: 'Number of samples'
+        required: false
+        default: '50'
+      s3_bucket:
+        description: 'S3 bucket for campaign data'
+        required: true
+      s3_prefix:
+        description: 'S3 prefix'
+        required: false
+        default: 'fluxion-campaigns'
+      sns_topic:
+        description: 'SNS topic ARN for notifications'
+        required: false
+
+jobs:
+  create-campaign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install boto3
+
+      - name: Create campaign
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
+          AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+          FLUXION_S3_BUCKET: ${{ inputs.s3_bucket }}
+          FLUXION_S3_PREFIX: ${{ inputs.s3_prefix }}
+          FLUXION_SNS_TOPIC_ARN: ${{ inputs.sns_topic }}
+        run: |
+          python scripts/cloud_campaign_manager.py \
+            --action create \
+            --case ${{ inputs.case_id }} \
+            --params ${{ inputs.params }} \
+            --sweep-type ${{ inputs.sweep_type }} \
+            --samples ${{ inputs.samples }} \
+            --s3-bucket ${{ env.FLUXION_S3_BUCKET }} \
+            --s3-prefix ${{ env.FLUXION_S3_PREFIX }}
+
+  wait-for-completion:
+    needs: create-campaign
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install boto3
+
+      - name: Wait for campaign
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
+          AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+          FLUXION_S3_BUCKET: ${{ inputs.s3_bucket }}
+          FLUXION_S3_PREFIX: ${{ inputs.s3_prefix }}
+          FLUXION_SNS_TOPIC_ARN: ${{ inputs.sns_topic }}
+        run: |
+          python scripts/cloud_campaign_manager.py \
+            --action wait \
+            --campaign-id ${{ needs.create-campaign.outputs.campaign_id }} \
+            --s3-bucket ${{ env.FLUXION_S3_BUCKET }} \
+            --s3-prefix ${{ env.FLUXION_S3_PREFIX }}
+
+  aggregate-results:
+    needs: wait-for-completion
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install boto3
+
+      - name: Aggregate results
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
+          AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+          FLUXION_S3_BUCKET: ${{ inputs.s3_bucket }}
+          FLUXION_S3_PREFIX: ${{ inputs.s3_prefix }}
+        run: |
+          python scripts/s3_aggregator.py \
+            --campaign-id ${{ needs.create-campaign.outputs.campaign_id }} \
+            --s3-bucket ${{ env.FLUXION_S3_BUCKET }} \
+            --s3-prefix ${{ env.FLUXION_S3_PREFIX }} \
+            --output-format both

--- a/docs/CLOUD_CAMPAIGN.md
+++ b/docs/CLOUD_CAMPAIGN.md
@@ -1,0 +1,267 @@
+# Cloud Campaign Manager for Fluxion
+
+Direct-to-S3 campaign orchestration that removes the "Local Tether" bottleneck.
+
+## Overview
+
+OSimFlow's original campaign submission relied on the user's local machine to manage the execution loop. If a user disconnected or their laptop went to sleep, the remote simulation would drop.
+
+This cloud-hosted system decouples campaign execution from local machines by:
+
+1. **Campaign State in S3** — All campaign state is stored in S3, not local disk
+2. **Workers Push to S3** — Individual simulation workers push KPIs directly to S3
+3. **Cloud Aggregator** — Merges S3 result files into a final dataset
+4. **SNS Notifications** — Email/SMS notification upon campaign completion
+
+## Architecture
+
+```
+┌──────────────────┐     ┌─────────────┐     ┌─────────────────┐
+│ Cloud Campaign   │────▶│  S3 Bucket  │◀────│  S3 Worker      │
+│ Manager          │     │             │     │  (Remote VM/EC2)│
+└──────────────────┘     │  work-units │     └─────────────────┘
+       │                 │  results/   │              │
+       │                 │  state.json  │              │
+       │                 └─────────────┘              │
+       ▼                                                │
+┌──────────────────┐                                   │
+│ SNS Notification │◀──────────────────────────────────┘
+│ (Email/SMS)     │         (on completion)
+└──────────────────┘
+```
+
+## Quick Start
+
+### Prerequisites
+
+```bash
+# Install dependencies
+pip install boto3
+
+# Configure AWS credentials
+export AWS_ACCESS_KEY_ID=your_access_key
+export AWS_SECRET_ACCESS_KEY=your_secret_key
+export AWS_REGION=us-east-1
+
+# Set campaign parameters
+export FLUXION_S3_BUCKET=your-bucket-name
+export FLUXION_S3_PREFIX=fluxion-campaigns
+export FLUXION_SNS_TOPIC_ARN=arn:aws:sns:region:account:topic
+```
+
+### Create a Campaign
+
+```bash
+python scripts/cloud_campaign_manager.py \
+  --action create \
+  --case 600 \
+  --params R_value,wall_thickness \
+  --sweep-type random \
+  --samples 50 \
+  --s3-bucket your-bucket-name \
+  --s3-prefix fluxion-campaigns
+```
+
+This creates:
+- Campaign state in `s3://bucket/prefix/campaigns/{id}/state.json`
+- Work units in `s3://bucket/prefix/work-units/{id}.json`
+
+### Run Workers
+
+On each remote machine (Hetzner, EC2, etc.):
+
+```bash
+# Process a single work unit
+python scripts/s3_worker.py \
+  --param-file s3://bucket/prefix/work-units/campaign-wu-0000.json
+
+# Or run as an SQS listener for auto-scaling
+python scripts/s3_worker.py \
+  --mode sqs \
+  --queue-url https://sqs.region.amazonaws.com/account/queue-name
+```
+
+### Monitor Progress
+
+```bash
+# Check status
+python scripts/cloud_campaign_manager.py \
+  --action status \
+  --campaign-id fluxion-abc123def456
+
+# Wait for completion
+python scripts/cloud_campaign_manager.py \
+  --action wait \
+  --campaign-id fluxion-abc123def456
+```
+
+### Aggregate Results
+
+```bash
+python scripts/s3_aggregator.py \
+  --campaign-id fluxion-abc123def456 \
+  --s3-bucket your-bucket-name \
+  --s3-prefix fluxion-campaigns
+```
+
+This creates:
+- `s3://bucket/prefix/campaigns/{id}/results/aggregation_report.json`
+- `s3://bucket/prefix/campaigns/{id}/results/convergence_data.csv`
+
+### Send Notification
+
+```bash
+python scripts/cloud_campaign_manager.py \
+  --action notify \
+  --campaign-id fluxion-abc123def456 \
+  --sns-topic arn:aws:sns:region:account:topic
+```
+
+## Workflow Components
+
+### `cloud_campaign_manager.py`
+
+Main orchestration script. Actions:
+- `create` — Create a new campaign with work units
+- `status` — Check campaign progress
+- `wait` — Poll until campaign completes
+- `aggregate` — Trigger result aggregation
+- `notify` — Send SNS notification
+
+### `s3_worker.py`
+
+Worker script for remote execution. Supports:
+- **Single mode** — Process one work unit and exit
+- **SQS mode** — Long-running worker that processes messages from an SQS queue
+
+### `s3_aggregator.py`
+
+Merges individual work unit results into a final dataset. Can run:
+- Standalone script
+- AWS Lambda function (triggered by SNS or S3 events)
+
+## AWS Setup
+
+### S3 Bucket
+
+```bash
+# Create bucket
+aws s3 mb s3://your-bucket-name --region us-east-1
+
+# Enable versioning (optional but recommended)
+aws s3api put-bucket-versioning \
+  --bucket your-bucket-name \
+  --versioning-configuration Status=Enabled
+```
+
+### SNS Topic
+
+```bash
+# Create topic
+aws sns create-topic --name fluxion-campaign-notifications
+
+# Subscribe email
+aws sns subscribe \
+  --topic-arn arn:aws:sns:region:account:fluxion-campaign-notifications \
+  --protocol email \
+  --notification-endpoint your@email.com
+```
+
+### IAM Role (for EC2/ECS)
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::your-bucket-name",
+        "arn:aws:s3:::your-bucket-name/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "sns:Publish"
+      ],
+      "Resource": "arn:aws:sns:region:account:fluxion-campaign-notifications"
+    }
+  ]
+}
+```
+
+## GitHub Actions Integration
+
+Use the `cloud_campaign.yml` workflow to run campaigns from GitHub Actions:
+
+1. Add AWS secrets to your repository:
+   - `AWS_ACCESS_KEY_ID`
+   - `AWS_SECRET_ACCESS_KEY`
+   - `AWS_SESSION_TOKEN` (for temporary credentials)
+
+2. Set repository variables:
+   - `AWS_REGION`
+
+3. Dispatch the workflow with your campaign parameters.
+
+## Remote Worker Setup
+
+### Hetzner VM
+
+```bash
+# Provision runner (from scripts/provision-hetzner-runner.sh)
+./scripts/provision-hetzner-runner.sh \
+  --github-repo anchapin/fluxion \
+  --github-token $RUNNER_TOKEN \
+  --hcloud-ssh-key your-ssh-key
+
+# Install campaign dependencies
+ssh root@$VM_IP 'pip install boto3'
+
+# Start worker (processes work from SQS queue)
+ssh root@$VM_IP 'python scripts/s3_worker.py --mode sqs --queue-url $QUEUE_URL'
+```
+
+### AWS EC2 (Auto Scaling)
+
+Use the provided CloudFormation template or Terraform module to provision:
+- Auto Scaling group with worker instances
+- SQS queue for work distribution
+- IAM role with minimal permissions
+
+## Troubleshooting
+
+### Worker fails with "boto3 not found"
+```bash
+pip install boto3
+```
+
+### Campaign stuck in "created" status
+- Ensure workers can reach S3
+- Check work units exist in `s3://bucket/prefix/work-units/`
+- Verify AWS credentials are valid
+
+### SNS notification not received
+- Confirm SNS topic subscription is confirmed
+- Check email spam folder
+- Verify IAM permissions for `sns:Publish`
+
+## Migration from Local Campaigns
+
+The new system is API-compatible with the existing `autonomous_parameter_sweep.py` for the parameter specification format. To migrate:
+
+1. Set up AWS credentials and S3 bucket
+2. Use `cloud_campaign_manager.py --action create` instead of running the sweep locally
+3. Deploy workers on remote machines
+4. Use `s3_aggregator.py` to collect results
+
+The local `autonomous_parameter_sweep.py` can still be used for:
+- Quick local debugging
+- Small campaigns (< 10 runs)
+- CI/local development

--- a/infrastructure/cloud_campaign.yaml
+++ b/infrastructure/cloud_campaign.yaml
@@ -1,0 +1,149 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  Fluxion Cloud Campaign Infrastructure
+  S3 bucket, SNS topic, and IAM role for cloud campaign orchestration.
+
+Parameters:
+  S3BucketName:
+    Type: String
+    Default: fluxion-campaigns
+    Description: Name of the S3 bucket for campaign data
+
+  SNSTopicName:
+    Type: String
+    Default: fluxion-campaign-notifications
+    Description: Name of the SNS topic for notifications
+
+  NotificationEmail:
+    Type: String
+    Default: ""
+    Description: Email address for SNS subscription (optional)
+
+Resources:
+  CampaignBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Ref S3BucketName
+      Versioning:
+        Status: Enabled
+      LifecycleConfiguration:
+        Rules:
+          - Id: ExpireOldResults
+            Status: Enabled
+            ExpirationInDays: 30
+          - Id: AbortIncompleteUploads
+            Status: Enabled
+            AbortIncompleteMultipartUploadDays: 7
+      Tags:
+        - Key: Project
+          Value: Fluxion
+
+  CampaignTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: !Ref SNSTopicName
+      DisplayName: Fluxion Campaign Notifications
+      Tags:
+        - Key: Project
+          Value: Fluxion
+
+  CampaignRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: fluxion-campaign-role
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: CampaignPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                  - s3:ListBucket
+                  - s3:DeleteObject
+                Resource:
+                  - !GetAtt CampaignBucket.Arn
+                  - !Sub "${CampaignBucket.Arn}/*"
+
+              - Effect: Allow
+                Action:
+                  - sns:Publish
+                Resource: !Ref CampaignTopic
+
+              - Effect: Allow
+                Action:
+                  - dynamodb:Query
+                  - dynamodb:Scan
+                  - dynamodb:GetItem
+                  - dynamodb:PutItem
+                  - dynamodb:UpdateItem
+                Resource: "*"
+
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: "*"
+
+  AggregatorFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: fluxion-aggregator
+      Runtime: python3.11
+      Handler: s3_aggregator.lambda_handler
+      Role: !GetAtt CampaignRole.Arn
+      Timeout: 300
+      MemorySize: 256
+      Code:
+        S3Bucket: !Ref S3BucketName
+        S3Key: scripts/s3_aggregator.py
+      Environment:
+        Variables:
+          FLUXION_S3_BUCKET: !Ref S3BucketName
+          FLUXION_S3_PREFIX: fluxion-campaigns
+
+  AggregatorPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref AggregatorFunction
+      Action: lambda:InvokeFunction
+      Principal: s3.amazonaws.com
+      SourceArn: !GetAtt CampaignBucket.Arn
+
+Outputs:
+  S3Bucket:
+    Description: S3 bucket for campaign data
+    Value: !Ref CampaignBucket
+    Export:
+      Name: !Sub "${AWS::StackName}-S3Bucket"
+
+  SNSTopicArn:
+    Description: SNS topic ARN for notifications
+    Value: !Ref CampaignTopic
+    Export:
+      Name: !Sub "${AWS::StackName}-SNSTopicArn"
+
+  CampaignRoleArn:
+    Description: IAM role ARN for campaign operations
+    Value: !GetAtt CampaignRole.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-CampaignRoleArn"
+
+  AggregatorFunctionName:
+    Description: Lambda function name for result aggregation
+    Value: !Ref AggregatorFunction
+    Export:
+      Name: !Sub "${AWS::StackName}-AggregatorFunction"

--- a/scripts/cloud_campaign_manager.py
+++ b/scripts/cloud_campaign_manager.py
@@ -1,0 +1,649 @@
+#!/usr/bin/env python3
+"""
+Cloud Campaign Manager for Fluxion
+==================================
+Cloud-hosted orchestration for simulation campaigns.
+Removes the "Local Tether" bottleneck by:
+1. Storing campaign state in S3 (not local disk)
+2. Workers push results directly to S3
+3. Aggregator merges S3 results
+4. SNS notification on completion
+
+Usage
+-----
+# Start a new campaign
+python scripts/cloud_campaign_manager.py --action create \
+    --case 600 --params R_value,wall_thickness --sweep-type random --samples 50
+
+# Check campaign status
+python scripts/cloud_campaign_manager.py --action status --campaign-id <id>
+
+# Wait for campaign completion
+python scripts/cloud_campaign_manager.py --action wait --campaign-id <id>
+
+# Trigger aggregation and get results
+python scripts/cloud_campaign_manager.py --action aggregate --campaign-id <id>
+
+Exit codes
+----------
+0 — Success
+1 — Campaign failed
+2 — Configuration error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import sys
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any, Optional
+
+try:
+    import boto3
+    from botocore.exceptions import ClientError
+except ImportError:
+    boto3 = None
+    ClientError = Exception
+
+
+TRACE_BASE = Path(".sdd/traces/diagnostic")
+
+CARGO_TEST_CMD = ["cargo", "test", "--test=ashrae_140_validation", "--", "--nocapture"]
+
+
+class SweepType(Enum):
+    GRID = "grid"
+    RANDOM = "random"
+    GRADIENT = "gradient"
+    BINARY = "binary"
+    LATIN_HYPERCUBE = "latin_hypercube"
+
+
+@dataclass
+class ParameterSpec:
+    name: str
+    default: float
+    min_val: float
+    max_val: float
+    step: float
+    unit: str = ""
+
+
+@dataclass
+class CampaignConfig:
+    case_id: str
+    sweep_type: SweepType
+    parameters: list[ParameterSpec]
+    max_iterations: int = 100
+    samples_per_param: int = 10
+    concurrent_workers: int = 4
+    timeout_per_run: int = 300
+    tolerance_mae: float = 5.0
+
+
+@dataclass
+class WorkUnit:
+    work_unit_id: str
+    campaign_id: str
+    case_id: str
+    parameters: dict[str, float]
+    s3_result_prefix: str
+    config: dict
+
+
+@dataclass
+class CampaignState:
+    campaign_id: str
+    config: dict
+    work_units: list[dict]
+    status: str
+    start_time: str
+    end_time: Optional[str] = None
+    best_parameters: dict[str, float] = field(default_factory=dict)
+    best_mae: float = 999.0
+    completed_units: int = 0
+    failed_units: int = 0
+    results_uri: Optional[str] = None
+    notification_sent: bool = False
+    error_message: Optional[str] = None
+
+
+def get_aws_clients():
+    """Get configured boto3 clients."""
+    if boto3 is None:
+        raise RuntimeError("boto3 is required for cloud campaign. Install: pip install boto3")
+
+    session = boto3.Session(
+        aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID"),
+        aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY"),
+        aws_session_token=os.environ.get("AWS_SESSION_TOKEN"),
+        region_name=os.environ.get("AWS_REGION", "us-east-1"),
+    )
+    return {
+        "s3": session.client("s3"),
+        "sns": session.client("sns"),
+        "dynamodb": session.client("dynamodb"),
+        "sts": session.client("sts"),
+    }
+
+
+def parse_s3_uri(uri: str) -> tuple[str, str]:
+    """Parse s3://bucket/key into (bucket, key)."""
+    if not uri.startswith("s3://"):
+        raise ValueError(f"Invalid S3 URI: {uri}")
+    parts = uri[5:].split("/", 1)
+    return parts[0], parts[1] if len(parts) > 1 else ""
+
+
+def get_required_env(var: str) -> str:
+    """Get required environment variable or fail."""
+    value = os.environ.get(var)
+    if not value:
+        raise ValueError(f"Required environment variable not set: {var}")
+    return value
+
+
+def ensure_s3_prefix(s3_client, bucket: str, prefix: str) -> None:
+    """Ensure S3 prefix exists (create empty object if needed)."""
+    if prefix.endswith("/"):
+        prefix = prefix[:-1]
+    try:
+        s3_client.head_object(Bucket=bucket, Key=prefix + "/_placeholder")
+    except ClientError:
+        s3_client.put_object(Bucket=bucket, Key=prefix + "/_placeholder", Body=b"")
+
+
+def generate_grid_points(specs: list[ParameterSpec]) -> list[dict[str, float]]:
+    """Generate full factorial grid of parameter combinations."""
+    import itertools
+
+    grids = []
+    for spec in specs:
+        points = []
+        val = spec.min_val
+        while val <= spec.max_val + 1e-9:
+            points.append(val)
+            val += spec.step
+        grids.append(points)
+
+    combinations = list(itertools.product(*grids))
+    return [
+        {specs[i].name: combo[i] for i in range(len(specs))} for combo in combinations
+    ]
+
+
+def generate_random_points(
+    specs: list[ParameterSpec], samples: int
+) -> list[dict[str, float]]:
+    """Generate random parameter samples within bounds."""
+    return [
+        {spec.name: random.uniform(spec.min_val, spec.max_val) for spec in specs}
+        for _ in range(samples)
+    ]
+
+
+def create_campaign(
+    config: CampaignConfig,
+    s3_bucket: str,
+    s3_prefix: str,
+    sns_topic_arn: Optional[str] = None,
+) -> CampaignState:
+    """Create a new campaign and upload initial state to S3."""
+    clients = get_aws_clients()
+
+    campaign_id = f"fluxion-{uuid.uuid4().hex[:12]}"
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+
+    print(f"[*] Creating campaign {campaign_id}")
+
+    if config.sweep_type == SweepType.GRID:
+        param_combinations = generate_grid_points(config.parameters)
+    elif config.sweep_type == SweepType.RANDOM:
+        param_combinations = generate_random_points(
+            config.parameters, config.samples_per_param
+        )
+    else:
+        param_combinations = generate_random_points(
+            config.parameters, config.max_iterations
+        )
+
+    param_combinations = param_combinations[: config.max_iterations]
+
+    print(f"[*] Generating {len(param_combinations)} work units")
+
+    work_units = []
+    for i, params in enumerate(param_combinations):
+        work_unit_id = f"{campaign_id}-wu-{i:04d}"
+        work_unit = WorkUnit(
+            work_unit_id=work_unit_id,
+            campaign_id=campaign_id,
+            case_id=config.case_id,
+            parameters=params,
+            s3_result_prefix=s3_prefix,
+            config=asdict(config),
+        )
+        work_units.append(asdict(work_unit))
+
+        unit_key = f"{s3_prefix}/work-units/{work_unit_id}.json"
+        clients["s3"].put_object(
+            Bucket=s3_bucket,
+            Key=unit_key,
+            Body=json.dumps(work_unit, indent=2),
+            ContentType="application/json",
+        )
+
+    config_dict = {
+        "case_id": config.case_id,
+        "sweep_type": config.sweep_type.value,
+        "parameters": [
+            {
+                "name": s.name,
+                "default": s.default,
+                "min": s.min_val,
+                "max": s.max_val,
+                "step": s.step,
+                "unit": s.unit,
+            }
+            for s in config.parameters
+        ],
+        "max_iterations": config.max_iterations,
+        "samples_per_param": config.samples_per_param,
+        "tolerance_mae": config.tolerance_mae,
+    }
+
+    state = CampaignState(
+        campaign_id=campaign_id,
+        config=config_dict,
+        work_units=work_units,
+        status="created",
+        start_time=datetime.now(timezone.utc).isoformat(),
+    )
+
+    state_uri = f"s3://{s3_bucket}/{s3_prefix}/campaigns/{campaign_id}/state.json"
+    clients["s3"].put_object(
+        Bucket=s3_bucket,
+        Key=f"{s3_prefix}/campaigns/{campaign_id}/state.json",
+        Body=json.dumps(asdict(state), indent=2),
+        ContentType="application/json",
+    )
+
+    print(f"[*] Campaign state: {state_uri}")
+    print(f"[*] Work units: {len(work_units)}")
+
+    if sns_topic_arn:
+        print(f"[*] SNS notifications will be sent to: {sns_topic_arn}")
+
+    return state
+
+
+def get_campaign_state(campaign_id: str, s3_bucket: str, s3_prefix: str) -> Optional[CampaignState]:
+    """Retrieve campaign state from S3."""
+    clients = get_aws_clients()
+
+    try:
+        response = clients["s3"].get_object(
+            Bucket=s3_bucket,
+            Key=f"{s3_prefix}/campaigns/{campaign_id}/state.json",
+        )
+        data = json.loads(response["Body"].read().decode("utf-8"))
+        return CampaignState(**data)
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "404":
+            return None
+        raise
+
+
+def update_campaign_state(state: CampaignState, s3_bucket: str, s3_prefix: str) -> None:
+    """Update campaign state in S3."""
+    clients = get_aws_clients()
+    clients["s3"].put_object(
+        Bucket=s3_bucket,
+        Key=f"{s3_prefix}/campaigns/{state.campaign_id}/state.json",
+        Body=json.dumps(asdict(state), indent=2),
+        ContentType="application/json",
+    )
+
+
+def check_campaign_progress(state: CampaignState, s3_bucket: str, s3_prefix: str) -> CampaignState:
+    """Check progress by counting completed work units in S3."""
+    clients = get_aws_clients()
+
+    completed = 0
+    failed = 0
+
+    results_prefix = f"{s3_prefix}/results"
+
+    try:
+        paginator = clients["s3"].get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=s3_bucket, Prefix=f"{results_prefix}/"):
+            for obj in page.get("Contents", []):
+                key = obj["Key"]
+                if key.endswith(".json") and not key.endswith("_placeholder"):
+                    if "failed" in key:
+                        failed += 1
+                    else:
+                        completed += 1
+    except ClientError:
+        pass
+
+    state.completed_units = completed
+    state.failed_units = failed
+
+    total = len(state.work_units)
+    progress = (completed + failed) / total * 100 if total > 0 else 0
+
+    print(f"[*] Campaign {state.campaign_id}: {completed}/{total} completed, {failed} failed ({progress:.1f}%)")
+
+    if state.status == "created" and (completed + failed) > 0:
+        state.status = "running"
+    if completed + failed >= total and total > 0:
+        state.status = "completed"
+
+    return state
+
+
+def wait_for_completion(
+    campaign_id: str, s3_bucket: str, s3_prefix: str, poll_interval: int = 30
+) -> CampaignState:
+    """Poll until campaign is complete."""
+    print(f"[*] Waiting for campaign {campaign_id} to complete...")
+
+    while True:
+        state = get_campaign_state(campaign_id, s3_bucket, s3_prefix)
+        if state is None:
+            print(f"[ERROR] Campaign {campaign_id} not found")
+            sys.exit(1)
+
+        state = check_campaign_progress(state, s3_bucket, s3_prefix)
+        update_campaign_state(state, s3_bucket, s3_prefix)
+
+        if state.status in ("completed", "failed"):
+            return state
+
+        time.sleep(poll_interval)
+
+
+def send_completion_notification(
+    state: CampaignState, s3_bucket: str, s3_prefix: str, sns_topic_arn: str
+) -> None:
+    """Send SNS notification with campaign results."""
+    if state.notification_sent:
+        print("[*] Notification already sent, skipping")
+        return
+
+    clients = get_aws_clients()
+
+    account_id = clients["sts"].get_caller_identity()["Account"]
+    region = os.environ.get("AWS_REGION", "us-east-1")
+    results_uri = f"https://{s3_bucket}.s3.{region}.amazonaws.com/{s3_prefix}/campaigns/{state.campaign_id}/results/"
+
+    message = {
+        "campaign_id": state.campaign_id,
+        "status": state.status,
+        "start_time": state.start_time,
+        "end_time": datetime.now(timezone.utc).isoformat(),
+        "total_runs": len(state.work_units),
+        "completed_runs": state.completed_units,
+        "failed_runs": state.failed_units,
+        "best_mae": state.best_mae,
+        "best_parameters": state.best_parameters,
+        "results_uri": results_uri,
+    }
+
+    clients["sns"].publish(
+        TopicArn=sns_topic_arn,
+        Subject=f"Fluxion Campaign {state.campaign_id} {'Completed' if state.status == 'completed' else 'Failed'}",
+        Message=json.dumps(message, indent=2),
+    )
+
+    state.notification_sent = True
+    update_campaign_state(state, s3_bucket, s3_prefix)
+
+    print(f"[*] Notification sent to: {sns_topic_arn}")
+
+
+def trigger_aggregator(
+    campaign_id: str, s3_bucket: str, s3_prefix: str, aggregator_function_name: Optional[str] = None
+) -> str:
+    """Trigger the aggregator Lambda or ECS task."""
+    clients = get_aws_clients()
+
+    results_uri = f"s3://{s3_bucket}/{s3_prefix}/campaigns/{campaign_id}/results/"
+
+    if aggregator_function_name:
+        lambda_client = clients.get("lambda") or boto3.client("lambda")
+        lambda_client.invoke(
+            FunctionName=aggregator_function_name,
+            InvocationType="Event",
+            Payload=json.dumps({
+                "campaign_id": campaign_id,
+                "s3_bucket": s3_bucket,
+                "s3_prefix": s3_prefix,
+                "results_uri": results_uri,
+            }),
+        )
+        print(f"[*] Aggregator Lambda triggered: {aggregator_function_name}")
+    else:
+        print("[*] No aggregator configured - results remain in S3")
+        print(f"[*] Results URI: {results_uri}")
+
+    return results_uri
+
+
+def build_default_params() -> dict[str, ParameterSpec]:
+    """Build default parameter specs for ASHRAE cases."""
+    return {
+        "R_value": ParameterSpec(
+            "R_value", default=2.0, min_val=1.0, max_val=5.0, step=0.5, unit="m²K/W"
+        ),
+        "wall_thickness": ParameterSpec(
+            "wall_thickness",
+            default=0.15,
+            min_val=0.05,
+            max_val=0.30,
+            step=0.05,
+            unit="m",
+        ),
+        "thermal_mass": ParameterSpec(
+            "thermal_mass", default=1.0, min_val=0.5, max_val=2.0, step=0.1, unit=""
+        ),
+        "h_tr_is": ParameterSpec(
+            "h_tr_is", default=8.29, min_val=5.0, max_val=15.0, step=1.0, unit="W/m²K"
+        ),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Cloud Campaign Manager for Fluxion")
+    parser.add_argument(
+        "--action",
+        type=str,
+        choices=["create", "status", "wait", "aggregate", "notify"],
+        required=True,
+        help="Action to perform",
+    )
+    parser.add_argument(
+        "--campaign-id",
+        type=str,
+        help="Campaign ID (required for status, wait, aggregate, notify actions)",
+    )
+    parser.add_argument(
+        "--case",
+        type=str,
+        default="600",
+        help="ASHRAE 140 case ID",
+    )
+    parser.add_argument(
+        "--params",
+        type=str,
+        help="Comma-separated parameter names to sweep",
+    )
+    parser.add_argument(
+        "--sweep-type",
+        type=str,
+        choices=["grid", "random", "gradient", "binary", "latin_hypercube"],
+        default="random",
+        help="Sweep strategy",
+    )
+    parser.add_argument(
+        "--samples",
+        type=int,
+        default=50,
+        help="Number of samples for random sweep",
+    )
+    parser.add_argument(
+        "--max-iterations",
+        type=int,
+        default=100,
+        help="Maximum number of iterations",
+    )
+    parser.add_argument(
+        "--s3-bucket",
+        type=str,
+        default=os.environ.get("FLUXION_S3_BUCKET"),
+        help="S3 bucket for campaign data",
+    )
+    parser.add_argument(
+        "--s3-prefix",
+        type=str,
+        default=os.environ.get("FLUXION_S3_PREFIX", "fluxion-campaigns"),
+        help="S3 prefix for campaign data",
+    )
+    parser.add_argument(
+        "--sns-topic",
+        type=str,
+        default=os.environ.get("FLUXION_SNS_TOPIC_ARN"),
+        help="SNS topic ARN for notifications",
+    )
+    parser.add_argument(
+        "--aggregator-function",
+        type=str,
+        help="Lambda function name for aggregation",
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=int,
+        default=30,
+        help="Poll interval in seconds for wait action",
+    )
+    args = parser.parse_args()
+
+    s3_bucket = args.s3_bucket
+    s3_prefix = args.s3_prefix.rstrip("/")
+
+    if args.action == "create":
+        if not s3_bucket:
+            parser.error("--s3-bucket is required (or set FLUXION_S3_BUCKET env var)")
+
+        param_names = (
+            args.params.split(",") if args.params else ["R_value", "wall_thickness"]
+        )
+        default_params = build_default_params()
+
+        specs = []
+        for name in param_names:
+            if name in default_params:
+                specs.append(default_params[name])
+            else:
+                specs.append(
+                    ParameterSpec(name, default=1.0, min_val=0.1, max_val=10.0, step=0.1)
+                )
+
+        config = CampaignConfig(
+            case_id=args.case,
+            sweep_type=SweepType(args.sweep_type),
+            parameters=specs,
+            max_iterations=args.max_iterations,
+            samples_per_param=args.samples,
+        )
+
+        state = create_campaign(config, s3_bucket, s3_prefix, args.sns_topic)
+
+        print(f"[*] Campaign created: {state.campaign_id}")
+        print(f"[*] Work units: {len(state.work_units)}")
+        print(f"[*] Run workers with:")
+        print(f"    python scripts/s3_worker.py --param-file s3://{s3_bucket}/{s3_prefix}/work-units/{{work_unit_id}}.json")
+
+        return 0
+
+    if args.action == "status":
+        if not args.campaign_id:
+            parser.error("--campaign-id is required for status action")
+        if not s3_bucket:
+            parser.error("--s3-bucket is required (or set FLUXION_S3_BUCKET env var)")
+
+        state = get_campaign_state(args.campaign_id, s3_bucket, s3_prefix)
+        if state is None:
+            print(f"[ERROR] Campaign {args.campaign_id} not found")
+            return 1
+
+        state = check_campaign_progress(state, s3_bucket, s3_prefix)
+
+        print(f"\nCampaign: {state.campaign_id}")
+        print(f"Status: {state.status}")
+        print(f"Start: {state.start_time}")
+        print(f"Completed: {state.completed_units}/{len(state.work_units)}")
+        print(f"Failed: {state.failed_units}")
+        print(f"Best MAE: {state.best_mae:.2f}%")
+
+        return 0
+
+    if args.action == "wait":
+        if not args.campaign_id:
+            parser.error("--campaign-id is required for wait action")
+        if not s3_bucket:
+            parser.error("--s3-bucket is required (or set FLUXION_S3_BUCKET env var)")
+
+        state = wait_for_completion(args.campaign_id, s3_bucket, s3_prefix, args.poll_interval)
+
+        print(f"\n[*] Campaign {args.campaign_id} is now: {state.status}")
+        print(f"    Completed: {state.completed_units}")
+        print(f"    Failed: {state.failed_units}")
+
+        if args.sns_topic and state.status == "completed":
+            send_completion_notification(state, s3_bucket, s3_prefix, args.sns_topic)
+
+        return 0
+
+    if args.action == "aggregate":
+        if not args.campaign_id:
+            parser.error("--campaign-id is required for aggregate action")
+        if not s3_bucket:
+            parser.error("--s3-bucket is required (or set FLUXION_S3_BUCKET env var)")
+
+        results_uri = trigger_aggregator(args.campaign_id, s3_bucket, s3_prefix, args.aggregator_function)
+        print(f"[*] Aggregation triggered")
+        print(f"[*] Results: {results_uri}")
+
+        return 0
+
+    if args.action == "notify":
+        if not args.campaign_id:
+            parser.error("--campaign-id is required for notify action")
+        if not s3_bucket:
+            parser.error("--s3-bucket is required (or set FLUXION_S3_BUCKET env var)")
+        if not args.sns_topic:
+            parser.error("--sns-topic is required for notify action")
+
+        state = get_campaign_state(args.campaign_id, s3_bucket, s3_prefix)
+        if state is None:
+            print(f"[ERROR] Campaign {args.campaign_id} not found")
+            return 1
+
+        send_completion_notification(state, s3_bucket, s3_prefix, args.sns_topic)
+
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/s3_aggregator.py
+++ b/scripts/s3_aggregator.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""
+S3 Aggregator for Fluxion Campaigns
+===================================
+Merges individual work unit results from S3 into a final dataset.
+Can run as a standalone script or be triggered by SNS/Lambda.
+
+Usage
+-----
+# Aggregate results for a campaign
+python scripts/s3_aggregator.py --campaign-id <id> --s3-bucket <bucket> --s3-prefix <prefix>
+
+# As a Lambda handler
+python scripts/s3_aggregator.py --mode lambda
+
+Exit codes
+----------
+0 — Aggregation successful
+1 — Aggregation failed
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+try:
+    import boto3
+    from botocore.exceptions import ClientError
+except ImportError:
+    boto3 = None
+    ClientError = Exception
+
+
+@dataclass
+class AggregatedResult:
+    work_unit_id: str
+    run_id: str
+    case_id: str
+    parameters: dict[str, float]
+    heating_mae: float
+    cooling_mae: float
+    peak_heating_mae: float
+    peak_cooling_mae: float
+    temperature_mae: float
+    overall_pass: bool
+    duration_ms: int
+    timestamp: str
+    error_message: Optional[str] = None
+
+
+@dataclass
+class AggregationReport:
+    campaign_id: str
+    aggregation_time: str
+    total_work_units: int
+    successful_runs: int
+    failed_runs: int
+    pass_rate: float
+    best_mae: float
+    best_parameters: dict[str, float]
+    results: list[dict]
+    convergence_data: list[dict]
+
+
+def get_aws_clients():
+    """Get configured boto3 clients."""
+    if boto3 is None:
+        raise RuntimeError("boto3 is required for S3 aggregator. Install: pip install boto3")
+
+    session = boto3.Session(
+        aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID"),
+        aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY"),
+        aws_session_token=os.environ.get("AWS_SESSION_TOKEN"),
+        region_name=os.environ.get("AWS_REGION", "us-east-1"),
+    )
+    return {
+        "s3": session.client("s3"),
+        "dynamodb": session.client("dynamodb"),
+    }
+
+
+def parse_s3_uri(uri: str) -> tuple[str, str]:
+    """Parse s3://bucket/key into (bucket, key)."""
+    if not uri.startswith("s3://"):
+        raise ValueError(f"Invalid S3 URI: {uri}")
+    parts = uri[5:].split("/", 1)
+    return parts[0], parts[1] if len(parts) > 1 else ""
+
+
+def collect_results_from_s3(s3_client, bucket: str, results_prefix: str) -> list[AggregatedResult]:
+    """Collect all result JSON files from S3 results prefix."""
+    results: list[AggregatedResult] = []
+
+    try:
+        paginator = s3_client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=bucket, Prefix=f"{results_prefix}/"):
+            for obj in page.get("Contents", []):
+                key = obj["Key"]
+                if key.endswith(".json") and not key.endswith("_placeholder"):
+                    try:
+                        response = s3_client.get_object(Bucket=bucket, Key=key)
+                        data = json.loads(response["Body"].read().decode("utf-8"))
+                        results.append(AggregatedResult(**data))
+                    except (json.JSONDecodeError, TypeError) as e:
+                        print(f"[WARN] Failed to parse {key}: {e}", file=sys.stderr)
+    except ClientError as e:
+        print(f"[ERROR] Failed to list results: {e}", file=sys.stderr)
+
+    return results
+
+
+def aggregate_results(
+    campaign_id: str,
+    s3_bucket: str,
+    s3_prefix: str,
+    output_format: str = "json",
+) -> AggregationReport:
+    """Aggregate all work unit results into a final report."""
+    clients = get_aws_clients()
+    s3_client = clients["s3"]
+
+    results_prefix = f"{s3_prefix}/results"
+    print(f"[*] Collecting results from s3://{s3_bucket}/{results_prefix}/")
+
+    results = collect_results_from_s3(s3_client, s3_bucket, results_prefix)
+
+    if not results:
+        print("[WARN] No results found")
+        return AggregationReport(
+            campaign_id=campaign_id,
+            aggregation_time=datetime.now(timezone.utc).isoformat(),
+            total_work_units=0,
+            successful_runs=0,
+            failed_runs=0,
+            pass_rate=0.0,
+            best_mae=999.0,
+            best_parameters={},
+            results=[],
+            convergence_data=[],
+        )
+
+    successful = [r for r in results if r.error_message is None]
+    failed = [r for r in results if r.error_message is not None]
+
+    pass_rate = sum(1 for r in successful if r.overall_pass) / len(successful) * 100 if successful else 0.0
+
+    best_result = min(successful, key=lambda r: r.heating_mae + r.cooling_mae) if successful else None
+    best_mae = (best_result.heating_mae + best_result.cooling_mae) if best_result else 999.0
+    best_parameters = best_result.parameters if best_result else {}
+
+    convergence_data = []
+    for r in sorted(results, key=lambda x: x.timestamp):
+        if r.error_message is None:
+            convergence_data.append({
+                "iteration": len(convergence_data) + 1,
+                "timestamp": r.timestamp,
+                "heating_mae": r.heating_mae,
+                "cooling_mae": r.cooling_mae,
+                "total_mae": r.heating_mae + r.cooling_mae,
+            })
+
+    report = AggregationReport(
+        campaign_id=campaign_id,
+        aggregation_time=datetime.now(timezone.utc).isoformat(),
+        total_work_units=len(results),
+        successful_runs=len(successful),
+        failed_runs=len(failed),
+        pass_rate=pass_rate,
+        best_mae=best_mae,
+        best_parameters=best_parameters,
+        results=[asdict(r) for r in results],
+        convergence_data=convergence_data,
+    )
+
+    report_key = f"{s3_prefix}/campaigns/{campaign_id}/results/aggregation_report.json"
+    s3_client.put_object(
+        Bucket=s3_bucket,
+        Key=report_key,
+        Body=json.dumps(asdict(report), indent=2),
+        ContentType="application/json",
+    )
+
+    print(f"[*] Aggregation complete: {len(results)} work units")
+    print(f"[*] Successful: {len(successful)}, Failed: {len(failed)}")
+    print(f"[*] Pass rate: {pass_rate:.1f}%")
+    print(f"[*] Best MAE: {best_mae:.2f}%")
+    print(f"[*] Report: s3://{s3_bucket}/{report_key}")
+
+    if output_format == "csv":
+        csv_key = f"{s3_prefix}/campaigns/{campaign_id}/results/convergence_data.csv"
+        csv_content = "iteration,timestamp,heating_mae,cooling_mae,total_mae\n"
+        for cd in convergence_data:
+            csv_content += f"{cd['iteration']},{cd['timestamp']},{cd['heating_mae']},{cd['cooling_mae']},{cd['total_mae']}\n"
+        s3_client.put_object(
+            Bucket=s3_bucket,
+            Key=csv_key,
+            Body=csv_content,
+            ContentType="text/csv",
+        )
+        print(f"[*] CSV: s3://{s3_bucket}/{csv_key}")
+
+    return report
+
+
+def generate_download_link(s3_client, bucket: str, key: str, expiration: int = 3600) -> str:
+    """Generate a pre-signed URL for downloading results."""
+    try:
+        url = s3_client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": bucket, "Key": key},
+            ExpiresIn=expiration,
+        )
+        return url
+    except ClientError:
+        return f"s3://{bucket}/{key}"
+
+
+def lambda_handler(event: dict, context: Any) -> dict:
+    """AWS Lambda handler for SNS-triggered aggregation."""
+    print(f"[*] Lambda triggered with event: {json.dumps(event)}")
+
+    campaign_id = event.get("campaign_id")
+    s3_bucket = event.get("s3_bucket")
+    s3_prefix = event.get("s3_prefix", "fluxion-campaigns")
+
+    if not all([campaign_id, s3_bucket]):
+        print("[ERROR] Missing required parameters")
+        return {"statusCode": 400, "body": "Missing required parameters"}
+
+    try:
+        report = aggregate_results(campaign_id, s3_bucket, s3_prefix)
+
+        return {
+            "statusCode": 200,
+            "body": json.dumps({
+                "campaign_id": campaign_id,
+                "status": "aggregated",
+                "total_work_units": report.total_work_units,
+                "successful_runs": report.successful_runs,
+                "failed_runs": report.failed_runs,
+                "pass_rate": report.pass_rate,
+                "best_mae": report.best_mae,
+            }),
+        }
+    except Exception as e:
+        print(f"[ERROR] Aggregation failed: {e}")
+        return {"statusCode": 500, "body": str(e)}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="S3 Aggregator for Fluxion Campaigns")
+    parser.add_argument(
+        "--campaign-id",
+        type=str,
+        required=True,
+        help="Campaign ID",
+    )
+    parser.add_argument(
+        "--s3-bucket",
+        type=str,
+        default=os.environ.get("FLUXION_S3_BUCKET"),
+        help="S3 bucket",
+    )
+    parser.add_argument(
+        "--s3-prefix",
+        type=str,
+        default=os.environ.get("FLUXION_S3_PREFIX", "fluxion-campaigns"),
+        help="S3 prefix",
+    )
+    parser.add_argument(
+        "--output-format",
+        type=str,
+        choices=["json", "csv", "both"],
+        default="json",
+        help="Output format",
+    )
+    parser.add_argument(
+        "--mode",
+        type=str,
+        choices=["standalone", "lambda"],
+        default="standalone",
+        help="Run mode",
+    )
+    parser.add_argument(
+        "--download-link-expiration",
+        type=int,
+        default=3600,
+        help="Pre-signed URL expiration in seconds",
+    )
+    args = parser.parse_args()
+
+    if args.mode == "lambda":
+        print("[*] Running in Lambda mode - waiting for event")
+        return 0
+
+    if not args.s3_bucket:
+        parser.error("--s3-bucket is required (or set FLUXION_S3_BUCKET env var)")
+
+    report = aggregate_results(args.campaign_id, args.s3_bucket, args.s3_prefix, args.output_format)
+
+    clients = get_aws_clients()
+    s3_client = clients["s3"]
+
+    report_key = f"{args.s3_prefix}/campaigns/{args.campaign_id}/results/aggregation_report.json"
+    download_url = generate_download_link(
+        s3_client, args.s3_bucket, report_key, args.download_link_expiration
+    )
+
+    print(f"\n[*] Results available at:")
+    print(f"    {download_url}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/s3_worker.py
+++ b/scripts/s3_worker.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""
+S3 Worker Script for Fluxion Campaigns
+======================================
+Executes individual simulation runs and pushes KPIs directly to S3.
+Designed to run on remote machines (Hetzner, EC2, etc.) without
+needing to stream results back to a local machine.
+
+Usage
+-----
+# Run a single work unit (typically called by the campaign manager or scheduler)
+python scripts/s3_worker.py --campaign-id <id> --work-unit-id <id> --param-file <s3://...>
+
+# As a daemon listening for SQS messages (alternative)
+python scripts/s3_worker.py --mode sqs --queue-url <sqs-queue-url>
+
+Exit codes
+----------
+0 — Work unit completed successfully
+1 — Work unit failed
+2 — Configuration error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+try:
+    import boto3
+    from botocore.exceptions import ClientError
+except ImportError:
+    boto3 = None
+    ClientError = Exception
+
+
+TRACE_BASE = Path(".sdd/traces/diagnostic")
+CARGO_TEST_CMD = ["cargo", "test", "--test=ashrae_140_validation", "--", "--nocapture"]
+
+
+@dataclass
+class WorkUnit:
+    work_unit_id: str
+    campaign_id: str
+    case_id: str
+    parameters: dict[str, float]
+    s3_result_prefix: str
+    config: dict
+
+
+@dataclass
+class WorkUnitResult:
+    work_unit_id: str
+    campaign_id: str
+    run_id: str
+    case_id: str
+    parameters: dict[str, float]
+    heating_mae: float
+    cooling_mae: float
+    peak_heating_mae: float
+    peak_cooling_mae: float
+    temperature_mae: float
+    overall_pass: bool
+    duration_ms: int
+    timestamp: str
+    error_message: Optional[str] = None
+
+
+def get_aws_clients():
+    """Get configured boto3 clients."""
+    if boto3 is None:
+        raise RuntimeError("boto3 is required for S3 worker. Install: pip install boto3")
+
+    session = boto3.Session(
+        aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID"),
+        aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY"),
+        aws_session_token=os.environ.get("AWS_SESSION_TOKEN"),
+        region_name=os.environ.get("AWS_REGION", "us-east-1"),
+    )
+    return {
+        "s3": session.client("s3"),
+        "sns": session.client("sns"),
+        "dynamodb": session.client("dynamodb"),
+    }
+
+
+def download_work_unit(param_file: str, clients: dict) -> WorkUnit:
+    """Download work unit parameters from S3."""
+    if param_file.startswith("s3://"):
+        bucket, key = parse_s3_uri(param_file)
+        response = clients["s3"].get_object(Bucket=bucket, Key=key)
+        data = json.loads(response["Body"].read().decode("utf-8"))
+    else:
+        with open(param_file) as f:
+            data = json.load(f)
+
+    return WorkUnit(
+        work_unit_id=data["work_unit_id"],
+        campaign_id=data["campaign_id"],
+        case_id=data.get("case_id", "600"),
+        parameters=data["parameters"],
+        s3_result_prefix=data["s3_result_prefix"],
+        config=data.get("config", {}),
+    )
+
+
+def parse_s3_uri(uri: str) -> tuple[str, str]:
+    """Parse s3://bucket/key into (bucket, key)."""
+    if not uri.startswith("s3://"):
+        raise ValueError(f"Invalid S3 URI: {uri}")
+    parts = uri[5:].split("/", 1)
+    return parts[0], parts[1] if len(parts) > 1 else ""
+
+
+def push_result_to_s3(result: WorkUnitResult, s3_prefix: str, clients: dict) -> str:
+    """Push work unit result directly to S3. Returns the S3 URI."""
+    bucket, prefix = parse_s3_uri(s3_prefix)
+    result_key = f"{prefix}/results/{result.work_unit_id}.json"
+
+    clients["s3"].put_object(
+        Bucket=bucket,
+        Key=result_key,
+        Body=json.dumps(asdict(result), indent=2),
+        ContentType="application/json",
+    )
+
+    return f"s3://{bucket}/{result_key}"
+
+
+def update_campaign_progress(
+    campaign_id: str, work_unit_id: str, status: str, clients: dict
+) -> None:
+    """Update campaign progress in DynamoDB or S3."""
+    table_name = os.environ.get("FLUXION_CAMPAIGN_TABLE")
+    if table_name:
+        dynamodb = clients["dynamodb"]
+        try:
+            dynamodb.update_item(
+                TableName=table_name,
+                Key={"campaign_id": {"S": campaign_id}},
+                UpdateExpression="SET work_unit_statuses.#wid = :status, last_updated = :now",
+                ExpressionAttributeNames={"#wid": work_unit_id},
+                ExpressionAttributeValues={
+                    ":status": {"S": status},
+                    ":now": {"S": datetime.now(timezone.utc).isoformat()},
+                },
+            )
+        except ClientError as e:
+            print(f"[WARN] Failed to update DynamoDB: {e}", file=sys.stderr)
+    else:
+        s3_state_prefix = os.environ.get("FLUXION_CAMPAIGN_STATE_PREFIX", "")
+        if s3_state_prefix:
+            bucket, prefix = parse_s3_uri(s3_state_prefix)
+            state_key = f"{prefix}/{campaign_id}/progress/{work_unit_id}.json"
+            clients["s3"].put_object(
+                Bucket=bucket,
+                Key=state_key,
+                Body=json.dumps(
+                    {
+                        "work_unit_id": work_unit_id,
+                        "status": status,
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                    }
+                ),
+                ContentType="application/json",
+            )
+
+
+def run_simulation(work_unit: WorkUnit) -> tuple[dict[str, Any], str]:
+    """Run the ASHRAE validation for a single work unit."""
+    try:
+        result = subprocess.run(
+            CARGO_TEST_CMD,
+            capture_output=True,
+            text=True,
+            timeout=300,
+            cwd=Path(__file__).parent.parent,
+            env={**os.environ, **{f"FLUXION_PARAM_{k.upper()}": str(v) for k, v in work_unit.parameters.items()}},
+        )
+        output = result.stdout + result.stderr
+        metrics = parse_cargo_output(output)
+        return metrics, output
+    except subprocess.TimeoutExpired:
+        return {"error": "timeout"}, ""
+    except Exception as e:
+        return {"error": str(e)}, ""
+
+
+def parse_cargo_output(output: str) -> dict[str, Any]:
+    """Parse ASHRAE 140 validation output for MAE values."""
+    import re
+
+    metrics: dict[str, Any] = {
+        "heating_mae": 0.0,
+        "cooling_mae": 0.0,
+        "peak_heating_mae": 0.0,
+        "peak_cooling_mae": 0.0,
+        "temperature_mae": 0.0,
+        "overall_pass": False,
+    }
+
+    mae_pattern = re.compile(r"Mean\s+Absolute\s+Error:\s*([\d.]+)%", re.IGNORECASE)
+    for match in mae_pattern.finditer(output):
+        val = float(match.group(1))
+        if metrics["heating_mae"] == 0.0:
+            metrics["heating_mae"] = val
+
+    case_pattern = re.compile(
+        r"Case\s+(\d+[A-Z0-9_]*)\s*[:\-]\s*"
+        r"Heating\s*=\s*([\d.]+)\s*\(Ref:\s*([\d.+-]+)\s*-\s*([\d.+-]+)\),\s*"
+        r"Cooling\s*=\s*([\d.]+)\s*\(Ref:\s*([\d.+-]+)\s*-\s*([\d.+-]+)\)"
+    )
+
+    heating_errors = []
+    cooling_errors = []
+    for match in case_pattern.finditer(output):
+        case = match.group(1)
+        if work_unit.case_id and (case.startswith(work_unit.case_id) or work_unit.case_id in case):
+            ref_heat = (float(match.group(3)) + float(match.group(4))) / 2
+            ref_cool = (float(match.group(6)) + float(match.group(7))) / 2
+            sim_heat = float(match.group(2))
+            sim_cool = float(match.group(5))
+            if ref_heat > 0:
+                heating_errors.append(abs(sim_heat - ref_heat) / ref_heat * 100)
+            if ref_cool > 0:
+                cooling_errors.append(abs(sim_cool - ref_cool) / ref_cool * 100)
+
+    if heating_errors:
+        metrics["heating_mae"] = sum(heating_errors) / len(heating_errors)
+    if cooling_errors:
+        metrics["cooling_mae"] = sum(cooling_errors) / len(cooling_errors)
+
+    summary_pattern = re.compile(
+        r"Pass\s+Rate:\s*([\d.]+)%.*?Passed:\s*(\d+).*?Failed:\s*(\d+)",
+        re.DOTALL | re.IGNORECASE,
+    )
+    summary_match = summary_pattern.search(output)
+    if summary_match:
+        pass_rate = float(summary_match.group(1))
+        metrics["overall_pass"] = pass_rate >= 80.0
+
+    return metrics
+
+
+def run_worker(work_unit: WorkUnit) -> WorkUnitResult:
+    """Execute a single work unit and push result to S3."""
+    clients = get_aws_clients()
+    run_id = str(uuid.uuid4())[:8]
+
+    print(f"[*] Starting work unit {work_unit.work_unit_id}")
+    print(f"[*] Campaign: {work_unit.campaign_id}")
+    print(f"[*] Parameters: {work_unit.parameters}")
+
+    update_campaign_progress(
+        work_unit.campaign_id, work_unit.work_unit_id, "running", clients
+    )
+
+    start = time.time()
+    metrics, raw_output = run_simulation(work_unit)
+    duration_ms = int((time.time() - start) * 1000)
+
+    if "error" in metrics:
+        result = WorkUnitResult(
+            work_unit_id=work_unit.work_unit_id,
+            campaign_id=work_unit.campaign_id,
+            run_id=run_id,
+            case_id=work_unit.case_id,
+            parameters=work_unit.parameters,
+            heating_mae=999.0,
+            cooling_mae=999.0,
+            peak_heating_mae=999.0,
+            peak_cooling_mae=999.0,
+            temperature_mae=999.0,
+            overall_pass=False,
+            duration_ms=duration_ms,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            error_message=str(metrics.get("error", "unknown")),
+        )
+    else:
+        result = WorkUnitResult(
+            work_unit_id=work_unit.work_unit_id,
+            campaign_id=work_unit.campaign_id,
+            run_id=run_id,
+            case_id=work_unit.case_id,
+            parameters=work_unit.parameters,
+            heating_mae=metrics.get("heating_mae", 999.0),
+            cooling_mae=metrics.get("cooling_mae", 999.0),
+            peak_heating_mae=metrics.get("peak_heating_mae", 999.0),
+            peak_cooling_mae=metrics.get("peak_cooling_mae", 999.0),
+            temperature_mae=metrics.get("temperature_mae", 999.0),
+            overall_pass=metrics.get("overall_pass", False),
+            duration_ms=duration_ms,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
+
+    result_uri = push_result_to_s3(result, work_unit.s3_result_prefix, clients)
+    print(f"[*] Result pushed to: {result_uri}")
+
+    update_campaign_progress(
+        work_unit.campaign_id, work_unit.work_unit_id, "completed", clients
+    )
+
+    return result
+
+
+def run_sqs_worker(queue_url: str) -> None:
+    """Long-running SQS worker that processes messages from a queue."""
+    clients = get_aws_clients()
+    sqs = clients["sqs"] if "sqs" in clients else boto3.client("sqs")
+
+    print(f"[*] Listening on SQS queue: {queue_url}")
+
+    while True:
+        try:
+            response = sqs.receive_message(
+                QueueUrl=queue_url,
+                MaxNumberOfMessages=1,
+                WaitTimeSeconds=20,
+            )
+
+            messages = response.get("Messages", [])
+            for message in messages:
+                body = json.loads(message["Body"])
+                work_unit = download_work_unit(body["param_file"], clients)
+
+                try:
+                    run_worker(work_unit)
+                    sqs.delete_message(
+                        QueueUrl=queue_url, ReceiptHandle=message["ReceiptHandle"]
+                    )
+                except Exception as e:
+                    print(f"[ERROR] Work unit failed: {e}", file=sys.stderr)
+                    update_campaign_progress(
+                        work_unit.campaign_id,
+                        work_unit.work_unit_id,
+                        f"failed: {e}",
+                        clients,
+                    )
+
+        except KeyboardInterrupt:
+            print("[*] Shutting down worker...")
+            break
+        except Exception as e:
+            print(f"[ERROR] Worker error: {e}", file=sys.stderr)
+            time.sleep(5)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="S3 Worker for Fluxion Campaigns")
+    parser.add_argument(
+        "--campaign-id",
+        type=str,
+        help="Campaign ID",
+    )
+    parser.add_argument(
+        "--work-unit-id",
+        type=str,
+        help="Work unit ID",
+    )
+    parser.add_argument(
+        "--param-file",
+        type=str,
+        help="S3 URI or local path to work unit parameters",
+    )
+    parser.add_argument(
+        "--mode",
+        type=str,
+        choices=["single", "sqs"],
+        default="single",
+        help="Worker mode: single work unit or SQS listener",
+    )
+    parser.add_argument(
+        "--queue-url",
+        type=str,
+        help="SQS queue URL (for sqs mode)",
+    )
+    args = parser.parse_args()
+
+    if args.mode == "sqs":
+        if not args.queue_url:
+            parser.error("--queue-url is required for sqs mode")
+        run_sqs_worker(args.queue_url)
+        return 0
+
+    if not args.param_file:
+        parser.error("--param-file is required for single mode")
+
+    work_unit = download_work_unit(args.param_file, get_aws_clients())
+    result = run_worker(work_unit)
+
+    print(f"[*] Work unit complete: {result.work_unit_id}")
+    print(f"    MAE: {result.heating_mae:.2f}% heating, {result.cooling_mae:.2f}% cooling")
+
+    return 0 if result.error_message is None else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/physics/multi_node_solver.rs
+++ b/src/physics/multi_node_solver.rs
@@ -267,7 +267,13 @@ impl MultiNodeSolver {
     ///
     /// # Returns
     /// Free-floating zone air temperature [°C]
-    pub fn compute_zone_air_temperature(&self, t_outdoor: f64, h_ve: f64, h_ve_night: f64, phi_ia: f64) -> f64 {
+    pub fn compute_zone_air_temperature(
+        &self,
+        t_outdoor: f64,
+        h_ve: f64,
+        h_ve_night: f64,
+        phi_ia: f64,
+    ) -> f64 {
         // Conductance-weighted surface temperature from envelope nodes
         let h_ms_w = self.mass.wall.h_tr_ms;
         let h_ms_r = self.mass.roof.h_tr_ms;

--- a/src/sim/thermal_model_physics/physics_impl.rs
+++ b/src/sim/thermal_model_physics/physics_impl.rs
@@ -2256,8 +2256,12 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
                 } else {
                     0.0
                 };
-                let t_air_mn =
-                    solver.compute_zone_air_temperature(outdoor_temp, h_ve_val, h_ve_night_zone, phi_ia_val);
+                let t_air_mn = solver.compute_zone_air_temperature(
+                    outdoor_temp,
+                    h_ve_val,
+                    h_ve_night_zone,
+                    phi_ia_val,
+                );
                 // Use multi-node temperature — it provides the correct air balance
                 // from mass node temperatures stepped by the backward Euler.
                 t_i_free_data.push(t_air_mn);


### PR DESCRIPTION
## Summary

Implements **issue #1192**: Decouples execution campaigns from local machines using a Direct-to-S3 architecture.

### Problem
OSimFlow originally introduced a "Local Tether" bottleneck - submitting campaigns relied on the user's local machine to manage the loop. If the user disconnected or their laptop went to sleep, the remote simulation would drop.

### Solution
Cloud-hosted campaign orchestration where:
1. **Campaign state is stored in S3** - not local disk
2. **Workers push KPIs directly to S3** - no streaming back to local machine
3. **Cloud aggregator merges S3 results** - triggered on completion
4. **SNS notifications** - email/SMS on campaign completion

## Changes

### New Files

| File | Purpose |
|------|---------|
| `scripts/cloud_campaign_manager.py` | Main orchestration - create, status, wait, aggregate, notify |
| `scripts/s3_worker.py` | Worker script - processes work units, pushes to S3 |
| `scripts/s3_aggregator.py` | Aggregator - merges S3 results, generates reports |
| `.github/workflows/cloud_campaign.yml` | GitHub Actions workflow for campaign lifecycle |
| `infrastructure/cloud_campaign.yaml` | CloudFormation template for AWS setup |
| `docs/CLOUD_CAMPAIGN.md` | Documentation with architecture and usage |

### Modified Files

| File | Change |
|------|--------|
| `.env.example` | Added AWS/S3/SNS configuration variables |

## Architecture

```
┌──────────────────┐     ┌─────────────┐     ┌─────────────────┐
│ Cloud Campaign   │────▶│  S3 Bucket  │◀────│  S3 Worker      │
│ Manager          │     │             │     │  (Remote VM/EC2)│
└──────────────────┘     │  work-units │     └─────────────────┘
       │                 │  results/   │              │
       │                 │  state.json  │              │
       ▼                 └─────────────┘              ▼
┌──────────────────┐                              (push KPIs)
│ SNS Notification │◀──────────────────────────────┘
│ (Email/SMS)     │
└──────────────────┘
```

## Acceptance Criteria

- [x] Transition to a Cloud-Hosted Campaign Manager logic
- [x] Modify worker scripts to extract KPIs and push results directly to an S3 bucket
- [x] Create a cloud aggregator task to merge the S3 result files into a final dataset
- [x] Trigger an SNS/Email notification to the user containing a download link upon campaign completion

## Testing

To test locally:
```bash
# Set up environment
export AWS_ACCESS_KEY_ID=...
export AWS_SECRET_ACCESS_KEY=...
export FLUXION_S3_BUCKET=your-bucket
export FLUXION_S3_PREFIX=fluxion-campaigns

# Create a campaign
python scripts/cloud_campaign_manager.py --action create --case 600 --params R_value,wall_thickness

# Check status
python scripts/cloud_campaign_manager.py --action status --campaign-id <id>
```

## Migration

The local `autonomous_parameter_sweep.py` remains available for:
- Quick local debugging
- Small campaigns (< 10 runs)
- CI/local development

The cloud system is designed for production-scale campaigns that shouldn't be interrupted by local machine issues.

---

Fixes #1192