### PR TITLE
fix(#1259): make determinism check fail loudly + harden macOS runner

### DIFF
--- a/.github/workflows/determinism_check.yml
+++ b/.github/workflows/determinism_check.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-13]
         rust: [stable]
 
     steps:
@@ -56,6 +56,29 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-determinism-cargo-
 
+      - name: Verify clang_rt.osx availability (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          echo "=== clang_rt.osx diagnostic ==="
+          # Search for clang_rt.osx in common Xcode toolchain locations
+          FOUND=false
+          for clang_dir in \
+            "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang"/*/lib/darwin \
+            "/Applications/Xcode_*.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang"/*/lib/darwin \
+            "/Users/runner/Library/Caches/ort.pyke.io/dfbin/"*/lib; do
+            if [ -f "$clang_dir/libclang_rt.osx" ]; then
+              echo "✅ Found: $clang_dir/libclang_rt.osx"
+              FOUND=true
+            fi
+          done
+          if [ "$FOUND" = "false" ]; then
+            echo "⚠️  WARNING: libclang_rt.osx not found in standard locations"
+            echo "   This may cause link failures with ORT (ONNX Runtime)"
+            echo "   Current Xcode path:"
+            xcode-select -p 2>/dev/null || echo "   xcode-select failed"
+          fi
+          echo "================================"
+
       - name: Build fluxion
         shell: bash
         run: |
@@ -69,7 +92,7 @@ jobs:
           # Reduce parallelism on macOS to avoid resource pressure that can cause
           # linker toolchain failures (clang_rt.osx not found). Use --verbose to
           # capture linker diagnostics that would otherwise be truncated in CI logs.
-          if [ "${{ matrix.os }}" = "macos-14" ]; then
+          if [ "${{ matrix.os }}" = "macos-13" ]; then
             export CARGO_BUILD_JOBS=2
             echo "macOS detected: limiting CARGO_BUILD_JOBS=2 to reduce memory pressure"
           fi
@@ -170,7 +193,7 @@ jobs:
           all_values = {}
 
           # Read hashes and values from all platforms
-          for os_name in ['ubuntu-latest', 'windows-latest', 'macos-latest']:
+          for os_name in ['ubuntu-latest', 'windows-latest', 'macos-13']:
               hash_file = os.path.join(artifacts_dir, f'case900-output-{os_name}', 'output_hash.txt')
               values_file = os.path.join(artifacts_dir, f'case900-output-{os_name}', 'output_values.json')
 

--- a/.github/workflows/determinism_check.yml
+++ b/.github/workflows/determinism_check.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         rust: [stable]
 
     steps:
@@ -92,7 +92,7 @@ jobs:
           # Reduce parallelism on macOS to avoid resource pressure that can cause
           # linker toolchain failures (clang_rt.osx not found). Use --verbose to
           # capture linker diagnostics that would otherwise be truncated in CI logs.
-          if [ "${{ matrix.os }}" = "macos-13" ]; then
+          if [ "${{ matrix.os }}" = "macos-latest" ]; then
             export CARGO_BUILD_JOBS=2
             echo "macOS detected: limiting CARGO_BUILD_JOBS=2 to reduce memory pressure"
           fi
@@ -193,7 +193,7 @@ jobs:
           all_values = {}
 
           # Read hashes and values from all platforms
-          for os_name in ['ubuntu-latest', 'windows-latest', 'macos-13']:
+          for os_name in ['ubuntu-latest', 'windows-latest', 'macos-latest']:
               hash_file = os.path.join(artifacts_dir, f'case900-output-{os_name}', 'output_hash.txt')
               values_file = os.path.join(artifacts_dir, f'case900-output-{os_name}', 'output_values.json')
 

--- a/.github/workflows/determinism_check.yml
+++ b/.github/workflows/determinism_check.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-14]
         rust: [stable]
 
     steps:
@@ -57,12 +57,42 @@ jobs:
             ${{ runner.os }}-determinism-cargo-
 
       - name: Build fluxion
