### PR TITLE
fix(#1277): reconcile FiveR1CSolver transient docs with implementation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -237,10 +237,10 @@ pub trait HeatConductionSolver: Send + Sync {
 >
 > | Path | Location | Dynamic? | Drives free-float / HVAC? |
 > |------|----------|---------|---------------------------|
-> | **Per-wall transient solver** (`FiveR1CSolver`) | `physics/five_r1c_solver.rs` (Module 3) | **Yes** — explicit Euler updates `T_mass` with `dt`; `energy_storage_rate()` returns `Q_ext - Q_to_air`. Note: returned flux uses steady-state formula `(T_ext-T_int)/R_total` (issue #1277). | No (Module 3 isolation only) |
+> | **Per-wall transient solver** (`FiveR1CSolver`) | `physics/five_r1c_solver.rs` (Module 3) | **Yes** — explicit Euler `T_mass += (T_ext − T_mass) / (R_total · C_total) · dt`; returned flux `(T_mass − T_int) / R_total`; `energy_storage_rate()` returns `Q_ext = (T_ext − T_mass) / R_total`. The first `step()` after `initialize()` is a steady-state seed (`T_mass = (T_int + T_ext) / 2`, `q = ΔT / R_total`, `energy_storage_rate = 0`) so single-step callers continue to observe `q_ss`. Closed by #1277. | No (Module 3 isolation only) |
 > | **Zone-level ISO 13790 thermal network** (5R1C / 6R2C / 9R4C) | `sim/thermal_model_core.rs` + `sim/thermal_model_physics/` (Module 5) | **Yes** (coefficient-tuned 5R1C / backward-Euler 9R4C) | **Yes** — this is the network that produces zone air temperature, heating/cooling loads, and free-floating temperatures |
 >
-> ADR-002 (`docs/adr/0002-promote-9r4c-high-mass-default.md`) resolved the drift by documenting this split and selecting the **9R4C zone-level network** as the sole solver for high-mass constructions (see Module 5). The Module 3 `FiveR1CSolver` is unchanged (steady-state, isolation-tested).
+> ADR-002 (`docs/adr/0002-promote-9r4c-high-mass-default.md`) resolved the drift by documenting this split and selecting the **9R4C zone-level network** as the sole solver for high-mass constructions (see Module 5). The Module 3 `FiveR1CSolver` is the transient per-surface solver validated against the 1% conduction tolerance criterion in `tests/conduction_5r1c_isolation.rs`.
 
 **Validation target**: Inside surface heat flux within 1% of E+ for step-change temperature test on 200mm concrete wall.
 

--- a/tests/conduction_5r1c_isolation.rs
+++ b/tests/conduction_5r1c_isolation.rs
@@ -39,24 +39,28 @@
 //!
 //! where τ = C_m · R_total is the thermal time constant.
 //!
-//! # Current Implementation Status
+//! # Current Implementation Status (post #1277)
 //!
-//! **CRITICAL**: The current `FiveR1CSolver::step()` ignores `timestep`, `h_interior`,
-//! and `h_exterior`. It computes only the steady-state flux Q = ΔT / R_total.
-//! The mass node `T_mass` is never updated, and `energy_storage_rate()` returns 0.0.
+//! `FiveR1CSolver::step()` is **transient**:
+//! - Explicit Euler update: `T_mass += (T_ext − T_mass) / (R_total · C_total) · dt`
+//! - Returned flux: `(T_mass − T_int) / R_total` (depends on the evolved mass node)
+//! - `energy_storage_rate()` returns `Q_ext = (T_ext − T_mass) / R_total` (non-zero
+//!   once the wall is evolving)
+//! - The first `step()` after `initialize()` is a steady-state seed
+//!   (`T_mass = (T_int + T_ext) / 2`, `q = ΔT / R_total`, `energy_storage_rate = 0`)
+//!   so single-step callers continue to observe `q_ss`. See `five_r1c_solver.rs`
+//!   lines 144-184 for the seed branch and 203-216 for the transient branch.
 //!
-//! Therefore:
-//! - Steady-state tests (Section 1) PASS
-//! - Transient tests (Section 2): #1206 CLOSED — transient dynamics implemented
-//! - Time constant tests (Section 3): #1206 CLOSED — transient dynamics implemented
+//! The solver ignores `h_interior` and `h_exterior` — the surface films are
+//! folded into `R_total` by `WallSpec::total_r_value()`.
 //!
-//! # Acceptance Criteria (Issue #961)
+//! # Acceptance Criteria (Issue #961, closed by #1277)
 //!
 //! - [x] Steady-state within 0.1% of Q = ΔT/R
-//! - [ ] Transient matches exponential within 1% (blocked: solver is steady-state only)
-//! - [ ] Time constant within 2% (blocked: solver is steady-state only)
-//! - [x] 3+ construction types tested
-//! - [x] Test runs in <500ms
+//! - [x] Transient matches exponential within 1% (Section 2)
+//! - [x] Time constant within 2% of `C_total · R_total` (Section 3)
+//! - [x] 3+ construction types tested (lightweight, heavyweight, insulated, very heavyweight)
+//! - [x] Test runs in <500ms (Section 5)
 //!
 //! # References
 //!
@@ -451,21 +455,22 @@ fn test_r_total_matches_wall_spec() {
 // Section 2: Transient Step Response
 // ===========================================================================
 //
-// The FiveR1CSolver DOES implement transient dynamics:
-// - T_mass is updated via explicit Euler: T_mass += dT_mass * dt
-// - energy_storage_rate() returns Q_ext - Q_to_air (non-zero during transients)
+// The FiveR1CSolver is fully transient (issue #1277 closed):
+// - T_mass is updated via explicit Euler:
+//     T_mass += (T_ext − T_mass) / (R_total · C_total) · dt
+// - Returned flux depends on the evolved mass node:
+//     q = (T_mass − T_int) / R_total
+// - energy_storage_rate() returns Q_ext = (T_ext − T_mass) / R_total
 //
-// However, the returned flux from step() uses the steady-state formula
-// (T_ext - T_int) / R_total regardless of T_mass. This means the zone
-// balance sees the steady-state flux immediately, giving τ_measured ≈ dt.
+// The lumped model matches the closed-form exponential response
+//     q(t) = q_ss · (1 − exp(−t / τ))
+// with τ = C_total · R_total, which the tests below assert against.
 //
-// The R_1/R_2 split uses R_total/2 for each half (ignoring R_se and R_si
-// surface films). The analytical τ = C_total * R_total assumes the wall's
-// total R-value without surface films.
-//
-// These tests document the gap between the current implementation and
-// the analytical expectations. The flux at steady state and the τ accuracy
-// need improvement (issue #1277).
+// Each test seeds the wall to equilibrium (T_ext = T_int, q_ss = 0) and
+// then applies a step change to T_ext; the first step() at equilibrium
+// seeds T_mass to the midpoint, so the subsequent step() sequence evolves
+// T_mass from (T_int + T_ext) / 2 toward the new T_ext — yielding the
+// q(t) = q_ss · (1 − exp(−t / τ)) form expected by the assertions.
 
 /// Transient step response: exponential approach to steady-state.
 ///
@@ -681,9 +686,11 @@ fn test_transient_step_response_insulated() {
 // ===========================================================================
 //
 // These tests verify that the solver's effective time constant matches
-// τ = C_total × R_total derived from the WallSpec.
-//
-// Currently ignored because the solver doesn't implement transient dynamics.
+// τ = C_total × R_total derived from the WallSpec. Issue #1277 closed:
+// transient dynamics are implemented, the τ measurement threshold (63.2%
+// of q_ss, i.e. (1 − e⁻¹)) is reached within 2% of the analytical value,
+// and these tests run alongside the steady-state and transient step
+// response tests.
 
 /// Time constant verification for heavyweight wall.
 ///


### PR DESCRIPTION
Resolves #1277

The FiveR1CSolver::step() implementation correctly uses explicit Euler transient update; ARCHITECTURE.md was stale (claimed "steady-state" despite the code already updating T_mass with dt, per PRs #1206, #1308/#1316). This PR updates the doc and reconciles the stale test-file comments.

## What changed

- **ARCHITECTURE.md** — Conduction module ADR-002 table row for FiveR1CSolver (line 240):
  - Remove stale "Note: returned flux uses steady-state formula (T_ext-T_int)/R_total" (fixed by #1308/#1316).
  - Cite the explicit Euler formula: `T_mass += (T_ext − T_mass) / (R_total · C_total) · dt`.
  - Document the returned flux `(T_mass − T_int) / R_total` and `energy_storage_rate() = Q_ext`.
  - Document the first-call seed branch (`T_mass = (T_int + T_ext) / 2`, `q = q_ss`) so single-step callers continue to observe `q_ss`.
  - Remove stale "unchanged (steady-state, isolation-tested)" qualifier on line 243.
- **tests/conduction_5r1c_isolation.rs** — Reconcile three stale comment blocks (header, Section 2, Section 3) that still described FiveR1CSolver as "steady-state only" despite transient dynamics being implemented. The `#[ignore]` attributes were already removed by prior work (no `#[ignore]` remains in the file).

## Verification

- **Python** (per AGENTS.md "Python not mental math" rule) confirmed the explicit-Euler update: for 200mm concrete (R=0.1156 m²K/W, C=375,478 J/(m²K), τ≈12.06 h) with T_int=20°C, T_ext=0°C, dt=3600s: `energy_storage_rate() = -86.5 W/m² ≠ 0.0` ✓ (acceptance criterion).
- **`cargo test --features ort --test conduction_5r1c_isolation`**: 21 passed, 0 failed, 0 ignored. No regressions.

## Why I did not rebase on `origin/fix/issue-1277-five-r1c-transient`

That remote branch tip (`b983d2a`, "fix #1287 SurfaceHeatFluxProvider mock parity tests") is ~30 commits behind local HEAD and would drag in 26 unrelated files (SurrogateManager ONNX wiring, multi-zone CLI, surface_flux_provider, ASHRAE 140 blind validation, etc.). The `#1277` doc-reconciliation work is a 2-file, 38+/31- diff and is fully satisfied by building on the current local state (which already includes commit 3664478 "docs(#1277): Reconcile FiveR1CSolver transient implementation with architecture docs" on main plus #1308/#1316 coupling fixes).

## Out of scope

- Zone-level 9R4C network (Agent E / ADR-002) — untouched.
- Synthetic conduction CSV replacement (Agent B / #1208) — untouched.

## Files changed (2)

- `ARCHITECTURE.md` (+2 -2)
- `tests/conduction_5r1c_isolation.rs` (+36 -29)

Co-Authored-By: Claude <noreply@anthropic.com>