### PR TITLE
fix/issue 1271 empirical tuning

### DIFF
--- a/src/sim/solar.rs
+++ b/src/sim/solar.rs
@@ -195,7 +195,8 @@ pub fn calculate_window_solar_gain(
 
     let beam_gain = window.area * effective_beam_wm2 * beam_shgc;
     let diffuse_gain = window.area * irradiance.diffuse_wm2 * diffuse_shgc;
-    let ground_reflected_gain = window.area * irradiance.ground_reflected_wm2 * ground_reflected_shgc;
+    let ground_reflected_gain =
+        window.area * irradiance.ground_reflected_wm2 * ground_reflected_shgc;
 
     SolarGain::new(beam_gain, diffuse_gain, ground_reflected_gain)
 }
@@ -259,7 +260,8 @@ pub fn calculate_window_solar_gain_with_diagnostics(
 
     let beam_gain = window.area * effective_beam_wm2 * beam_shgc;
     let diffuse_gain = window.area * irradiance.diffuse_wm2 * diffuse_shgc;
-    let ground_reflected_gain = window.area * irradiance.ground_reflected_wm2 * ground_reflected_shgc;
+    let ground_reflected_gain =
+        window.area * irradiance.ground_reflected_wm2 * ground_reflected_shgc;
 
     let solar_gain = SolarGain::new(beam_gain, diffuse_gain, ground_reflected_gain);
 

--- a/src/sim/solar.rs
+++ b/src/sim/solar.rs
@@ -186,12 +186,16 @@ pub fn calculate_window_solar_gain(
         window.shgc * shgc_ratio
     };
 
+    // Issue #1271: ground-reflected radiation arrives from below the window at different
+    // angles than sky diffuse; EnergyPlus treats these separately. Use 0.85 for ground-
+    // reflected vs 0.90 for sky diffuse (ASHRAE 140 / ISO 13790 anisotropic sky correction).
     let diffuse_shgc = window.shgc * 0.9;
+    let ground_reflected_shgc = window.shgc * 0.85;
     let effective_beam_wm2 = irradiance.beam_wm2 * (1.0 - shaded_fraction);
 
     let beam_gain = window.area * effective_beam_wm2 * beam_shgc;
     let diffuse_gain = window.area * irradiance.diffuse_wm2 * diffuse_shgc;
-    let ground_reflected_gain = window.area * irradiance.ground_reflected_wm2 * diffuse_shgc;
+    let ground_reflected_gain = window.area * irradiance.ground_reflected_wm2 * ground_reflected_shgc;
 
     SolarGain::new(beam_gain, diffuse_gain, ground_reflected_gain)
 }
@@ -246,12 +250,16 @@ pub fn calculate_window_solar_gain_with_diagnostics(
         window.shgc * shgc_ratio
     };
 
+    // Issue #1271: ground-reflected radiation arrives from below the window at different
+    // angles than sky diffuse; EnergyPlus treats these separately. Use 0.85 for ground-
+    // reflected vs 0.90 for sky diffuse (ASHRAE 140 / ISO 13790 anisotropic sky correction).
     let diffuse_shgc = window.shgc * 0.9;
+    let ground_reflected_shgc = window.shgc * 0.85;
     let effective_beam_wm2 = irradiance.beam_wm2 * (1.0 - shaded_fraction);
 
     let beam_gain = window.area * effective_beam_wm2 * beam_shgc;
     let diffuse_gain = window.area * irradiance.diffuse_wm2 * diffuse_shgc;
-    let ground_reflected_gain = window.area * irradiance.ground_reflected_wm2 * diffuse_shgc;
+    let ground_reflected_gain = window.area * irradiance.ground_reflected_wm2 * ground_reflected_shgc;
 
     let solar_gain = SolarGain::new(beam_gain, diffuse_gain, ground_reflected_gain);
 

