### PR TITLE
ci(#1258): fix Docker build GHA cache BlobNotFound

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -63,8 +63,8 @@ jobs:
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=build-test-v3
+          cache-to: type=gha,scope=build-test-v3,mode=max
 
       - name: Run container smoke test
         if: github.event_name != 'pull_request'
@@ -128,8 +128,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,push-by-digest=true,name-canonical=true
-          cache-from: type=gha,scope=build-${{ matrix.slug }}
-          cache-to: type=gha,scope=build-${{ matrix.slug }},mode=max
+          cache-from: type=gha,scope=build-${{ matrix.slug }}-v3
+          cache-to: type=gha,scope=build-${{ matrix.slug }}-v3,mode=max
 
       - name: Export digest
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
Fixes #1258

## Root Cause
The  uses GitHub Actions cache backend () with scope keys  and . GitHub Actions stores these cache blobs in Azure Blob Storage (). Those blobs have been silently evicted by GHA's internal cache lifecycle management — a known infrastructure behavior where older cache entries are garbage-collected when they exceed age or size limits. Once evicted,  attempts to pull the missing blob and fails with  on every run, making the failure deterministic rather than intermittent.

## What Changed
- : Bumped GHA cache scope version from  to  in all three jobs that use  cache:
  - :  → 
  -  (amd64):  → 
  -  (arm64):  → 

## Verification
- YAML validated with PyYAML
- Dockerfile builds successfully locally with Docker 29.6.0
- GHA  cannot be reproduced locally (GHA cache backend is inaccessible outside of GitHub Actions CI) — CI run required to confirm the fix resolves the consistent failure

## Risks/Follow-ups
- First run after merge will have no cache (cold start); subsequent runs will populate fresh v3 cache
- If GHA evicts v3 cache as well, the root fix would be switching to  cache or adding a  fallback — both are more invasive; version-bumping is the minimal defensible first step
- Consider adding a cache-cleanup step or switching to  in a follow-up if this recurs

## Summary by Sourcery

CI:
- Adjust Docker build workflow to use versioned GitHub Actions cache scopes for test and matrix build jobs to avoid collisions with evicted caches.