### PR TITLE
ci(#1260): scope cargo-mutants to fluxion crate to fix CI OOM

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -17,23 +17,36 @@ minimum_test_timeout = 60
 
 # Exclude modules with complex generic types from mutation testing
 # These modules have type hierarchies that cause cargo-mutants to OOM
-# even on machines with 32GB+ RAM
+# during the discovery phase (issue #1260 re-opens #1244).
+#
+# Root cause: the crate split (#1255) only moved `weather` to fluxion-core.
+# The physics module (CTF solvers, multi-node solvers, geometry tensors with
+# heavily-parameterized generic types) stayed in the main `fluxion` crate.
+# During cargo-mutants discovery, these types expand combinatorially and
+# cause ~28 GB peak allocation — well beyond what even 32 GB CI runners can
+# sustain after accounting for OS, rustc, and other concurrent processes.
+#
+# The long-term fix (moving physics to fluxion-core) is tracked in
+# docs/mutation_testing_crate_split.md Phase 2. Until then, we scope
+# mutation testing to the modules that fit in CI memory.
 exclude_globs = [
-    # Large generic-heavy files that cause exponential memory growth during analysis
+    # FULL physics tree — the primary OOM source (complex generic types)
+    # All *.rs files under src/physics/ cause exponential type expansion.
+    # Excluding the whole tree avoids the combinatorial generic expansion.
+    "src/physics/**",
+
+    # Large sim files with complex generic types
     "src/sim/thermal_model_physics/**",
     "src/sim/thermal_model_core.rs",
-    "src/sim/construction.rs",
-    "src/physics/state_space_ctf.rs",
-    "src/physics/nd_array.rs",
-    "src/physics/multi_node_solver.rs",
-    # AI/ML modules with complex type hierarchies
-    "src/ai/surrogate.rs",
-    "src/ai/modular_surrogate.rs",
-    "src/ai/distributed.rs",
-    "src/ai/ensemble.rs",
-    "src/ai/neural_field.rs",
+    "src/sim/thermal_model_iterative.rs",
+    "src/sim/sky_radiation.rs",
+
+    # AI/ML modules — ort (ONNX) loaded even without default features,
+    # causes large type hierarchies and binary download overhead
+    "src/ai/**",
+
     # Large validation modules
-    "src/validation/ashrae_140_cases.rs",
+    "src/validation/**",
 ]
 
 # Use slice sharding for better memory locality when running manually

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,13 +1,18 @@
 name: Mutation Testing
 
-# Mutation testing (issue #1255).
+# Mutation testing (issue #1255, #1260).
 #
 # The workspace was split into `fluxion` + `fluxion-core` so that cargo-mutants can
-# target only the main `fluxion` crate while `fluxion-core` is built once and cached,
-# cutting peak memory dramatically versus the previous single-crate layout.
+# target only the main `fluxion` crate while `fluxion-core` is built once and cached.
 #
-# Run manually, or on PRs that touch physics/sim logic:
-#   cargo mutants -p fluxion --baseline skip
+# IMPORTANT: src/physics/**, src/ai/**, and src/validation/** are EXCLUDED from
+# mutation analysis in .cargo/mutants.toml because those modules have complex generic
+# types (CTF solvers, multi-node solvers, ONNX type hierarchies) that cause OOM
+# during cargo-mutants discovery even on 32 GB runners. The long-term fix (moving
+# physics to fluxion-core) is in docs/mutation_testing_crate_split.md Phase 2.
+#
+# Run manually (requires 32 GB+ machine):
+#   cargo mutants --config .cargo/mutants.toml -p fluxion --jobs 2 --baseline skip
 #
 # See docs/mutation_testing_crate_split.md for the phased plan to reach the <4GB
 # target (Phase 3 gates `ort`/ONNX behind a feature flag).
@@ -53,13 +58,19 @@ jobs:
 
       - name: Run mutation testing
         env:
-          # Bound peak memory: serialize rustc invocations and cap cargo parallelism.
-          CARGO_BUILD_JOBS: "2"
           CARGO_INCREMENTAL: "0"
         run: |
+          # --config: explicitly load .cargo/mutants.toml (not auto-discovered in CI
+          #           when running via `cargo mutants`; this ensures exclude_globs apply).
+          # --jobs 2: cap parallelism to bound peak RSS to what the 32 GB runner allows.
           # -p fluxion: mutate only the main crate; fluxion-core is a cached dep.
-          cargo mutants -p fluxion --baseline skip --no-default-features -- \
-            --test-threads=4
+          # --baseline skip: skip the no-mutant baseline run to save time + memory.
+          # --no-default-features: exclude ort (ONNX) even though it's a direct dep;
+          #           ort's type hierarchy is still large even without CUDA/TensorRT.
+          # See .cargo/mutants.toml for the full exclude_globs list (src/physics/**,
+          # src/ai/**, src/validation/** are all excluded to prevent discovery OOM).
+          cargo mutants --config .cargo/mutants.toml -p fluxion --jobs 2 \
+            --baseline skip --no-default-features -- --test-threads=2
 
       - name: Generate HTML report
         if: always()

--- a/docs/ripr_investigation_1254.md
+++ b/docs/ripr_investigation_1254.md
@@ -133,26 +133,41 @@ it is bounded by diff size and parse cost (no compilation).
 
 ---
 
-## 5. Fluxion context (current state)
+## 5. Fluxion context (current state, updated #1260)
 
-- **Crate structure:** fluxion is a **single crate** (`fluxion`, `cdylib` + `rlib`),
-  *not* a Cargo workspace. (There is no `docs/mutation_testing_crate_split.md` —
-  that document does not exist in the repo.) This is relevant: cargo-mutants must
-  type-check the entire single crate's complex type hierarchies at once, which is
-  what drives its ~28 GB peak. ripr sidesteps this entirely.
-- **OOM history (Issue #1244):** `cargo-mutants` 27.x needs ~28 GB to analyze
-  fluxion's type hierarchies. Standard `ubuntu-latest` runners have 7 GB.
-  Commits `c8480ef`, `e83a35e`, and the revert `8b4012e` all tried to scope
-  mutation testing to smaller modules; final state `7c47842` **disabled** CI
-  mutation testing and restricted it to `workflow_dispatch` on a 32 GB runner.
+> **⚠ This section supersedes the description above.** The workspace split
+> (#1255, merged as #1257) was completed — but only partially, which is why
+> the OOM returned (Issue #1260 re-opens #1244).
+
+- **Crate structure:** fluxion is now a **Cargo workspace** with two packages:
+  - `fluxion` (root, `cdylib` + `rlib`) — `src/physics/`, `src/ai/`, `src/sim/`,
+    `src/validation/`, etc.
+  - `fluxion-core` (`src/fluxion-core/`) — `weather/` module only (true leaf).
+    See `docs/mutation_testing_crate_split.md` for the full Phase 2 plan.
+  The `weather` module was the only clean leaf; `physics`, `ai`, and `validation`
+  are blocked from moving by bidirectional dependency cycles with `sim`. This is
+  why the OOM returned: `src/physics/` (CTF solvers, multi-node solvers,
+  geometry tensors with heavily-parameterized generics) stayed in `fluxion` and
+  is still analyzed by cargo-mutants.
+- **Current memory fix (issue #1260):** `.cargo/mutants.toml` was updated to add
+  `src/physics/**`, `src/ai/**`, and `src/validation/**` to `exclude_globs`, and
+  the CI workflow was updated to pass `--config .cargo/mutants.toml --jobs 2`.
+  This scopes mutation testing to the sim/weather/API modules that fit in CI memory.
+  The long-term fix is moving `physics` to `fluxion-core` (Phase 2 of the crate
+  split), which is blocked on breaking the `physics → sim` cycle.
+- **`ort` is not yet behind a feature flag.** It is a direct `[dependencies]` entry.
+  The Phase 3 success criterion in #1255 (`ort` behind a feature flag → <4 GB)
+  is **not yet met**. Gating `ort` behind a `#[cfg(feature = "ort")]` remains the
+  path to removing the `src/ai/**` exclusion and achieving full crate mutation
+  coverage on standard runners.
 - **Current CI layout:**
   - `.github/workflows/rust-tests.yml` — per-PR fast gate on `ubuntu-latest` (7 GB).
   - `.github/workflows/ci.yml` — main-merge jobs (Python, integration).
-  - `.github/workflows/mutation-testing.yml` — **disabled**, `workflow_dispatch`
-    only, runs on `ubuntu-latest-8-cores` (32 GB), runs `cargo mutants`.
-- **Net effect today:** fluxion has *no* mutation signal on per-PR CI, and the
-  confirmation run is manual. This is exactly the gap ripr is designed to fill:
-  cheap, advisory, per-PR.
+  - `.github/workflows/mutation-testing.yml` — `workflow_dispatch` on
+    `ubuntu-latest-8-cores` (32 GB), runs `cargo mutants` with reduced scope.
+- **Net effect:** cargo-mutants is re-enabled with reduced scope (physics/ai excluded).
+  The per-PR mutation signal is still absent; ripr is the tool to fill that gap.
+  See §6.3 for the planned nightly-scheduled confirmation run.
 
 ---
 


### PR DESCRIPTION
Fixes #1260
References #1254

## Root Cause

The OOM returned because issue #1255 (crate split) only moved the `weather` module to `fluxion-core`. The `src/physics/` module — with its heavily-parameterized generic types (CTF solvers, multi-node solvers, geometry tensors) — stayed in the main `fluxion` crate. During `cargo-mutants` discovery, these types expand combinatorially, causing ~28 GB peak allocation — beyond what the 32 GB CI runner can sustain after OS/rustc overhead.

Additionally, `ort` (ONNX) remains a direct dependency (not behind a feature flag), contributing large type hierarchies even with `--no-default-features`.

## What Changed

**`.cargo/mutants.toml`** — Expanded `exclude_globs` to exclude the full `src/physics/**` tree (was only specific files), plus `src/ai/**`, `src/validation/**`, `src/sim/thermal_model_core.rs`, `src/sim/thermal_model_iterative.rs`, and `src/sim/sky_radiation.rs`. This scopes mutation analysis to the sim/weather/API modules that fit in CI memory.

**`.github/workflows/mutation-testing.yml`** — Added `--config .cargo/mutants.toml` (explicit config load), `--jobs 2` (cap parallelism), reduced `--test-threads` from 4 to 2. Removed non-inherited `CARGO_BUILD_JOBS`.

**`docs/ripr_investigation_1254.md`** — Updated Section 5 to reflect the actual workspace split state (fluxion + fluxion-core, weather moved only). No changes to recommendations.

## Verification

**Locally verified:**
- `cargo build --workspace` passes (270 crates, clean)
- `cargo fmt --check` passes (no output = clean)
- YAML syntax validated with Python yaml.safe_load

**CI will confirm:**
- `cargo mutants --config .cargo/mutants.toml -p fluxion --jobs 2 --baseline skip --no-default-features` completes without OOM
- Mutation testing workflow succeeds on `ubuntu-latest-8-cores` (32 GB runner)

## Ripr Evaluation

Full doc: `docs/ripr_investigation_1254.md`

**Summary:** The ripr investigation is complete. Recommendation: adopt ripr as a Phase-1 **advisory per-PR lane** (fits 7 GB runner, seconds, static analysis) + keep `cargo-mutants` as the nightly confirmation engine on the 32 GB runner. ripr cannot replace mutation testing; it fills the per-PR gap that cargo-mutants cannot cover on standard runners.

Key updated note: ripr doc incorrectly stated fluxion was a "single crate" — it is now a workspace (fluxion + fluxion-core), but the analysis and recommendations remain valid.

## Risks / Follow-ups

- `ort` behind feature flag is still not done — blocks full <4GB target (Phase 3, tracked separately)
- `src/physics/` -> `fluxion-core` move still needed for full mutation coverage (Phase 2)
- ripr integration workflow (`.github/workflows/ripr.yml`) not yet implemented — tracked as follow-up

## Summary by Sourcery

Scope mutation testing to fluxion modules that fit within CI memory limits and document the updated workspace state and trade-offs.

Enhancements:
- Narrow mutation analysis via .cargo/mutants.toml to exclude physics, AI, and validation trees plus selected heavy sim files that cause cargo-mutants OOMs.
- Adjust the mutation-testing workflow to load the mutants config explicitly, cap parallelism, and reduce test threads for more predictable memory usage.

CI:
- Refine the mutation-testing GitHub Actions workflow to use the shared mutants configuration and tuned parallelism settings while documenting current exclusions and long-term plans.

Documentation:
- Update the ripr investigation document to reflect the current fluxion/fluxion-core workspace split, partial crate move, and the implications for mutation testing and CI layout.