### PR TITLE
docs(thermal): resolve #1269 — obsolete 6R2C/5R1C fallback notes replaced with ADR-002 (9R4C) reality

### DIFF
--- a/src/sim/thermal_model_core.rs
+++ b/src/sim/thermal_model_core.rs
@@ -1906,23 +1906,23 @@ impl ThermalModel<VectorField> {
             model.enable_9r4c_model();
         }
 
-        // CTF-primary surface temperature coupling for high-mass free-floating cases only
-        // For low-mass (600FF, 650FF), the 6R2C model provides adequate thermal mass
-        // Effect if removed: 900FF and 950FF free-floating temp predictions less accurate
-        // SESSION 89: The 6R2C lumped model's τ ≈ 26h under-represents thermal mass (concrete h₁₂ = 771 W/K
-        // is too high). The CTF solver captures multi-layer conduction dynamics correctly (τ ≈ 120-200h).
-        // Enable CTF with iterative zone coupling so T_si drives the zone air heat balance directly.
+        // High-mass free-float driver (ADR-002, docs/adr/0002-promote-9r4c-high-mass-default.md):
+        // 900FF/950FF are routed to the 9R4C multi-node network by the
+        // `HighMass9R4C` arm above (`enable_9r4c_model()`). The 9R4C solver
+        // derives the free-floating zone air temperature from backward-Euler-stepped
+        // wall/roof/floor/internal-mass nodes (see `physics_impl.rs::step_physics`
+        // → `t_i_free_mn`), NOT from the 5R1C/6R2C closed-form `t_i_free`.
         //
-        // REVERTED: Do NOT enable 6R2C for 900FF/950FF - the 6R2C t_i_free formula doesn't
-        // properly use thermal mass temperatures in its numerator, causing massive temperature errors.
-        // Case 900FF should use the standard 5R1C path which correctly models thermal mass
-        // through the single lumped thermal node. See issue #860 for tracking.
-        if spec.case_id == "900FF" || spec.case_id == "950FF" {
-            // Use 5R1C model (default) - do NOT call configure_6r2c_model()
-            // The 6R2C model has issues with thermal mass coupling in t_i_free formula
-            // Previously this block enabled 6R2C which caused max temp ~0°C (outdoor tracking)
-            // or ~15°C (still too low). The 5R1C model produces correct ~44°C max temp.
-        }
+        // History (issue #1269 — superseded): an earlier investigation proposed
+        // fixing the 6R2C `t_i_free` numerator and re-enabling 6R2C for 900FF/950FF
+        // because they were believed to fall back to 5R1C. That premise is obsolete:
+        //   - The routing enum (`thermal_model.rs::ThermalModelType`) has only
+        //     `LowMass5R1C` and `HighMass9R4C`; 6R2C is never selected.
+        //   - `t_i_free` (`physics_impl.rs`) already includes mass temperatures in
+        //     its numerator (`num_tm = derived_h_ms_is_prod · mass_temperatures`).
+        //   - ADR-002 made 9R4C the sole high-mass free-float driver.
+        // The no-op `if case_id == "900FF" || "950FF"` guard that previously lived
+        // here has been removed as dead/misleading code.
 
         // Handle inter-zone conductance for multi-zone buildings (Case 960 sunspace)
         if num_zones > 1 && !spec.common_walls.is_empty() {


### PR DESCRIPTION
## Summary

Closes #1269.

Issue #1269 was an **investigation** that proposed two changes. Investigation found both premises **obsolete** (superseded by ADR-002 / commit `d7a0007`), so this PR makes **no physics change** — it syncs main and corrects misleading dead code/comments.

### Why the issue's premises are obsolete

| #1269 premise | Current reality |
|---|---|
| 900FF/950FF silently fall back to **5R1C** | They route to **9R4C** (`thermal_model.rs:39-46` → `HighMass9R4C`; enabled at `thermal_model_core.rs:1905-1907`). The routing enum has only `LowMass5R1C` and `HighMass9R4C` — **6R2C is never selected.** |
| 6R2C `t_i_free` numerator missing mass temps | `t_i_free` (`physics_impl.rs:262-265, 447-450`) already includes them: `num_tm = derived_h_ms_is_prod · mass_temperatures` |
| `h_ms_coeff` 13.4 → 9.1 (HighMass) | **Already on main** via #1273; brought into this branch by fast-forward merge of `origin/main` |
| Target = `thermal_model_core.rs:1909-1925` | Was a **stale comment block + dead no-op `if` guard**, not a formula |

Per `AGENTS.md` (*"Do NOT modify physics code without checking ARCHITECTURE.md first"*) and ADR-002 (9R4C is the sole high-mass free-float driver), re-enabling 6R2C would contradict the architecture.

## Changes

- **Merge** `origin/main` (fast-forward) → brings in #1273 (`h_ms_coeff` 13.4→9.1) + #1272 + #1267.
- `src/sim/thermal_model_core.rs`: replaced the obsolete "do NOT enable 6R2C for 900FF/950FF" comment block with an accurate description of the 9R4C free-float driver; **removed the dead no-op** `if spec.case_id == "900FF" || "950FF" {}` guard.

## Verification

- `cargo check --all` ✅ (clean, 270 crates)
- No physics behavior change — comment/dead-code removal only.

## Follow-up

The remaining high-mass free-float accuracy gap (~0.6 °C warm night min, per ARCHITECTURE.md) is a separate 9R4C concern (recommended fix #2: direct longwave-to-sky path / ground-coupled floor node) and is **out of scope** for #1269.