### PR TITLE
fix(#1283): Use construction_type for blind ThermalModelType selection

### DIFF
--- a/src/sim/thermal_model.rs
+++ b/src/sim/thermal_model.rs
@@ -36,12 +36,11 @@ pub enum ThermalModelType {
 
 impl From<&crate::validation::ashrae_140_cases::CaseSpec> for ThermalModelType {
     fn from(spec: &crate::validation::ashrae_140_cases::CaseSpec) -> Self {
-        match spec.case_id.as_str() {
-            "600" | "600FF" | "650" | "650FF" => ThermalModelType::LowMass5R1C,
-            _ if spec.case_id.starts_with("9") && spec.case_id != "960" => {
-                ThermalModelType::HighMass9R4C
-            }
-            _ => ThermalModelType::LowMass5R1C,
+        use crate::validation::ashrae_140_cases::ConstructionType;
+        match spec.construction_type {
+            ConstructionType::LowMass => ThermalModelType::LowMass5R1C,
+            ConstructionType::HighMass => ThermalModelType::HighMass9R4C,
+            ConstructionType::Special => ThermalModelType::LowMass5R1C,
         }
     }
 }
@@ -949,13 +948,13 @@ mod tests {
     }
 
     #[test]
-    fn test_thermal_model_type_from_case_spec_excludes_960() {
+    fn test_thermal_model_type_from_case_spec_case_960() {
         use crate::validation::ashrae_140_cases::CaseBuilder;
 
         let case_960 = CaseBuilder::case_960_sunspace();
         assert_eq!(
             ThermalModelType::from(&case_960),
-            ThermalModelType::LowMass5R1C
+            ThermalModelType::HighMass9R4C
         );
     }
 


### PR DESCRIPTION
## Summary

This PR implements a key part of Issue #1283: making ThermalModelType selection truly blind by using `construction_type` (a physics property) instead of `case_id` (case identification).

## Changes

### `src/sim/thermal_model.rs`

**Before:** `ThermalModelType::from(spec)` used `spec.case_id` to determine model type:
- \"600\", \"600FF\", \"650\", \"650FF\" → LowMass5R1C
- case_ids starting with \"9\" (except 960) → HighMass9R4C

**After:** Uses `spec.construction_type` instead:
- `ConstructionType::LowMass` → LowMass5R1C
- `ConstructionType::HighMass` → HighMass9R4C
- `ConstructionType::Special` → LowMass5R1C

This ensures the validation engine does not receive case-identification information during blind validation runs (acceptance criterion: \"ValidationMode::Blind executes simulation with no case-ID passed to engine\").

## Test Updates

- Renamed `test_thermal_model_type_from_case_spec_excludes_960` → `test_thermal_model_type_from_case_spec_case_960`
- Case 960 now correctly returns `HighMass9R4C` based on its `construction_type = HighMass`
- The special handling for Case 960 (6R2C model) is applied separately in `enable_advanced_solver()` based on validation mode and case_id

## Validation Results

After this change, the blind validation test shows:

| Case | Metric | Simulated | Ref Min | Ref Max | % Error | Status |
|------|--------|-----------|---------|---------|---------|--------|
| 600 | AnnualHeating | 2.9391 | 4.36 | 5.79 | 42.09% | FAIL |
| 600 | AnnualCooling | 3.2316 | 3.92 | 6.14 | 35.75% | FAIL |
| 900 | AnnualHeating | 1.5231 | 1.17 | 2.04 | 5.10% | PASS |
| 900 | AnnualCooling | 1.2377 | 2.13 | 3.67 | 57.32% | FAIL |

**Note:** Case 600 and Case 900 failures are physics-level issues (documented in Issue #1281 for Case 900 cooling). Fixing these is out of scope for this PR per Issue #1283.

## Verification

- All lib tests pass: 2479 passed, 2 ignored
- Blind validation integration tests pass: 2 passed