### PR TITLE
fix(ventilation): resolve #1207 — make get_ach weather-dependent

### DIFF
--- a/src/sim/ventilation.rs
+++ b/src/sim/ventilation.rs
@@ -110,9 +110,26 @@ pub fn calculate_combined_infiltration_ach(
 }
 
 /// Trait for defining air change rate (ACH) schedules.
+///
+/// All implementations should return weather-dependent ACH when applicable,
+/// using the provided weather parameters.
 pub trait VentilationSchedule: Debug + Send + Sync {
     /// Returns the air change rate (ACH) for a given hour.
-    fn get_ach(&self, hour: usize) -> f64;
+    ///
+    /// # Arguments
+    /// * `hour` - Hour of day (0-23)
+    /// * `T_outdoor` - Outdoor temperature [C]
+    /// * `T_indoor` - Indoor temperature [C]
+    /// * `wind_speed` - Wind speed [m/s]
+    /// * `volume` - Zone volume [m³]
+    fn get_ach(
+        &self,
+        hour: usize,
+        T_outdoor: f64,
+        T_indoor: f64,
+        wind_speed: f64,
+        volume: f64,
+    ) -> f64;
     /// Clones the schedule into a boxed trait object.
     fn clone_box(&self) -> Box<dyn VentilationSchedule>;
 }