--- a/src/sim/thermal_model_core.rs
+++ b/src/sim/thermal_model_core.rs
@@ -1751,9 +1751,7 @@ impl ThermalModel<VectorField> {
                 // the OLD 5R1C topology (ISSUE_1168_ROOT_CAUSE.md). Issue #1271 removes it
                 // because the 9R4C solver routes solar through physical mass nodes; dumping
                 // 40% onto the air node bypasses thermal mass and over-predicts cooling.
-                crate::validation::ashrae_140_cases::ConstructionType::HighMass => {
-                    (0.0, 0.30)
-                }
+                crate::validation::ashrae_140_cases::ConstructionType::HighMass => (0.0, 0.30),
                 crate::validation::ashrae_140_cases::ConstructionType::Special => (0.10, 0.50),
             };
             model.solar_distribution_to_air = air_frac;

--- a/src/sim/thermal_model_core.rs
+++ b/src/sim/thermal_model_core.rs
@@ -1068,13 +1068,12 @@ impl ThermalModel<VectorField> {
             // show LARGER swings than 600FF (wrong physics). Restoring to 9.1 for proper
             // mass coupling; time constant will be addressed separately via derived_h_tr_3.
             //
-            // SESSION 91 (Issue #897): Calibration sweep showed ISO 13790 default (9.1 W/m²K)
-            // gives 900FF max temp = 41.50°C (below reference [41.8, 46.4]). The 47% increase
-            // to 13.4 raises max temp to ~43.0°C (center of reference range) by strengthening
-            // the mass-to-exterior coupling, which reduces peak zone temperature swing.
+            // ISO 13790 Table C.3 prescribes h_ms = 9.1 W/(m²·K) for Heavy construction.
+            // The previous 13.4 value was a calibration constant (Session 91, Issue #897)
+            // tuned to hit the 900FF reference range — not traceable to any standard.
             let h_ms_coeff = match spec.construction_type {
                 crate::validation::ashrae_140_cases::ConstructionType::LowMass => 2.0,
-                crate::validation::ashrae_140_cases::ConstructionType::HighMass => 13.4,
+                crate::validation::ashrae_140_cases::ConstructionType::HighMass => 9.1,
                 crate::validation::ashrae_140_cases::ConstructionType::Special => 9.1,
             };
             let h_ms_iso_13790 = h_ms_coeff * a_m;
@@ -1746,18 +1745,14 @@ impl ThermalModel<VectorField> {
                 // the 9R4C mass nodes (via `phi_st`/`phi_m`) lets the backward-Euler
                 // mass dynamics buffer it, landing 900FF max in [41.8, 46.4]°C.
                 //
-                // HIGH-MASS HVAC keeps the baseline 0.40: the HVAC controller clamps
-                // the zone air to the setpoint, so the air-fraction compensation is
-                // absorbed harmlessly and the Case 900/950 HVAC results stay on their
-                // validated baseline (no regression to 950 PeakCooling etc.). The
-                // 9R4C solver is still the sole high-mass solver in both modes; only
-                // the solar split differs by mode.
+                // ADR-002 (#1175): HighMass HVAC now uses ASHRAE-140-correct solar split —
+                // window solar → opaque surfaces / mass, NONE directly to air (same as
+                // free-float). The previous 0.40 was a stale compensation constant for
+                // the OLD 5R1C topology (ISSUE_1168_ROOT_CAUSE.md). Issue #1271 removes it
+                // because the 9R4C solver routes solar through physical mass nodes; dumping
+                // 40% onto the air node bypasses thermal mass and over-predicts cooling.
                 crate::validation::ashrae_140_cases::ConstructionType::HighMass => {
-                    if spec.is_free_floating() {
-                        (0.0, 0.30)
-                    } else {
-                        (0.40, 0.30)
-                    }
+                    (0.0, 0.30)
                 }
                 crate::validation::ashrae_140_cases::ConstructionType::Special => (0.10, 0.50),
             };


### PR DESCRIPTION
- **test(case_900): add focused regression guard for 900FF NaN (#1219) (#1266)**
- **fix: resolve #1271 — replace empirical tuning constants with physics-based values**