-        run: cargo build --release --features wiring-tracing
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "=== Toolchain diagnostic ==="
+          echo "rustc: $(rustc --version 2>&1)"
+          echo "cargo: $(cargo --version 2>&1)"
+          echo "cc: $(cc --version 2>&1 | head -1 || echo 'cc not found')"
+          echo "macOS: $(sw_vers 2>&1 || echo 'sw_vers not found')"
+          echo "================================"
+          # Reduce parallelism on macOS to avoid resource pressure that can cause
+          # linker toolchain failures (clang_rt.osx not found). Use --verbose to
+          # capture linker diagnostics that would otherwise be truncated in CI logs.
+          if [ "${{ matrix.os }}" = "macos-14" ]; then
+            export CARGO_BUILD_JOBS=2
+            echo "macOS detected: limiting CARGO_BUILD_JOBS=2 to reduce memory pressure"
+          fi
+          # Use || true to ensure diagnostics run even on build failure; then capture
+          # cargo's exit code via PIPESTATUS and explicitly exit with it.
+          cargo build --release --features wiring-tracing --verbose 2>&1 | tee build_output.txt || true
+          BUILD_STATUS=${PIPESTATUS[0]}
+          echo "================================"
+          echo "cargo build exit status: $BUILD_STATUS"
+          if [ $BUILD_STATUS -ne 0 ]; then
+            echo "=== Last 100 lines of build output ==="
+            tail -100 build_output.txt
+            echo "=== dmesg (if available) ==="
+            dmesg 2>&1 | tail -20 || echo "(dmesg not available)"
+            exit $BUILD_STATUS
+          fi
+          echo "Build successful"
 
       - name: Run Case 900 Determinism Test
         id: case900
         shell: bash
         run: |
+          set -euo pipefail
           cargo test --test case_900_determinism --release -- --nocapture 2>&1 | tee case900_output.txt
 
       - name: Extract determinism values


### PR DESCRIPTION
Fixes #1259

## Defect A — Silent Failure (Root Cause)

The 'Build fluxion' step on macOS was failing with a linker error () but the verbose linker diagnostics were not captured in CI logs, making the failure appear silent. The workflow step did have proper error propagation via GitHub Actions' default shell handling, but there was no explicit , no toolchain diagnostics, and no verbose capture for post-mortem.

**What was fixed:**
- Added explicit `set -euo pipefail` and `shell: bash` to both Build fluxion and Run Case 900 steps
- Added `|| true` + PIPESTATUS check to ensure diagnostics always run even on failure, with explicit `exit $BUILD_STATUS` to propagate the cargo exit code and fail the step loudly
- Added `--verbose` flag to cargo build to capture full linker diagnostics that would otherwise be truncated
- Added toolchain diagnostic header (rustc, cargo, cc, macOS version) to every build for traceability
- Added dmesg capture on failure to detect OOM-kill if the runner runs out of memory

## Defect B — Intermittent macOS Toolchain Failure (Not Code Nondeterminism)

The intermittent 'Build fluxion' failure on macOS was a **toolchain infrastructure issue** (not physics code nondeterminism). The  linker error is caused by an incomplete Xcode toolchain installation on the  GitHub Actions runner — this is a known issue with  jumping to new Xcode versions before the clang_rt library is properly installed. When it passes, the toolchain happens to be complete; when it fails, it's missing.

**What was fixed:**
- Pinned macOS runner from `macos-latest` to `macos-14` for stable, reproducible toolchain availability
- Added `CARGO_BUILD_JOBS=2` on macOS to reduce memory pressure during linking, addressing resource-related toolchain failures

**CI-only behavior:** The macOS runner behavior is NOT reproducible locally. The fix must be validated through CI runs on the pinned `macos-14` runner.

## What Changed
- `.github/workflows/determinism_check.yml` — Build fluxion step now has explicit error propagation, toolchain diagnostics, verbose output, dmesg capture, and macOS parallelism limiting; macOS runner pinned to `macos-14`

## Verification
- `cargo build --release --features wiring-tracing`: PASS (local Linux)
- YAML syntax validated with PyYAML
- macOS runner behavior confirmed NOT reproducible locally — CI run on `macos-14` required to validate

## Residual Risks / Follow-ups
1. **ORT library cache path** — the logs showed a warning about `/Users/runner/Library/Caches/ort.pyke.io/dfbin/aarch64-apple-darwin/...`: this is a hardcoded path that may not exist on all macOS runners. Consider making this path configurable or using the cargo cache instead.
2. **filename collision warning on Windows** — the Windows build shows a warning about `fluxion.pdb` collision between bin and lib targets. This is a separate issue but worth investigating as it may become a hard error in future Rust versions.