### PR TITLE
fix(tests): resolve #1208 — 4 synthetic CSVs relabeled as analytical fixtures

### DIFF
--- a/tests/conduction_5r1c_isolation.rs
+++ b/tests/conduction_5r1c_isolation.rs
@@ -5,11 +5,24 @@
 //! # Test Strategy
 //!
 //! Validates `FiveR1CSolver` (src/physics/five_r1c_solver.rs) against closed-form
-//! analytical solutions, not against EnergyPlus. This is bottom-up unit testing:
+//! analytical solutions, NOT against EnergyPlus reference data. This is bottom-up
+//! unit testing:
 //!
 //! 1. **Steady-state**: Q = ΔT / R_total (Fourier's law, 1D slab)
 //! 2. **Transient step response**: Exponential approach to steady-state
 //! 3. **Thermal time constant**: τ = C × R
+//!
+//! # Reference Data Sources
+//!
+//! There are 6 CSV files in `tests/reference_data/conduction/`:
+//! - 2 files are REAL EnergyPlus 25.2.0 output: `step_response_200mm_concrete.csv`,
+//!   `step_response_fixed_zone_20c.csv`
+//! - 4 files are SYNTHETIC analytical test fixtures: `step_response_composite.csv`,
+//!   `step_response_floor.csv`, `step_response_lightweight.csv`, `step_response_roof.csv`
+//!
+//! **This test file does NOT use the CSV files** — it computes expected values
+//! analytically from WallSpec parameters. The CSV files exist for future E+
+//! validation work but are clearly labeled as synthetic fixtures.
 //!
 //! # 5R1C Model (ISO 13790 / EN 15270)
 //!

--- a/tests/generate_conduction_reference_data.py
+++ b/tests/generate_conduction_reference_data.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python3
 """
-Generate EnergyPlus reference data for conduction step response tests.
+Generate analytical test fixture data for conduction step response tests.
 
-This script generates synthetic reference data for wall, roof, and floor
-constructions based on EnergyPlus simulation methodology.
+This script generates SYNTHETIC (analytical) reference data for wall, roof, and
+floor constructions. This is NOT EnergyPlus output — it uses a simplified thermal
+model to estimate step response behavior.
 
-For actual E+ validation, run these constructions in EnergyPlus and export
-the surface heat flux and temperature data.
+**IMPORTANT**: These files are test fixtures, NOT validation data.
+They are useful for testing solver behavior but should NOT be used to validate
+against actual EnergyPlus simulations.
+
+For actual E+ validation reference data, run constructions in EnergyPlus and
+export the surface heat flux and temperature data to real CSV files.
 
 Usage:
     python tests/generate_conduction_reference_data.py
@@ -372,9 +377,10 @@ def generate_step_response(
 
     # Write CSV
     with open(output_path, "w", newline="") as f:
-        f.write(f"# EnergyPlus Reference Data: {construction_name}\n")
-        f.write("# Generated: 2026-06-12 (synthetic for testing)\n")
-        f.write("# Note: Replace with actual E+ output for validation\n")
+        f.write(f"# Analytical Test Fixture: {construction_name}\n")
+        f.write("# Generated: 2026-06-12 (SYNTHETIC — NOT from EnergyPlus)\n")
+        f.write("# This file contains analytically-derived step response data for testing.\n")
+        f.write("# Do NOT use for EnergyPlus validation — not representative of actual E+ output.\n")
         f.write(f"# U-value: {u_value:.4f} W/m²K\n")
         f.write(f"# Total R-value: {r_total:.4f} m²K/W\n")
         f.write(f"# Thermal mass: {c_total:.1f} J/m²K\n")
@@ -454,9 +460,8 @@ def main():
     )
 
     print("\nReference data generation complete.")
-    print(
-        "NOTE: These are synthetic data files. Replace with actual E+ output for validation."
-    )
+    print("NOTE: These are synthetic test fixtures, NOT EnergyPlus output.")
+    print("For E+ validation, replace with actual simulation results.")
 
 
 if __name__ == "__main__":

--- a/tests/reference_data/conduction/step_response_composite.csv
+++ b/tests/reference_data/conduction/step_response_composite.csv
@@ -1,6 +1,7 @@
-# EnergyPlus Reference Data: Composite Concrete Wall
-# Generated: 2026-06-12 (synthetic for testing)
-# Note: Replace with actual E+ output for validation
+# Analytical Test Fixture: Composite Concrete Wall
+# Generated: 2026-06-12 (SYNTHETIC — NOT from EnergyPlus)
+# This file contains analytically-derived step response data for testing purposes.
+# Do NOT use for EnergyPlus validation — not representative of actual E+ output.
 # U-value: 0.5059 W/m²K
 # Total R-value: 1.9768 m²K/W
 # Thermal mass: 258805.4 J/m²K

--- a/tests/reference_data/conduction/step_response_floor.csv
+++ b/tests/reference_data/conduction/step_response_floor.csv
@@ -1,6 +1,7 @@
-# EnergyPlus Reference Data: Insulated Floor
-# Generated: 2026-06-12 (synthetic for testing)
-# Note: Replace with actual E+ output for validation
+# Analytical Test Fixture: Insulated Floor
+# Generated: 2026-06-12 (SYNTHETIC — NOT from EnergyPlus)
+# This file contains analytically-derived step response data for testing purposes.
+# Do NOT use for EnergyPlus validation — not representative of actual E+ output.
 # U-value: 0.1902 W/m²K
 # Total R-value: 5.2583 m²K/W
 # Thermal mass: 25985.8 J/m²K

--- a/tests/reference_data/conduction/step_response_lightweight.csv
+++ b/tests/reference_data/conduction/step_response_lightweight.csv
@@ -1,6 +1,7 @@
-# EnergyPlus Reference Data: Lightweight Steel Stud Wall
-# Generated: 2026-06-12 (synthetic for testing)
-# Note: Replace with actual E+ output for validation
+# Analytical Test Fixture: Lightweight Steel Stud Wall
+# Generated: 2026-06-12 (SYNTHETIC — NOT from EnergyPlus)
+# This file contains analytically-derived step response data for testing purposes.
+# Do NOT use for EnergyPlus validation — not representative of actual E+ output.
 # U-value: 0.5314 W/m²K
 # Total R-value: 1.8818 m²K/W
 # Thermal mass: 359568.0 J/m²K

--- a/tests/reference_data/conduction/step_response_roof.csv
+++ b/tests/reference_data/conduction/step_response_roof.csv
@@ -1,6 +1,7 @@
-# EnergyPlus Reference Data: Roof Assembly
-# Generated: 2026-06-12 (synthetic for testing)
-# Note: Replace with actual E+ output for validation
+# Analytical Test Fixture: Roof Assembly
+# Generated: 2026-06-12 (SYNTHETIC — NOT from EnergyPlus)
+# This file contains analytically-derived step response data for testing purposes.
+# Do NOT use for EnergyPlus validation — not representative of actual E+ output.
 # U-value: 0.3177 W/m²K
 # Total R-value: 3.1480 m²K/W
 # Thermal mass: 20062.5 J/m²K


### PR DESCRIPTION
Resolves #1208 by relabeling 4 synthetic CSV files as Analytical Test Fixtures rather than misrepresenting them as EnergyPlus output.