@@ -130,7 +147,14 @@ impl ConstantVentilation {
 }
 
 impl VentilationSchedule for ConstantVentilation {
-    fn get_ach(&self, _hour: usize) -> f64 {
+    fn get_ach(
+        &self,
+        _hour: usize,
+        _T_outdoor: f64,
+        _T_indoor: f64,
+        _wind_speed: f64,
+        _volume: f64,
+    ) -> f64 {
         self.ach
     }
     fn clone_box(&self) -> Box<dyn VentilationSchedule> {
@@ -186,7 +210,14 @@ impl ScheduledVentilation {
 }
 
 impl VentilationSchedule for ScheduledVentilation {
-    fn get_ach(&self, hour: usize) -> f64 {
+    fn get_ach(
+        &self,
+        hour: usize,
+        _T_outdoor: f64,
+        _T_indoor: f64,
+        _wind_speed: f64,
+        _volume: f64,
+    ) -> f64 {
         if self.schedule[hour] {
             self.base_ach + self.fan_ach
         } else {
@@ -321,8 +352,15 @@ impl WeatherDependentVentilation {
 }
 
 impl VentilationSchedule for WeatherDependentVentilation {
-    fn get_ach(&self, _hour: usize) -> f64 {
-        self.base_ach
+    fn get_ach(
+        &self,
+        _hour: usize,
+        T_outdoor: f64,
+        T_indoor: f64,
+        wind_speed: f64,
+        volume: f64,
+    ) -> f64 {
+        self.get_ach_weather(T_outdoor, T_indoor, wind_speed, volume)
     }
     fn clone_box(&self) -> Box<dyn VentilationSchedule> {
         Box::new(self.clone())
@@ -361,16 +399,16 @@ mod tests {
     fn test_constant_ventilation() {
         let vent = ConstantVentilation::new(0.5);
         assert_eq!(vent.ach, 0.5);
-        assert_eq!(vent.get_ach(0), 0.5);
-        assert_eq!(vent.get_ach(12), 0.5);
-        assert_eq!(vent.get_ach(23), 0.5);
+        assert_eq!(vent.get_ach(0, 20.0, 22.0, 2.0, 100.0), 0.5);
+        assert_eq!(vent.get_ach(12, 20.0, 22.0, 2.0, 100.0), 0.5);
+        assert_eq!(vent.get_ach(23, 20.0, 22.0, 2.0, 100.0), 0.5);
     }
 
     #[test]
     fn test_constant_ventilation_clone() {
         let vent = ConstantVentilation::new(1.0);
         let cloned = vent.clone_box();
-        assert_eq!(cloned.get_ach(5), 1.0);
+        assert_eq!(cloned.get_ach(5, 20.0, 22.0, 2.0, 100.0), 1.0);
     }
 
     #[test]
@@ -381,7 +419,7 @@ mod tests {
         assert!(!vent.schedule.iter().any(|&x| x)); // all false
                                                     // Should return base_ach for all hours
         for hour in 0..24 {
-            assert_eq!(vent.get_ach(hour), 0.3);
+            assert_eq!(vent.get_ach(hour, 20.0, 22.0, 2.0, 100.0), 0.3);
         }
     }
 
@@ -389,13 +427,13 @@ mod tests {
     fn test_night_ventilation_normal_range() {
         let vent = ScheduledVentilation::night_ventilation(0.3, 2.0, 22, 6);
         // Fan ON from hour 22 to 23, 0 to 5
-        assert_eq!(vent.get_ach(21), 0.3); // before start
-        assert_eq!(vent.get_ach(22), 2.3); // fan on
-        assert_eq!(vent.get_ach(23), 2.3); // fan on
-        assert_eq!(vent.get_ach(0), 2.3); // fan on (next day)
-        assert_eq!(vent.get_ach(5), 2.3); // fan on
-        assert_eq!(vent.get_ach(6), 0.3); // fan off
-        assert_eq!(vent.get_ach(12), 0.3); // fan off
+        assert_eq!(vent.get_ach(21, 20.0, 22.0, 2.0, 100.0), 0.3); // before start
+        assert_eq!(vent.get_ach(22, 20.0, 22.0, 2.0, 100.0), 2.3); // fan on
+        assert_eq!(vent.get_ach(23, 20.0, 22.0, 2.0, 100.0), 2.3); // fan on
+        assert_eq!(vent.get_ach(0, 20.0, 22.0, 2.0, 100.0), 2.3); // fan on (next day)
+        assert_eq!(vent.get_ach(5, 20.0, 22.0, 2.0, 100.0), 2.3); // fan on
+        assert_eq!(vent.get_ach(6, 20.0, 22.0, 2.0, 100.0), 0.3); // fan off
+        assert_eq!(vent.get_ach(12, 20.0, 22.0, 2.0, 100.0), 0.3); // fan off
     }
 
     #[test]
@@ -403,24 +441,24 @@ mod tests {
         let vent = ScheduledVentilation::night_ventilation(0.3, 2.0, 10, 10);
         // When start == end, fan is on all 24 hours
         for hour in 0..24 {
-            assert_eq!(vent.get_ach(hour), 2.3);
+            assert_eq!(vent.get_ach(hour, 20.0, 22.0, 2.0, 100.0), 2.3);
         }
     }
 
     #[test]
     fn test_night_ventilation_single_hour() {
         let vent = ScheduledVentilation::night_ventilation(0.5, 1.5, 14, 15);
-        assert_eq!(vent.get_ach(13), 0.5);
-        assert_eq!(vent.get_ach(14), 2.0); // fan on
-        assert_eq!(vent.get_ach(15), 0.5); // fan off
+        assert_eq!(vent.get_ach(13, 20.0, 22.0, 2.0, 100.0), 0.5);
+        assert_eq!(vent.get_ach(14, 20.0, 22.0, 2.0, 100.0), 2.0); // fan on
+        assert_eq!(vent.get_ach(15, 20.0, 22.0, 2.0, 100.0), 0.5); // fan off
     }
 
     #[test]
     fn test_scheduled_ventilation_clone() {
         let vent = ScheduledVentilation::night_ventilation(0.3, 2.0, 20, 8);
         let cloned = vent.clone_box();
-        assert_eq!(cloned.get_ach(21), 2.3);
-        assert_eq!(cloned.get_ach(10), 0.3);
+        assert_eq!(cloned.get_ach(21, 20.0, 22.0, 2.0, 100.0), 2.3);
+        assert_eq!(cloned.get_ach(10, 20.0, 22.0, 2.0, 100.0), 0.3);
     }
 
     #[test]
@@ -452,8 +490,8 @@ mod tests {
         let vent2: Box<dyn VentilationSchedule> =
             Box::new(ScheduledVentilation::night_ventilation(0.3, 2.0, 22, 6));
 
-        assert_eq!(vent1.get_ach(10), 0.5);
-        assert_eq!(vent2.get_ach(23), 2.3);
+        assert_eq!(vent1.get_ach(10, 20.0, 22.0, 2.0, 100.0), 0.5);
+        assert_eq!(vent2.get_ach(23, 20.0, 22.0, 2.0, 100.0), 2.3);
     }
 
     #[test]

--- a/tests/test_ventilation.rs
+++ b/tests/test_ventilation.rs
@@ -27,17 +27,17 @@ fn test_constant_ventilation_returns_same_ach() {
     let vent = ConstantVentilation::new(0.75);
 
     // Should return same ACH for any hour
-    assert_eq!(vent.get_ach(0), 0.75);
-    assert_eq!(vent.get_ach(6), 0.75);
-    assert_eq!(vent.get_ach(12), 0.75);
-    assert_eq!(vent.get_ach(23), 0.75);
+    assert_eq!(vent.get_ach(0, 20.0, 24.0, 2.0, 100.0), 0.75);
+    assert_eq!(vent.get_ach(6, 20.0, 24.0, 2.0, 100.0), 0.75);
+    assert_eq!(vent.get_ach(12, 20.0, 24.0, 2.0, 100.0), 0.75);
+    assert_eq!(vent.get_ach(23, 20.0, 24.0, 2.0, 100.0), 0.75);
 }
 
 #[test]
 fn test_constant_ventilation_zero_ach() {
     let vent = ConstantVentilation::new(0.0);
-    assert_eq!(vent.get_ach(0), 0.0);
-    assert_eq!(vent.get_ach(12), 0.0);
+    assert_eq!(vent.get_ach(0, 20.0, 24.0, 2.0, 100.0), 0.0);
+    assert_eq!(vent.get_ach(12, 20.0, 24.0, 2.0, 100.0), 0.0);
 }
 
 #[test]
@@ -45,8 +45,8 @@ fn test_constant_ventilation_clone() {
     let vent = ConstantVentilation::new(1.0);
     let cloned = vent.clone_box();
 
-    assert_eq!(cloned.get_ach(5), 1.0);
-    assert_eq!(cloned.get_ach(15), 1.0);
+    assert_eq!(cloned.get_ach(5, 20.0, 24.0, 2.0, 100.0), 1.0);
+    assert_eq!(cloned.get_ach(15, 20.0, 24.0, 2.0, 100.0), 1.0);
 }
 
 // ============================================================================
@@ -71,7 +71,7 @@ fn test_scheduled_ventilation_night_cooling_same_hour() {
 
     for hour in 0..24 {
         assert!(vent.schedule[hour], "Hour {} should be ON", hour);
-        assert_eq!(vent.get_ach(hour), 0.3 + 3.0);
+        assert_eq!(vent.get_ach(hour, 20.0, 24.0, 2.0, 100.0), 0.3 + 3.0);
     }
 }
 
@@ -95,9 +95,9 @@ fn test_scheduled_ventilation_night_cooling_normal_range() {
     }
 
     // Verify ACH values
-    assert_eq!(vent.get_ach(22), 0.3 + 2.0); // Fan ON
-    assert_eq!(vent.get_ach(3), 0.3 + 2.0); // Fan ON
-    assert_eq!(vent.get_ach(12), 0.3); // Fan OFF
+    assert_eq!(vent.get_ach(22, 20.0, 24.0, 2.0, 100.0), 0.3 + 2.0); // Fan ON
+    assert_eq!(vent.get_ach(3, 20.0, 24.0, 2.0, 100.0), 0.3 + 2.0); // Fan ON
+    assert_eq!(vent.get_ach(12, 20.0, 24.0, 2.0, 100.0), 0.3); // Fan OFF
 }
 
 #[test]
@@ -119,8 +119,8 @@ fn test_scheduled_ventilation_daytime_only() {
     }
 
     // Verify ACH values
-    assert_eq!(vent.get_ach(10), 0.5 + 1.5); // Fan ON
-    assert_eq!(vent.get_ach(20), 0.5); // Fan OFF
+    assert_eq!(vent.get_ach(10, 20.0, 24.0, 2.0, 100.0), 0.5 + 1.5); // Fan ON
+    assert_eq!(vent.get_ach(20, 20.0, 24.0, 2.0, 100.0), 0.5); // Fan OFF
 }
 
 #[test]
@@ -132,8 +132,8 @@ fn test_scheduled_ventilation_single_hour() {
     assert!(!vent.schedule[13]);
     assert!(!vent.schedule[15]);
 
-    assert_eq!(vent.get_ach(14), 0.3 + 2.0);
-    assert_eq!(vent.get_ach(13), 0.3);
+    assert_eq!(vent.get_ach(14, 20.0, 24.0, 2.0, 100.0), 0.3 + 2.0);
+    assert_eq!(vent.get_ach(13, 20.0, 24.0, 2.0, 100.0), 0.3);
 }
 
 #[test]
@@ -141,9 +141,9 @@ fn test_scheduled_ventilation_clone() {
     let vent = ScheduledVentilation::night_ventilation(0.5, 1.0, 20, 6);
     let cloned = vent.clone_box();
 
-    assert_eq!(cloned.get_ach(22), 0.5 + 1.0);
-    assert_eq!(cloned.get_ach(3), 0.5 + 1.0);
-    assert_eq!(cloned.get_ach(12), 0.5);
+    assert_eq!(cloned.get_ach(22, 20.0, 24.0, 2.0, 100.0), 0.5 + 1.0);
+    assert_eq!(cloned.get_ach(3, 20.0, 24.0, 2.0, 100.0), 0.5 + 1.0);
+    assert_eq!(cloned.get_ach(12, 20.0, 24.0, 2.0, 100.0), 0.5);
 }
 
 #[test]
@@ -152,10 +152,10 @@ fn test_scheduled_ventilation_zero_fan_ach() {
     let vent = ScheduledVentilation::night_ventilation(0.5, 0.0, 20, 6);
 
     for hour in 20..24 {
-        assert_eq!(vent.get_ach(hour), 0.5);
+        assert_eq!(vent.get_ach(hour, 20.0, 24.0, 2.0, 100.0), 0.5);
     }
     for hour in 0..6 {
-        assert_eq!(vent.get_ach(hour), 0.5);
+        assert_eq!(vent.get_ach(hour, 20.0, 24.0, 2.0, 100.0), 0.5);
     }
 }
 
@@ -274,7 +274,7 @@ fn test_ach_to_conductance_different_air_properties() {
 fn test_ventilation_negative_ach_handling() {
     // Negative ACH doesn't make physical sense, but we should handle it gracefully
     let vent = ConstantVentilation::new(-0.5);
-    let ach = vent.get_ach(0);
+    let ach = vent.get_ach(0, 20.0, 24.0, 2.0, 100.0);
 
     // The implementation doesn't clamp to positive, so we just verify it returns the value
     assert_eq!(ach, -0.5);
@@ -284,7 +284,7 @@ fn test_ventilation_negative_ach_handling() {
 fn test_ventilation_very_high_ach() {
     // Very high ventilation rate (industrial)
     let vent = ConstantVentilation::new(50.0);
-    assert_eq!(vent.get_ach(0), 50.0);
+    assert_eq!(vent.get_ach(0, 20.0, 24.0, 2.0, 100.0), 50.0);
 
     let conductance = ach_to_conductance(50.0, 100.0, 1.2, 1005.0);
     assert!(conductance.get::<watt_per_kelvin>() > 0.0);
@@ -298,7 +298,7 @@ fn test_scheduled_ventilation_full_day_on() {
     vent.schedule = [true; 24];
 
     for hour in 0..24 {
-        assert_eq!(vent.get_ach(hour), 0.3 + 1.0);
+        assert_eq!(vent.get_ach(hour, 20.0, 24.0, 2.0, 100.0), 0.3 + 1.0);
     }
 }
 
@@ -309,7 +309,7 @@ fn test_scheduled_ventilation_full_day_off() {
     // Default schedule is all false
 
     for hour in 0..24 {
-        assert_eq!(vent.get_ach(hour), 0.5);
+        assert_eq!(vent.get_ach(hour, 20.0, 24.0, 2.0, 100.0), 0.5);
     }
 }
 
@@ -323,7 +323,7 @@ fn test_ventilation_trait_object_usage() {
 
     // Should be able to call get_ach on any schedule
     for schedule in &schedules {
-        let ach = schedule.get_ach(12);
+        let ach = schedule.get_ach(12, 20.0, 24.0, 2.0, 100.0);
         assert!(ach >= 0.0);
     }
 }
@@ -351,17 +351,17 @@ fn test_scheduled_ventilation_boundary_hours() {
 
     // Hour 23 should be ON
     assert!(vent.schedule[23]);
-    assert_eq!(vent.get_ach(23), 1.3);
+    assert_eq!(vent.get_ach(23, 20.0, 24.0, 2.0, 100.0), 1.3);
 
     // Hour 0 should be ON
     assert!(vent.schedule[0]);
-    assert_eq!(vent.get_ach(0), 1.3);
+    assert_eq!(vent.get_ach(0, 20.0, 24.0, 2.0, 100.0), 1.3);
 
     // Hour 1 should be OFF (end_hour is exclusive)
     assert!(!vent.schedule[1]);
-    assert_eq!(vent.get_ach(1), 0.3);
+    assert_eq!(vent.get_ach(1, 20.0, 24.0, 2.0, 100.0), 0.3);
 
     // Hour 22 should be OFF
     assert!(!vent.schedule[22]);
-    assert_eq!(vent.get_ach(22), 0.3);
+    assert_eq!(vent.get_ach(22, 20.0, 24.0, 2.0, 100.0), 0.3);
 }

--- a/tests/ventilation_infiltration_vs_energyplus.rs
+++ b/tests/ventilation_infiltration_vs_energyplus.rs
@@ -110,7 +110,7 @@ fn test_constant_ach_matches_energyplus() {
     let mut sum_error_pct = 0.0_f64;
 
     for row in &ref_data {
-        let our_ach = vent.get_ach(row.hour - 1); // 0-indexed hour
+        let our_ach = vent.get_ach(row.hour - 1, row.outdoor_temp, 20.0, row.wind_speed, VOLUME); // 0-indexed hour
         let ep_ach = row.infiltration_ach;
 
         let error_pct = if ep_ach.abs() > 1e-10 {

--- a/tests/ventilation_schedule_trait.rs
+++ b/tests/ventilation_schedule_trait.rs
@@ -15,7 +15,7 @@
 //! - [x] Test runs in <100ms
 
 use fluxion::sim::ventilation::{
-    ach_to_conductance, calculate_combined_infiltration_ach, calculate_stack_infiltration_ach,
+    calculate_combined_infiltration_ach, calculate_stack_infiltration_ach,
     calculate_wind_infiltration_ach, ConstantVentilation, ScheduledVentilation,
     VentilationSchedule, WeatherDependentVentilation,
 };
@@ -28,7 +28,11 @@ use fluxion::sim::ventilation::{
 fn constant_ventilation_same_ach_all_hours() {
     let vent = ConstantVentilation::new(1.5);
     for hour in 0..8760 {
-        assert_eq!(vent.get_ach(hour), 1.5, "Hour {hour} should return 1.5 ACH");
+        assert_eq!(
+            vent.get_ach(hour, 20.0, 24.0, 2.0, 100.0),
+            1.5,
+            "Hour {hour} should return 1.5 ACH"
+        );
     }
 }
 
@@ -36,15 +40,15 @@ fn constant_ventilation_same_ach_all_hours() {
 fn constant_ventilation_zero_ach_is_non_negative() {
     let vent = ConstantVentilation::new(0.0);
     for hour in 0..24 {
-        assert!(vent.get_ach(hour) >= 0.0);
+        assert!(vent.get_ach(hour, 20.0, 24.0, 2.0, 100.0) >= 0.0);
     }
 }
 
 #[test]
 fn constant_ventilation_high_ach_remains_non_negative() {
     let vent = ConstantVentilation::new(100.0);
-    assert!(vent.get_ach(0) >= 0.0);
-    assert_eq!(vent.get_ach(0), 100.0);
+    assert!(vent.get_ach(0, 20.0, 24.0, 2.0, 100.0) >= 0.0);
+    assert_eq!(vent.get_ach(0, 20.0, 24.0, 2.0, 100.0), 100.0);
 }
 
 // ============================================================================
@@ -58,7 +62,7 @@ fn scheduled_ventilation_transitions_at_correct_hours_normal_range() {
     // Fan ON: 22, 23, 0, 1, 2, 3, 4, 5
     for hour in [22, 23, 0, 1, 2, 3, 4, 5] {
         assert_eq!(
-            vent.get_ach(hour),
+            vent.get_ach(hour, 20.0, 24.0, 2.0, 100.0),
             2.5,
             "Hour {hour} should have fan ON (ACH = 2.5)"
         );
@@ -67,7 +71,7 @@ fn scheduled_ventilation_transitions_at_correct_hours_normal_range() {
     // Fan OFF: 6..22
     for hour in 6..22 {
         assert_eq!(
-            vent.get_ach(hour),
+            vent.get_ach(hour, 20.0, 24.0, 2.0, 100.0),
             0.5,
             "Hour {hour} should have fan OFF (ACH = 0.5)"
         );
@@ -80,17 +84,29 @@ fn scheduled_ventilation_transitions_daytime_range() {
 
     // Fan ON: 8..18
     for hour in 8..18 {
-        assert_eq!(vent.get_ach(hour), 1.8, "Hour {hour}: fan ON");
+        assert_eq!(
+            vent.get_ach(hour, 20.0, 24.0, 2.0, 100.0),
+            1.8,
+            "Hour {hour}: fan ON"
+        );
     }
 
     // Fan OFF: 0..8
     for hour in 0..8 {
-        assert_eq!(vent.get_ach(hour), 0.3, "Hour {hour}: fan OFF");
+        assert_eq!(
+            vent.get_ach(hour, 20.0, 24.0, 2.0, 100.0),
+            0.3,
+            "Hour {hour}: fan OFF"
+        );
     }
 
     // Fan OFF: 18..24
     for hour in 18..24 {
-        assert_eq!(vent.get_ach(hour), 0.3, "Hour {hour}: fan OFF");
+        assert_eq!(
+            vent.get_ach(hour, 20.0, 24.0, 2.0, 100.0),
+            0.3,
+            "Hour {hour}: fan OFF"
+        );
     }
 }
 
@@ -98,16 +114,20 @@ fn scheduled_ventilation_transitions_daytime_range() {
 fn scheduled_ventilation_all_on_when_start_equals_end() {
     let vent = ScheduledVentilation::night_ventilation(0.2, 3.0, 10, 10);
     for hour in 0..24 {
-        assert_eq!(vent.get_ach(hour), 3.2, "Hour {hour}: all-on");
+        assert_eq!(
+            vent.get_ach(hour, 20.0, 24.0, 2.0, 100.0),
+            3.2,
+            "Hour {hour}: all-on"
+        );
     }
 }
 
 #[test]
 fn scheduled_ventilation_single_hour_transition() {
     let vent = ScheduledVentilation::night_ventilation(0.4, 1.0, 14, 15);
-    assert_eq!(vent.get_ach(13), 0.4); // OFF before
-    assert_eq!(vent.get_ach(14), 1.4); // ON
-    assert_eq!(vent.get_ach(15), 0.4); // OFF after (end is exclusive)
+    assert_eq!(vent.get_ach(13, 20.0, 24.0, 2.0, 100.0), 0.4); // OFF before
+    assert_eq!(vent.get_ach(14, 20.0, 24.0, 2.0, 100.0), 1.4); // ON
+    assert_eq!(vent.get_ach(15, 20.0, 24.0, 2.0, 100.0), 0.4); // OFF after (end is exclusive)
 }
 
 #[test]
@@ -115,17 +135,17 @@ fn scheduled_ventilation_midnight_wrap_boundary() {
     // Start=23, end=1 — wraps around midnight
     let vent = ScheduledVentilation::night_ventilation(0.3, 2.0, 23, 1);
 
-    assert_eq!(vent.get_ach(22), 0.3); // OFF
-    assert_eq!(vent.get_ach(23), 2.3); // ON
-    assert_eq!(vent.get_ach(0), 2.3); // ON
-    assert_eq!(vent.get_ach(1), 0.3); // OFF (end exclusive)
+    assert_eq!(vent.get_ach(22, 20.0, 24.0, 2.0, 100.0), 0.3); // OFF
+    assert_eq!(vent.get_ach(23, 20.0, 24.0, 2.0, 100.0), 2.3); // ON
+    assert_eq!(vent.get_ach(0, 20.0, 24.0, 2.0, 100.0), 2.3); // ON
+    assert_eq!(vent.get_ach(1, 20.0, 24.0, 2.0, 100.0), 0.3); // OFF (end exclusive)
 }
 
 #[test]
 fn scheduled_ventilation_always_non_negative() {
     let vent = ScheduledVentilation::night_ventilation(0.1, 0.5, 0, 24);
     for hour in 0..24 {
-        assert!(vent.get_ach(hour) >= 0.0);
+        assert!(vent.get_ach(hour, 20.0, 24.0, 2.0, 100.0) >= 0.0);
     }
 }
 
@@ -133,7 +153,11 @@ fn scheduled_ventilation_always_non_negative() {
 fn scheduled_ventilation_no_schedule_returns_base() {
     let vent = ScheduledVentilation::new(0.5, 3.0);
     for hour in 0..24 {
-        assert_eq!(vent.get_ach(hour), 0.5, "Default schedule: all OFF");
+        assert_eq!(
+            vent.get_ach(hour, 20.0, 24.0, 2.0, 100.0),
+            0.5,
+            "Default schedule: all OFF"
+        );
     }
 }
 
@@ -143,11 +167,11 @@ fn scheduled_ventilation_no_schedule_returns_base() {
 
 #[test]
 fn weather_dependent_base_ach_via_trait() {
-    // get_ach() on the trait returns base_ach (weather-agnostic fallback)
+    // get_ach() on the trait returns weather-dependent ACH
     let vent = WeatherDependentVentilation::new(0.5, 0.5, 3.0, 18.0, 26.0);
     for hour in 0..24 {
-        assert!(vent.get_ach(hour) >= 0.0);
-        assert_eq!(vent.get_ach(hour), 0.5);
+        let ach = vent.get_ach(hour, 20.0, 24.0, 2.0, 100.0);
+        assert!(ach >= 0.0);
     }
 }
 
@@ -233,7 +257,7 @@ fn weather_dependent_mixed_mode_construction() {
     let vent = WeatherDependentVentilation::mixed_mode(0.3, 3.0, 18.0, 26.0, 25.0);
     assert_eq!(vent.min_ach, vent.base_ach);
     assert_eq!(vent.indoor_cooling_setpoint, 25.0);
-    assert!(vent.get_ach(0) >= 0.0);
+    assert!(vent.get_ach(0, 20.0, 24.0, 2.0, 100.0) >= 0.0);
 }
 
 // ============================================================================
@@ -247,8 +271,8 @@ fn trait_dispatch_matches_direct_call_constant() {
 
     for hour in [0, 6, 12, 18, 23] {
         assert_eq!(
-            vent.get_ach(hour),
-            boxed.get_ach(hour),
+            vent.get_ach(hour, 20.0, 24.0, 2.0, 100.0),
+            boxed.get_ach(hour, 20.0, 24.0, 2.0, 100.0),
             "Direct vs dispatch mismatch at hour {hour}"
         );
     }
@@ -261,8 +285,8 @@ fn trait_dispatch_matches_direct_call_scheduled() {
 
     for hour in 0..24 {
         assert_eq!(
-            vent.get_ach(hour),
-            boxed.get_ach(hour),
+            vent.get_ach(hour, 20.0, 24.0, 2.0, 100.0),
+            boxed.get_ach(hour, 20.0, 24.0, 2.0, 100.0),
             "Direct vs dispatch mismatch at hour {hour}"
         );
     }
@@ -275,8 +299,8 @@ fn trait_dispatch_matches_direct_call_weather() {
 
     for hour in [0, 6, 12, 18, 23] {
         assert_eq!(
-            vent.get_ach(hour),
-            boxed.get_ach(hour),
+            vent.get_ach(hour, 20.0, 24.0, 2.0, 100.0),
+            boxed.get_ach(hour, 20.0, 24.0, 2.0, 100.0),
             "Direct vs dispatch mismatch at hour {hour}"
         );
     }
@@ -288,8 +312,14 @@ fn trait_dispatch_clone_box_roundtrip() {
     let cloned = original.clone_box();
     let recloned = cloned.clone_box();
 
-    assert_eq!(original.get_ach(5), cloned.get_ach(5));
-    assert_eq!(original.get_ach(5), recloned.get_ach(5));
+    assert_eq!(
+        original.get_ach(5, 20.0, 24.0, 2.0, 100.0),
+        cloned.get_ach(5, 20.0, 24.0, 2.0, 100.0)
+    );
+    assert_eq!(
+        original.get_ach(5, 20.0, 24.0, 2.0, 100.0),
+        recloned.get_ach(5, 20.0, 24.0, 2.0, 100.0)
+    );
 }
 
 #[test]
@@ -301,7 +331,7 @@ fn trait_dispatch_collection_of_mixed_types() {
     ];
 
     for (i, schedule) in schedules.iter().enumerate() {
-        let ach = schedule.get_ach(12);
+        let ach = schedule.get_ach(12, 20.0, 24.0, 2.0, 100.0);
         assert!(
             ach >= 0.0,
             "Schedule {i}: ACH must be non-negative, got {ach}"
@@ -316,15 +346,15 @@ fn trait_dispatch_collection_of_mixed_types() {
 #[test]
 fn edge_case_zero_ach_constant() {
     let vent = ConstantVentilation::new(0.0);
-    assert_eq!(vent.get_ach(0), 0.0);
-    assert_eq!(vent.get_ach(8759), 0.0);
+    assert_eq!(vent.get_ach(0, 20.0, 24.0, 2.0, 100.0), 0.0);
+    assert_eq!(vent.get_ach(8759, 20.0, 24.0, 2.0, 100.0), 0.0);
 }
 
 #[test]
 fn edge_case_zero_ach_scheduled() {
     let vent = ScheduledVentilation::new(0.0, 0.0);
     for hour in 0..24 {
-        assert_eq!(vent.get_ach(hour), 0.0);
+        assert_eq!(vent.get_ach(hour, 20.0, 24.0, 2.0, 100.0), 0.0);
     }
 }
 
@@ -440,10 +470,10 @@ fn test_completes_within_100ms() {
 
     let mut sum = 0.0f64;
     for hour in 0..8760 {
-        sum += constant.get_ach(hour);
-        sum += weather.get_ach(hour);
+        sum += constant.get_ach(hour, 20.0, 24.0, 2.0, 100.0);
+        sum += weather.get_ach(hour, 20.0, 24.0, 2.0, 100.0);
         // ScheduledVentilation indexes a 24-element array, use hour % 24
-        sum += scheduled.get_ach(hour % 24);
+        sum += scheduled.get_ach(hour % 24, 20.0, 24.0, 2.0, 100.0);
     }
 
     // Prevent optimizer from removing the loop


### PR DESCRIPTION
## Summary

Fixed the critical bug where WeatherDependentVentilation::get_ach() ignored all weather parameters and always returned base_ach.

## Changes

### Option A implemented: Added weather parameters to trait signature

Updated VentilationSchedule::get_ach() to accept weather-dependent parameters:
- hour: usize
- T_outdoor: f64 (C)
- T_indoor: f64 (C)
- wind_speed: f64 (m/s)
- volume: f64 (m3)

### Updated implementations

1. ConstantVentilation: Ignores weather params, returns constant ach
2. ScheduledVentilation: Ignores weather params, uses hour for schedule lookup
3. WeatherDependentVentilation: Now calls get_ach_weather() with actual weather parameters

### Files modified

- src/sim/ventilation.rs - Trait and implementation updates
- tests/test_ventilation.rs - Updated test calls
- tests/ventilation_infiltration_vs_energyplus.rs - Updated test calls
- tests/ventilation_schedule_trait.rs - Updated test calls

## Verification

- cargo test --lib: 2667 passed
- cargo test --test test_ventilation: 17 passed
- cargo test --test ventilation_schedule_trait: 35 passed
- cargo test --test ventilation_infiltration_vs_energyplus: 15 passed

## Architecture alignment

The trait signature now matches ARCHITECTURE.md Module 4 contract.

Fixes alexk307/fluxion#1207