### PR TITLE
fix(#1294): gate ort behind feature flag for mutation testing

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -29,6 +29,11 @@ minimum_test_timeout = 60
 # The long-term fix (moving physics to fluxion-core) is tracked in
 # docs/mutation_testing_crate_split.md Phase 2. Until then, we scope
 # mutation testing to the modules that fit in CI memory.
+#
+# src/ai/** is no longer excluded (issue #1294): the workflow now passes
+# --features ort so src/ai/surrogate compiles end-to-end. The ort type
+# hierarchy is still large, so peak RSS may still approach the 32 GB limit;
+# monitoring and follow-up are documented in the PR.
 exclude_globs = [
     # FULL physics tree — the primary OOM source (complex generic types)
     # All *.rs files under src/physics/ cause exponential type expansion.
@@ -40,10 +45,6 @@ exclude_globs = [
     "src/sim/thermal_model_core.rs",
     "src/sim/thermal_model_iterative.rs",
     "src/sim/sky_radiation.rs",
-
-    # AI/ML modules — ort (ONNX) loaded even without default features,
-    # causes large type hierarchies and binary download overhead
-    "src/ai/**",
 
     # Large validation modules
     "src/validation/**",

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -65,12 +65,14 @@ jobs:
           # --jobs 2: cap parallelism to bound peak RSS to what the 32 GB runner allows.
           # -p fluxion: mutate only the main crate; fluxion-core is a cached dep.
           # --baseline skip: skip the no-mutant baseline run to save time + memory.
-          # --no-default-features: exclude ort (ONNX) even though it's a direct dep;
-          #           ort's type hierarchy is still large even without CUDA/TensorRT.
-          # See .cargo/mutants.toml for the full exclude_globs list (src/physics/**,
-          # src/ai/**, src/validation/** are all excluded to prevent discovery OOM).
+          # --features ort: opt in to the ONNX runtime so src/ai/** (issue #1294) is
+          #           included in mutation analysis instead of excluded from
+          #           .cargo/mutants.toml. Without `--features ort`, the build
+          #           excludes `ort` entirely (issue #1294) and src/ai/surrogate
+          #           would fail to compile. The default feature set remains []
+          #           so non-AI builds stay slim — see Cargo.toml.
           cargo mutants --config .cargo/mutants.toml -p fluxion --jobs 2 \
-            --baseline skip --no-default-features -- --test-threads=2
+            --baseline skip --features ort -- --test-threads=2
 
       - name: Generate HTML report
         if: always()

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,8 +58,14 @@ default = []
 python-bindings = ["dep:pyo3", "dep:pyo3-build-config", "dep:numpy"]
 # Feature flag to enable Node.js/NAPI bindings (disabled by default for pure Rust testing)
 napi-bindings = ["dep:napi", "dep:napi-derive", "dep:napi-build"]
-# Feature flag for CUDA support (enables GPU-accelerated ONNX inference)
-cuda = ["ort/cuda", "ort/tensorrt"]
+# ONNX Runtime support (issue #1294). When disabled (the default), the crate does
+# not compile `ort` and src/ai/surrogate exposes only the mock / analytical fallback.
+# Opt in for AI surrogate inference, the ASHRAE ONNX tests, or mutation testing.
+ort = ["dep:ort"]
+# Alias for `ort` (issue #1294 requested feature naming).
+onnx = ["ort"]
+# CUDA / TensorRT execution providers for `ort` (issue #1294). Implies `ort`.
+cuda = ["ort", "ort/cuda", "ort/tensorrt"]
 # Feature flag for wiring tracing in integration tests (Plan 21-10)
 wiring-tracing = []
 # Feature flag for multi-zone support
@@ -129,8 +135,11 @@ rand_distr = "0.4"
 statrs = "0.18.0"
 
 # AI / Machine Learning Integration
-# Using 2.0.0-rc.10 (prerelease) as stable 1.20 is not available on crates.io
-ort = { version = "2.0.0-rc.10", features = ["download-binaries"] }
+# Using 2.0.0-rc.10 (prerelease) as stable 1.20 is not available on crates.io.
+# Gated behind the `ort` feature (issue #1294) so the default build (no features)
+# does not pull in the ONNX runtime. The mutation-testing workflow opts in via
+# `--features ort`; default Rust builds stay small and fast.
+ort = { version = "2.0.0-rc.10", features = ["download-binaries"], optional = true }
 
 # Python Interop
 pyo3 = { version = "0.22", features = ["extension-module", "auto-initialize", "abi3-py310"], optional = true }

--- a/src/ai/modular_surrogate.rs
+++ b/src/ai/modular_surrogate.rs
@@ -319,6 +319,7 @@ mod tests {
         assert_eq!(comp.name, "test");
     }
 
+    #[cfg(feature = "ort")]
     #[test]
     fn composite_surrogate_single_component() {
         let path = "tests_tmp_dummy.onnx";
@@ -335,6 +336,7 @@ mod tests {
         assert!(loads[0] > 0.0);
     }
 
+    #[cfg(feature = "ort")]
     #[test]
     fn composite_surrogate_two_components_sum() {
         let path = "tests_tmp_dummy.onnx";
@@ -353,6 +355,7 @@ mod tests {
         assert!(loads[0] > 0.0);
     }
 
+    #[cfg(feature = "ort")]
     #[test]
     fn composite_surrogate_three_components() {
         let path = "tests_tmp_dummy.onnx";
@@ -406,6 +409,7 @@ mod tests {
         assert_eq!(composite.num_components(), 3);
     }
 
+    #[cfg(feature = "ort")]
     #[test]
     fn composite_surrogate_with_valid_outputs() {
         let path = "tests_tmp_dummy.onnx";

--- a/src/ai/neural_field.rs
+++ b/src/ai/neural_field.rs
@@ -1,6 +1,7 @@
 use crate::physics::continuous::ContinuousField;
 use ndarray::ArrayD;
 use num_traits::Zero;
+#[cfg(feature = "ort")]
 use ort::{session::Session, value::Value};
 use std::f64::consts::PI;
 use std::ops::{Add, AddAssign, Mul};
@@ -61,6 +62,10 @@ impl<T> NeuralScalarField<T> {
 }
 
 impl NeuralScalarField<f64> {
+    /// Load a `NeuralScalarField` from an ONNX model file. Requires the
+    /// `ort` feature (issue #1294) — without it, returns a runtime error
+    /// explaining the missing feature.
+    #[cfg(feature = "ort")]
     pub fn from_onnx<P: AsRef<Path>>(
         model_path: P,
         input: ArrayD<f32>,
@@ -84,6 +89,16 @@ impl NeuralScalarField<f64> {
         };
 
         Ok(Self::new(weights)?)
+    }
+
+    /// Stub for non-`ort` builds (issue #1294). Always returns an error
+    /// explaining that ONNX inference is unavailable without `--features ort`.
+    #[cfg(not(feature = "ort"))]
+    pub fn from_onnx<P: AsRef<Path>>(
+        _model_path: P,
+        _input: ArrayD<f32>,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        Err("Loading ONNX models requires the `ort` feature (build with --features ort)".into())
     }
 }
 

--- a/src/ai/surrogate.rs
+++ b/src/ai/surrogate.rs
@@ -2,6 +2,7 @@
 
 use crate::ai::modular_surrogate::{ComponentSurrogate, CompositeSurrogate};
 use log::{info, warn};
+#[cfg(feature = "ort")]
 use ort::execution_providers::{
     CUDAExecutionProvider, CoreMLExecutionProvider, DirectMLExecutionProvider,
     OpenVINOExecutionProvider,
@@ -424,9 +425,28 @@ impl Default for SurrogateManager {
 }
 
 /// Thread-safe pool of ONNX Runtime sessions for concurrent inference.
+///
+/// Issue #1294: When the `ort` feature is disabled, `SessionPool` is an inert
+/// stub. The public surface (`Option<Arc<SessionPool>>` field on
+/// [`SurrogateManager`], `SessionPool::new` callers in tests) still compiles —
+/// only `create_session` actually attempts to load an ONNX model, and it
+/// returns an error when `ort` is disabled.
+#[cfg(feature = "ort")]
 #[derive(Debug)]
 pub struct SessionPool {
     sessions: Mutex<Vec<ort::session::Session>>,
+    model_path: String,
+    backend: InferenceBackend,
+    device_id: usize,
+}
+
+/// Inert stub of [`SessionPool`] used when the `ort` feature is disabled
+/// (issue #1294). Carries no ONNX state. Construction succeeds; any attempt
+/// to actually create an ONNX session via the corresponding methods returns
+/// an error (those methods only exist under `#[cfg(feature = "ort")]`).
+#[cfg(not(feature = "ort"))]
+#[derive(Debug)]
+pub struct SessionPool {
     model_path: String,
     backend: InferenceBackend,
     device_id: usize,
@@ -439,6 +459,7 @@ pub struct MultiDeviceSessionPool {
     _model_path: String,
 }
 
+#[cfg(feature = "ort")]
 impl MultiDeviceSessionPool {
     pub fn new(model_path: String, config: &MultiDeviceConfig) -> Result<Self, String> {
         let mut device_pools = Vec::new();
@@ -544,10 +565,29 @@ impl MultiDeviceSessionPool {
     }
 }
 
+/// Stub implementation when the `ort` feature is disabled (issue #1294).
+/// `MultiDeviceSessionPool::new` always fails; `num_devices` reports zero.
+#[cfg(not(feature = "ort"))]
+impl MultiDeviceSessionPool {
+    pub fn new(_model_path: String, _config: &MultiDeviceConfig) -> Result<Self, String> {
+        Err("Multi-device ONNX inference requires the `ort` feature".to_string())
+    }
+
+    pub fn num_devices(&self) -> usize {
+        0
+    }
+}
+
+/// RAII guard returned by [`MultiDeviceSessionPool::get_session`].
+///
+/// Issue #1294: only available with the `ort` feature — the `run_inference`
+/// signature depends on `ort::value::Value`.
+#[cfg(feature = "ort")]
 pub struct MultiDeviceSessionGuard {
     pool: Arc<SessionPool>,
 }
 
+#[cfg(feature = "ort")]
 impl MultiDeviceSessionGuard {
     pub fn run_inference(&self, input_tensor: ort::value::Value) -> Result<Vec<f64>, String> {
         let mut guard = self.pool.get_or_create_session()?;
@@ -565,6 +605,7 @@ impl MultiDeviceSessionGuard {
     }
 }
 
+#[cfg(feature = "ort")]
 impl SessionPool {
     fn new(
         model_path: String,
@@ -644,11 +685,43 @@ impl SessionPool {
     }
 }
 
+/// Stub [`SessionPool`] methods when the `ort` feature is disabled
+/// (issue #1294). `SessionPool::new` accepts a model path but never loads a
+/// session; `get_or_create_session` returns an error explaining that ONNX
+/// inference is unavailable.
+#[cfg(not(feature = "ort"))]
+impl SessionPool {
+    #[allow(dead_code)]
+    fn new(model_path: String, backend: InferenceBackend, device_id: usize) -> Self {
+        SessionPool {
+            model_path,
+            backend,
+            device_id,
+        }
+    }
+
+    #[allow(dead_code)]
+    fn get_or_create_session(&self) -> Result<SessionGuard<'_>, String> {
+        Err("ONNX inference requires the `ort` feature (build with --features ort)".to_string())
+    }
+}
+
+#[cfg(feature = "ort")]
 struct SessionGuard<'a> {
     pool: &'a SessionPool,
     session: Option<ort::session::Session>,
 }
 
+/// Stub [`SessionGuard`] when the `ort` feature is disabled (issue #1294).
+/// Constructed by [`SessionPool::get_or_create_session`] in its error path,
+/// but never actually used (the function returns `Err` before producing it).
+#[cfg(not(feature = "ort"))]
+#[allow(dead_code)]
+struct SessionGuard<'a> {
+    _pool: &'a SessionPool,
+}
+
+#[cfg(feature = "ort")]
 impl<'a> Drop for SessionGuard<'a> {
     fn drop(&mut self) {
         if let Some(session) = self.session.take() {
@@ -657,6 +730,7 @@ impl<'a> Drop for SessionGuard<'a> {
     }
 }
 
+#[cfg(feature = "ort")]
 impl<'a> std::ops::Deref for SessionGuard<'a> {
     type Target = ort::session::Session;
     fn deref(&self) -> &Self::Target {
@@ -664,6 +738,7 @@ impl<'a> std::ops::Deref for SessionGuard<'a> {
     }
 }
 
+#[cfg(feature = "ort")]
 impl<'a> std::ops::DerefMut for SessionGuard<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.session.as_mut().unwrap()
@@ -784,10 +859,28 @@ impl SurrogateManager {
         }
     }
 
+    #[cfg(feature = "ort")]
     pub fn load_onnx(path: &str) -> Result<Self, String> {
         Self::with_gpu_backend(path, InferenceBackend::CPU, 0)
     }
 
+    /// Stub for `cargo build` without the `ort` feature (issue #1294).
+    /// Returns a clear error instead of panicking; callers should detect the
+    /// missing feature and surface a friendly message. Still validates the
+    /// path so callers see a `not found` diagnostic before the feature error.
+    #[cfg(not(feature = "ort"))]
+    pub fn load_onnx(path: &str) -> Result<Self, String> {
+        use std::path::Path;
+        if !Path::new(path).exists() {
+            return Err(format!("ONNX model file not found: {}", path));
+        }
+        Err(
+            "Loading ONNX models requires the `ort` feature (build with --features ort)"
+                .to_string(),
+        )
+    }
+
+    #[cfg(feature = "ort")]
     pub fn with_gpu_backend(
         path: &str,
         backend: InferenceBackend,
@@ -814,6 +907,25 @@ impl SurrogateManager {
         })
     }
 
+    /// Stub for non-`ort` builds (issue #1294). Validates the path first so
+    /// callers still see a `not found` diagnostic before the feature error.
+    #[cfg(not(feature = "ort"))]
+    pub fn with_gpu_backend(
+        path: &str,
+        _backend: InferenceBackend,
+        _device_id: usize,
+    ) -> Result<Self, String> {
+        use std::path::Path;
+        if !Path::new(path).exists() {
+            return Err(format!("ONNX model file not found: {}", path));
+        }
+        Err(
+            "Loading ONNX models requires the `ort` feature (build with --features ort)"
+                .to_string(),
+        )
+    }
+
+    #[cfg(feature = "ort")]
     pub fn with_multi_device(path: &str, config: MultiDeviceConfig) -> Result<Self, String> {
         use std::path::Path;
         if !Path::new(path).exists() {
@@ -847,6 +959,13 @@ impl SurrogateManager {
         }
     }
 
+    /// Stub for non-`ort` builds (issue #1294).
+    #[cfg(not(feature = "ort"))]
+    pub fn with_multi_device(_path: &str, _config: MultiDeviceConfig) -> Result<Self, String> {
+        Err("Multi-device ONNX inference requires the `ort` feature".to_string())
+    }
+
+    #[cfg(feature = "ort")]
     pub fn load_modular(component_configs: &[(&str, InferenceBackend)]) -> Result<Self, String> {
         if component_configs.is_empty() {
             return Err("At least one component model required for modular surrogate".to_string());
@@ -875,6 +994,12 @@ impl SurrogateManager {
             composite: Some(composite),
             inference_metrics: Arc::new(parking_lot::Mutex::new(InferenceMetrics::default())),
         })
+    }
+
+    /// Stub for non-`ort` builds (issue #1294).
+    #[cfg(not(feature = "ort"))]
+    pub fn load_modular(_component_configs: &[(&str, InferenceBackend)]) -> Result<Self, String> {
+        Err("Modular ONNX surrogates require the `ort` feature".to_string())
     }
 
     pub fn predict_loads(&self, current_temps: &[f64]) -> Vec<f64> {
@@ -910,6 +1035,7 @@ impl SurrogateManager {
     /// - no ONNX model has been loaded via [`Self::load_onnx`]
     /// - input tensor shape does not match the model's expected input
     /// - the ONNX runtime reports an inference error
+    #[cfg(feature = "ort")]
     pub fn predict_loads_onnx(&self, current_temps: &[f64]) -> Result<Vec<f64>, String> {
         if !self.model_loaded {
             return Err("No ONNX model loaded".to_string());
@@ -953,6 +1079,13 @@ impl SurrogateManager {
         Ok(result)
     }
 
+    /// Stub for non-`ort` builds (issue #1294). Without the `ort` feature,
+    /// no ONNX model can ever be loaded, so this always errors.
+    #[cfg(not(feature = "ort"))]
+    pub fn predict_loads_onnx(&self, _current_temps: &[f64]) -> Result<Vec<f64>, String> {
+        Err("ONNX inference requires the `ort` feature (build with --features ort)".to_string())
+    }
+
     pub fn predict_loads_batched(&self, batch_temps: &[Vec<f64>]) -> Vec<Vec<f64>> {
         if let Some(ref comp) = self.composite {
             return batch_temps
@@ -985,6 +1118,7 @@ impl SurrogateManager {
 
     /// Explicit batched ONNX inference — returns an error instead of
     /// panicking or silently falling back to mock data.
+    #[cfg(feature = "ort")]
     pub fn predict_loads_batched_onnx(
         &self,
         batch_temps: &[Vec<f64>],
@@ -1044,6 +1178,15 @@ impl SurrogateManager {
         let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
         self.inference_metrics.lock().record_inference(elapsed_ms);
         Ok(batch_results)
+    }
+
+    /// Stub for non-`ort` builds (issue #1294).
+    #[cfg(not(feature = "ort"))]
+    pub fn predict_loads_batched_onnx(
+        &self,
+        _batch_temps: &[Vec<f64>],
+    ) -> Result<Vec<Vec<f64>>, String> {
+        Err("ONNX inference requires the `ort` feature (build with --features ort)".to_string())
     }
 }
 
@@ -1409,6 +1552,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "ort")]
     #[test]
     fn test_is_mock_false_when_model_loaded() {
         // Skip cleanly if the fixture is missing (e.g. cargo packaging dropped it).
@@ -1422,6 +1566,7 @@ mod tests {
         assert!(m.model_loaded);
     }
 
+    #[cfg(feature = "ort")]
     #[test]
     fn test_predict_loads_onnx_errors_when_no_model_loaded() {
         let m = SurrogateManager::new().unwrap();
@@ -1430,6 +1575,7 @@ mod tests {
         assert!(result.unwrap_err().contains("No ONNX model loaded"));
     }
 
+    #[cfg(feature = "ort")]
     #[test]
     fn test_load_real_onnx_model_and_inspect_io() {
         // Verifies the end-to-end ONNX pipeline: load, inspect inputs/outputs.
@@ -1470,6 +1616,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "ort")]
     #[test]
     fn test_predict_loads_onnx_runs_real_inference() {
         // End-to-end: the dummy model is a pass-through (output[0,0] = input[0,0]).
@@ -1503,6 +1650,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "ort")]
     #[test]
     fn test_predict_loads_uses_real_onnx_when_loaded() {
         // The public `predict_loads` should route through ONNX when a model
@@ -1534,6 +1682,7 @@ mod tests {
         assert_eq!(metrics.throughput, 0.0);
     }
 
+    #[cfg(feature = "ort")]
     #[test]
     fn test_predict_loads_batched_onnx_errors_when_no_model_loaded() {
         let m = SurrogateManager::new().unwrap();
@@ -1541,6 +1690,7 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[cfg(feature = "ort")]
     #[test]
     fn test_predict_loads_batched_runs_real_inference() {
         if !std::path::Path::new(DUMMY_ONNX_MODEL).exists() {

--- a/tests/test_session_pool.rs
+++ b/tests/test_session_pool.rs
@@ -103,6 +103,7 @@ fn test_concurrent_batched_inference() {
     }
 }
 
+#[cfg(feature = "ort")]
 #[test]
 fn test_concurrent_real_model_inference() {
     // If a real ONNX model is available, test concurrent inference with actual model


### PR DESCRIPTION
## Summary

Issue #1260 closed but `.github/workflows/mutation-testing.yml` still passed `--no-default-features` to avoid ort OOM. Make the gating real: `ort` is now an optional dependency, the workflow opts in via `--features ort`, and `src/ai/**` is included in mutation analysis (issue #1294 acceptance criteria).

## Changes

**`Cargo.toml`**
- `ort` is now `optional = true` (was unconditional).
- New feature `ort` gates the dep; `onnx` is an alias per issue body.
- `cuda = ["ort", "ort/cuda", "ort/tensorrt"]` (now implies `ort`).

**`src/ai/surrogate.rs`, `src/ai/neural_field.rs`, `src/ai/modular_surrogate.rs`**
- All `use ort::…`, struct fields, and impl blocks that depend on ort types are gated with `#[cfg(feature = "ort")]`.
- Inert stubs (returning descriptive errors) keep call sites compiling without the feature:
  - `SurrogateManager::load_onnx`, `with_gpu_backend`, `with_multi_device`, `load_modular`, `predict_loads_onnx`, `predict_loads_batched_onnx`
  - `SessionPool::new`, `get_or_create_session`, `MultiDeviceSessionPool::new`
- Inline ONNX-dependent unit tests gated behind `#[cfg(feature = "ort")]`; same for `tests/test_session_pool.rs::test_concurrent_real_model_inference`.

**`.github/workflows/mutation-testing.yml`**
- Switch from `--no-default-features` to `--features ort` so `src/ai/**` is actually built and analysed. The 32 GB runner's RSS ceiling is still an open question and must be measured on CI; documented in the workflow comments.

**`.cargo/mutants.toml`**
- Drop `src/ai/**` from `exclude_globs`. `src/physics/**` / `src/validation/**` remain excluded per `docs/mutation_testing_crate_split.md` Phase 2/4.

## Verification (this branch)

```
cargo build --no-default-features                  # OK
cargo build --features ort                         # OK
cargo build --features python-bindings             # OK
cargo build --features napi-bindings               # OK
cargo test --no-default-features --lib             # 2476 passed, 2 ignored
cargo test --features ort --lib                    # 2487 passed, 2 ignored (11 ort-only tests)
```

Pre-existing failures (independent of this change): `integration-fmi-cosimulation`, `zone_balance_eplus_isolation`, `ashrae_140_cases_800_810` — confirmed by `git stash` round-trip.

## What still must happen on CI

- The mutation-testing workflow now builds with `--features ort`, so `ort`'s type hierarchy returns to the per-mutant compile graph. RSS must be measured with `/usr/bin/time -v` (or equivalent) on the 32 GB runner. If OOM re-occurs, follow-ups are tracked in `docs/mutation_testing_crate_split.md` Phase 3 (the `SurrogateProvider` trait decoupling) — explicitly out of scope here.

## Out of scope (per issue body)

- `SurrogateProvider` trait decoupling (Phase 3 of `docs/mutation_testing_crate_split.md`)
- Moving physics/validation to `fluxion-core` (Phase 2/4)