### PR TITLE
feat(#1333): wire strict ±15% annual-energy CI gate

### DIFF
--- a/.agents/results/issue-B5-strict-gate.py
+++ b/.agents/results/issue-B5-strict-gate.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""
+Issue #1333 / B5 — strict ±15% annual-energy CI gate verification.
+
+Reproduces the ASHRAE 140 ±15% band math used by
+`tests/zone_balance_eplus_isolation.rs::EnergyReference` and asserts the
+same logic that the Rust strict-gate tests assert. This is a sanity
+check that the Python reproduction matches the Rust production code —
+NOT an assertion that the engine currently passes the band.
+
+Strict gate flow
+----------------
+1. `tests/zone_balance_eplus_isolation.rs` defines reference ranges for
+   Cases 600 (low-mass) and 900 (high-mass) as
+   `EnergyReference { case_id, annual_heating_min_mwh, annual_heating_max_mwh,
+                       annual_cooling_min_mwh, annual_cooling_max_mwh, ... }`.
+2. The acceptance band is computed as
+   `midpoint ± 15% of midpoint` of the [min, max] range from the
+   ASHRAE 140-2023 Annex B published values (matches EnergyPlus
+   regenerated hourly CSVs in `tests/reference_data/zone_balance/`).
+3. The strict CI gate
+   (`.github/workflows/ashrae_140_strict_energy_gate.yml`) runs the four
+   named tests on every PR; if any regress outside the band, the build
+   fails.
+
+Why this script
+---------------
+Per issue #1333 acceptance criteria: "Python verification script confirms
+±15% tolerance math: given current pre-#1323 Case 900 annual_cooling
+value vs ASHRAE 140 mid-band, prints the current ratio and PASS/FAIL
+against the gate (used as a smoke test that the logic matches the Rust
+test)."
+
+Run it locally with:
+    python3 .agents/results/issue-B5-strict-gate.py
+Exit code 0 = math matches Rust. Exit code 1 = mismatch (FAIL).
+
+Reference bands reproduced
+--------------------------
+- Case 600 (low-mass):  H=[4.36, 5.79] MWh  C=[3.92, 6.14] MWh
+- Case 900 (high-mass): H=[1.17, 2.04] MWh  C=[8.00, 10.50] MWh
+  (matches `tests/zone_balance_eplus_isolation.rs::CASE_600_REF` and
+  `::CASE_900_REF` exactly.)
+
+Engine values used here
+-----------------------
+The engine values below were measured by running
+    cargo test --release --features ort --test zone_balance_eplus_isolation \
+        -- --include-ignored \
+        test_case_600_annual_energy_ashrae140_tolerance \
+        test_case_900_annual_energy_ashrae140_tolerance
+on the post-#1323 branch (PR #1356 merged). They are reproduced here so
+this script is deterministic and offline — no engine run required.
+
+Output
+------
+Prints a table of band, engine value, and PASS/FAIL for each metric, plus
+an assertion that the computed bands match the Rust test's printed
+band edges to 3 decimal places.
+
+Issue link: https://github.com/anchapin/fluxion/issues/1333
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from typing import Tuple
+
+
+TOLERANCE_PCT = 0.15  # ASHRAE 140 annual-energy tolerance
+
+
+@dataclass(frozen=True)
+class EnergyReference:
+    case_id: str
+    annual_heating_min_mwh: float
+    annual_heating_max_mwh: float
+    annual_cooling_min_mwh: float
+    annual_cooling_max_mwh: float
+
+    def annual_heating_band(self) -> Tuple[float, float]:
+        """Acceptance band = midpoint ± 15% of midpoint."""
+        mid = 0.5 * (self.annual_heating_min_mwh + self.annual_heating_max_mwh)
+        tol = mid * TOLERANCE_PCT
+        return (mid - tol, mid + tol)
+
+    def annual_cooling_band(self) -> Tuple[float, float]:
+        mid = 0.5 * (self.annual_cooling_min_mwh + self.annual_cooling_max_mwh)
+        tol = mid * TOLERANCE_PCT
+        return (mid - tol, mid + tol)
+
+
+# Mirrors tests/zone_balance_eplus_isolation.rs::CASE_600_REF and ::CASE_900_REF
+CASE_600_REF = EnergyReference(
+    case_id="600",
+    annual_heating_min_mwh=4.36,
+    annual_heating_max_mwh=5.79,
+    annual_cooling_min_mwh=3.92,
+    annual_cooling_max_mwh=6.14,
+)
+CASE_900_REF = EnergyReference(
+    case_id="900",
+    annual_heating_min_mwh=1.17,
+    annual_heating_max_mwh=2.04,
+    annual_cooling_min_mwh=8.00,
+    annual_cooling_max_mwh=10.50,
+)
+
+
+# Engine values measured on the post-#1323 branch (PR #1356 merged).
+# These are the values the strict-gate CI workflow will evaluate when
+# the `#[ignore]` attributes are removed in the follow-up issue tracked
+# by PR #1367's body.
+ENGINE_VALUES = {
+    "600": {"heating_mwh": 3.167, "cooling_mwh": 2.672},
+    "900": {"heating_mwh": 1.626, "cooling_mwh": 1.203},
+}
+
+
+def evaluate(ref: EnergyReference, heating: float, cooling: float) -> dict:
+    """Apply the same logic as the Rust strict-gate test assertions."""
+    h_lo, h_hi = ref.annual_heating_band()
+    c_lo, c_hi = ref.annual_cooling_band()
+    return {
+        "heating_band": (h_lo, h_hi),
+        "heating_ok": h_lo <= heating <= h_hi,
+        "cooling_band": (c_lo, c_hi),
+        "cooling_ok": c_lo <= cooling <= c_hi,
+        "heating_ratio": heating / (0.5 * (h_lo + h_hi)),
+        "cooling_ratio": cooling / (0.5 * (c_lo + c_hi)),
+    }
+
+
+def main() -> int:
+    print("=" * 78)
+    print("Issue #1333 / B5 — strict ±15% annual-energy CI gate verification")
+    print("=" * 78)
+    print()
+    print(f"Reproducing band math from tests/zone_balance_eplus_isolation.rs")
+    print(f"  tolerance: ±{TOLERANCE_PCT * 100:.0f}% of midpoint of [min, max]")
+    print()
+
+    overall_ok = True
+    print(f"{'Case':<7}{'Metric':<10}{'Band (MWh)':<22}"
+          f"{'Engine (MWh)':<14}{'Ratio':<10}{'Status':<8}")
+    print("-" * 78)
+
+    for ref in (CASE_600_REF, CASE_900_REF):
+        eng = ENGINE_VALUES[ref.case_id]
+        result = evaluate(ref, eng["heating_mwh"], eng["cooling_mwh"])
+
+        h_lo, h_hi = result["heating_band"]
+        c_lo, c_hi = result["cooling_band"]
+
+        for label, band, value, ok, ratio in [
+            ("Heating", (h_lo, h_hi), eng["heating_mwh"],
+             result["heating_ok"], result["heating_ratio"]),
+            ("Cooling", (c_lo, c_hi), eng["cooling_mwh"],
+             result["cooling_ok"], result["cooling_ratio"]),
+        ]:
+            status = "PASS" if ok else "FAIL"
+            print(f"{ref.case_id:<7}{label:<10}"
+                  f"[{band[0]:.3f}, {band[1]:.3f}]      "
+                  f"{value:<14.3f}{ratio:<10.3f}{status:<8}")
+            if not ok:
+                overall_ok = False
+
+    print()
+
+    # ---- Math-matches-Rust assertion ----
+    # These are the exact numbers printed by the Rust test's assertion
+    # message (truncated to 3 decimal places):
+    #   Rust: 'Case 600 annual cooling X MWh outside ±15% band [4.275, 5.784]'
+    #   Rust: 'Case 900 annual cooling X MWh outside ±15% band [7.862, 10.637]'
+    c600_lo, c600_hi = CASE_600_REF.annual_cooling_band()
+    c900_lo, c900_hi = CASE_900_REF.annual_cooling_band()
+    h600_lo, h600_hi = CASE_600_REF.annual_heating_band()
+    h900_lo, h900_hi = CASE_900_REF.annual_heating_band()
+
+    expected = {
+        "Case 600 cooling band": (c600_lo, c600_hi, 4.275, 5.784),
+        "Case 900 cooling band": (c900_lo, c900_hi, 7.862, 10.637),
+        "Case 600 heating band": (h600_lo, h600_hi, 4.314, 5.836),
+        "Case 900 heating band": (h900_lo, h900_hi, 1.364, 1.846),
+    }
+    print("=== Math-matches-Rust assertion (3-dp) ===")
+    math_ok = True
+    for label, (actual_lo, actual_hi, rust_lo, rust_hi) in expected.items():
+        match = (
+            abs(actual_lo - rust_lo) < 0.001 and abs(actual_hi - rust_hi) < 0.001
+        )
+        print(f"  {label:<26}  Python=[{actual_lo:.3f}, {actual_hi:.3f}]"
+              f"  Rust=[{rust_lo:.3f}, {rust_hi:.3f}]"
+              f"  {'MATCH' if match else 'MISMATCH'}")
+        if not match:
+            math_ok = False
+
+    print()
+    print("=" * 78)
+    print("Gate wiring (issue #1333 acceptance criteria)")
+    print("=" * 78)
+    print("  [x] .github/workflows/ashrae_140_strict_energy_gate.yml exists.")
+    print("      Triggers on PR + push to main. Runs 4 named tests in")
+    print("      --release mode with --features ort.")
+    print("  [x] 4 named tests covered:")
+    print("        1. test_case_600_annual_energy_ashrae140_tolerance")
+    print("        2. test_case_900_annual_energy_ashrae140_tolerance")
+    print("        3. test_blind_mode_case_600_infrastructure")
+    print("        4. test_blind_mode_case_900_infrastructure")
+    print("  [x] release_gates.yaml::ci.required_checks lists the gate.")
+    print("  [ ] Tests 1+2 remain #[ignore] pending A#4 closure")
+    print("      verification (post-#1323 cooling-gap regression).")
+    print("      When un-ignored in the follow-up issue, the same gate")
+    print("      enforces the ±15% band automatically.")
+    print()
+    print("=" * 78)
+    if math_ok:
+        print("SMOKE-TEST RESULT: PASS — Python band math matches Rust test.")
+    else:
+        print("SMOKE-TEST RESULT: FAIL — Python band math diverged from Rust.")
+    print()
+    if not overall_ok:
+        print("ENGINE EVALUATION (informational):")
+        print("  Case 600 H FAIL: 3.167 MWh outside [4.314, 5.836]")
+        print("  Case 600 C FAIL: 2.672 MWh outside [4.275, 5.784]")
+        print("  Case 900 H PASS: 1.626 MWh within [1.364, 1.846]")
+        print("  Case 900 C FAIL: 1.203 MWh outside [7.862, 10.637]")
+        print()
+        print("  This is the expected pre-A#4 state. The gate's job is")
+        print("  to keep it this way (red) until the physics layer closes")
+        print("  the cooling gap — not to relax the band.")
+    print("=" * 78)
+    # Smoke-test exit code: 0 iff math matches Rust.
+    # The overall_ok flag (engine evaluation) is informational; the
+    # script's purpose is math-vs-Rust verification, not engine-PASS.
+    return 0 if math_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ashrae_140_strict_energy_gate.yml
+++ b/.github/workflows/ashrae_140_strict_energy_gate.yml
@@ -1,0 +1,230 @@
+# ASHRAE 140 Strict Annual-Energy CI Gate (Issue #1333)
+#
+# Runs the strict ±15% annual-energy tolerance tests for ASHRAE 140
+# Cases 600 (low-mass baseline) and 900 (high-mass) on every PR and push
+# to main. This is the durable regression guard that locks in the post-#1323
+# roof-solar physics fix (PR #1356) and prevents silent regressions in the
+# annual-energy band.
+#
+# What it runs
+# ------------
+# Four tests, each named explicitly so the gate's coverage is auditable.
+# Each test runs in its own cargo invocation with a substring filter
+# precise enough to match exactly one test (cargo test accepts only one
+# TESTNAME positional arg, and a too-broad substring like "_infrastructure"
+# matches 7 blind-mode tests in `ashrae_140_blind_validation.rs`).
+#
+#   1. test_case_600_annual_energy_ashrae140_tolerance  (zone_balance_eplus_isolation)
+#      filter: _case_600_annual_energy_ashrae140_tolerance
+#   2. test_case_900_annual_energy_ashrae140_tolerance  (zone_balance_eplus_isolation)
+#      filter: _case_900_annual_energy_ashrae140_tolerance
+#   3. test_blind_mode_case_600_infrastructure          (ashrae_140_blind_validation)
+#      filter: _blind_mode_case_600_infrastructure
+#   4. test_blind_mode_case_900_infrastructure          (ashrae_140_blind_validation)
+#      filter: _blind_mode_case_900_infrastructure
+#
+# The two `*_annual_energy_ashrae140_tolerance` tests are currently
+# `#[ignore]` pending issue A#4 closure verification (the residual
+# cooling-load gap after the post-#1323 roof-solar fix). When that issue
+# reports PASS and the `#[ignore]` attributes are removed, these tests
+# will run as part of this same gate invocation — without any workflow
+# change. The `--include-ignored` flag is NOT used; the gate must fail
+# honestly if a follow-up PR un-ignores a test that the physics cannot
+# yet satisfy (matches AGENTS.md "strict gate MUST fail honestly when
+# physics is wrong").
+#
+# The two `*_infrastructure` tests already run today (no `#[ignore]`).
+# They verify that the validator API exposes `ValidationMode::Blind` and
+# that Case 600/900 produce finite, non-zero annual energy through the
+# public API. They are the API-level companions to the strict-tolerance
+# tests (issue #1283).
+#
+# Why --release
+# -------------
+# The strict ±15% tolerance tests run annual simulations (8760 hourly
+# steps). Release mode matches the production binary and avoids the
+# 5-10x slowdown that debug-mode unit tests incur. Same reasoning as
+# `.github/workflows/ashrae_140_validation.yml`.
+#
+# Why --features ort
+# ------------------
+# Case 900 routes through the production `MultiNodeSolver` (9R4C thermal
+# network) when the construction is HighMass. That code path lives
+# behind the `ort` feature gate (per issue #1294). Without `--features
+# ort`, Case 900 would compile out of the `MultiNodeSolver` arm and the
+# strict gate would only exercise the low-mass path — false-positive
+# coverage.
+#
+# Status check name
+# -----------------
+# The job id is `strict-energy-gate`; the human-readable name is
+# "ASHRAE 140 Strict Energy Gate (Issue #1333)". Add this job name to
+# the branch protection "Required status checks" list (it is also
+# declared in `release_gates.yaml` under `ci.required_checks`).
+#
+# Linked issues
+# -------------
+# - #1333 — this issue (wire the gate)
+# - #1323 — roof-solar physics fix (PR #1356)
+# - #1328 — Case 900 peak-cooling closure verification
+# - #1295 — established the strict energy-conservation invariant CI pattern
+# - #1147 — ASHRAE 140 blind validation baseline
+# - #1283 — ValidationMode::Blind wiring
+# - #1332 — extended Blind coverage to Cases 800/810/920/950/960
+
+name: ASHRAE 140 Strict Energy Gate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+# Serialize strict-gate runs per ref so two pushes don't double-allocate
+# runners while the previous run is still queued. Different refs run in
+# parallel (so feature branches don't queue behind main).
+concurrency:
+  group: ashrae-140-strict-energy-gate-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1
+
+jobs:
+  strict-energy-gate:
+    name: ASHRAE 140 Strict Energy Gate (Issue #1333)
+    runs-on: ${{ vars.FLUXION_LINUX_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev pkg-config libfontconfig1-dev
+
+      - uses: ./.github/actions/setup-rust-python-env
+        with:
+          python-version: '3.10'
+
+      - name: Cache cargo registry + build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ashrae-140-strict-gate-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ashrae-140-strict-gate-${{ runner.os }}-
+
+      - name: Strict ±15% Case 600 tolerance (annual heating/cooling)
+        # Test 1/4: strict tolerance for low-mass Case 600.
+        # Filter `_case_600_annual_energy_ashrae140_tolerance` is precise —
+        # no other test in the workspace shares this suffix.
+        run: |
+          cargo test --release --features ort --verbose \
+            --test zone_balance_eplus_isolation \
+            _case_600_annual_energy_ashrae140_tolerance \
+            2>&1 | tee -a /tmp/strict_gate_output.txt
+          echo "---"
+          echo "exit_code=$?"
+
+      - name: Strict ±15% Case 900 tolerance (annual heating/cooling)
+        # Test 2/4: strict tolerance for high-mass Case 900.
+        run: |
+          cargo test --release --features ort --verbose \
+            --test zone_balance_eplus_isolation \
+            _case_900_annual_energy_ashrae140_tolerance \
+            2>&1 | tee -a /tmp/strict_gate_output.txt
+          echo "---"
+          echo "exit_code=$?"
+
+      - name: ValidationMode::Blind Case 600 infrastructure
+        # Test 3/4: API-level infrastructure for Case 600 (already passing).
+        # Filter `_blind_mode_case_600_infrastructure` is precise — only
+        # one test in the workspace matches this substring.
+        run: |
+          cargo test --release --features ort --verbose \
+            --test ashrae_140_blind_validation \
+            _blind_mode_case_600_infrastructure \
+            2>&1 | tee -a /tmp/strict_gate_output.txt
+          echo "---"
+          echo "exit_code=$?"
+
+      - name: ValidationMode::Blind Case 900 infrastructure
+        # Test 4/4: API-level infrastructure for Case 900 (already passing).
+        run: |
+          cargo test --release --features ort --verbose \
+            --test ashrae_140_blind_validation \
+            _blind_mode_case_900_infrastructure \
+            2>&1 | tee -a /tmp/strict_gate_output.txt
+          echo "---"
+          echo "exit_code=$?"
+
+      - name: Verify all 4 tests ran and gate is green
+        # The strict gate's contract: every named test appears in the
+        # cargo output, either as `ok` (passed), `ignored` (still gated
+        # by `#[ignore]`), or `FAILED` (regression — fail the build).
+        # A test name missing from the output means a follow-up refactor
+        # silently dropped it from the gate's coverage, which is itself
+        # a regression.
+        run: |
+          echo "=== Strict gate coverage check ==="
+          for t in \
+            test_case_600_annual_energy_ashrae140_tolerance \
+            test_case_900_annual_energy_ashrae140_tolerance \
+            test_blind_mode_case_600_infrastructure \
+            test_blind_mode_case_900_infrastructure ; do
+            if grep -qE "\\.\\.\\. $t \\.\\.\\. (ok|ignored|FAILED)" /tmp/strict_gate_output.txt; then
+              echo "  COVERED: $t"
+            else
+              echo "  DROPPED FROM GATE: $t"
+              echo "  This test name is no longer matched by the cargo filter."
+              echo "  Either the test was renamed/removed, or the workflow"
+              echo "  filter needs updating. Failing the build."
+              exit 1
+            fi
+          done
+
+          echo
+          echo "=== Strict gate result extraction ==="
+          # Strip ANSI colour codes for grep.
+          sed -i 's/\x1b\[[0-9;]*m//g' /tmp/strict_gate_output.txt
+
+          FAILED=$(grep -cE '^test .* \\.\\.\\. FAILED$' /tmp/strict_gate_output.txt || true)
+          PANICS=$(grep -cE 'panicked at' /tmp/strict_gate_output.txt || true)
+          PASSED=$(grep -cE '^test (test_case|test_blind_mode)_(600|900)_(annual_energy_ashrae140_tolerance|infrastructure) \\.\\.\\. ok$' /tmp/strict_gate_output.txt || true)
+          IGNORED=$(grep -cE '^test (test_case|test_blind_mode)_(600|900)_(annual_energy_ashrae140_tolerance|infrastructure) \\.\\.\\. ignored$' /tmp/strict_gate_output.txt || true)
+
+          echo "  Passed   : $PASSED"
+          echo "  Ignored  : $IGNORED (still gated by #[ignore] pending A#4)"
+          echo "  Failed   : $FAILED"
+          echo "  Panics   : $PANICS"
+
+          if [ "$FAILED" -gt 0 ] || [ "$PANICS" -gt 0 ]; then
+            echo
+            echo "::error::Strict ±15% annual-energy gate FAILED — Case 600/900 regression detected."
+            echo "See /tmp/strict_gate_output.txt for the failing assertion messages."
+            echo "Per AGENTS.md 'no parameter tuning, fix the math': the physics layer must be"
+            echo "fixed, NOT the tolerance band."
+            exit 1
+          fi
+          echo "PASS: ASHRAE 140 strict ±15% annual-energy gate holds."
+
+      - name: Upload strict-gate log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ashrae-140-strict-energy-gate
+          path: /tmp/strict_gate_output.txt
+          retention-days: 14

--- a/release_gates.yaml
+++ b/release_gates.yaml
@@ -168,3 +168,35 @@ ci:
 
   # Gate status output file
   output_file: "gate_status.json"
+
+  # =============================================================================
+  # REQUIRED STATUS CHECKS
+  # =============================================================================
+  # GitHub branch-protection "Required status checks" list. Every check
+  # named here must report `success` on the merge commit before the PR
+  # can be merged into `main`. Mirrors the `#1295` energy-conservation
+  # pattern (`rust-tests.yml::energy-conservation`) — the strict energy
+  # gate (#1333) is the next layer of the same regression-guard stack.
+  #
+  # Job names (NOT workflow names) must match the `jobs.<id>.name`
+  # field in each workflow file. To find them, look for
+  # `name: ASHRAE 140 Strict Energy Gate (Issue #1333)` in
+  # `.github/workflows/ashrae_140_strict_energy_gate.yml`.
+  required_checks:
+    # Strict ±15% annual-energy tolerance for ASHRAE 140 Cases 600/900
+    # (issue #1333). Currently exercises the two Blind-mode
+    # infrastructure tests (passing) plus the two strict-tolerance
+    # tests (skipped via `#[ignore]` pending A#4 closure verification).
+    # When the `#[ignore]` attributes are removed (tracked by the
+    # follow-up issue recorded in PR #1367's body), the same gate will
+    # enforce the ±15% band automatically.
+    - "ASHRAE 140 Strict Energy Gate (Issue #1333)"
+
+  # Job-to-workflow map (informational; branch-protection reads job
+  # names directly). Used by `scripts/release_gate_checker.py` to verify
+  # the required_checks list is in sync with the workflows directory.
+  workflow_index:
+    - job: "ASHRAE 140 Strict Energy Gate (Issue #1333)"
+      workflow: ".github/workflows/ashrae_140_strict_energy_gate.yml"
+      issue: 1333
+      triggered_by: "PR + push to main"

--- a/tests/zone_balance_eplus_isolation.rs
+++ b/tests/zone_balance_eplus_isolation.rs
@@ -828,17 +828,28 @@ fn test_case_600_blind_energy_infrastructure() {
     assert!(c_lo > 0.0 && c_hi > c_lo, "malformed cooling reference");
 }
 
-/// Case 600 STRICT ASHRAE 140 tolerance — IGNORED pending physics fix.
+/// Case 600 STRICT ASHRAE 140 tolerance — IGNORED pending A#4 closure.
 ///
-/// The cooling load calculation underestimates ASHRAE 140 reference by
-/// ~90% (current: ~0.5 MWh; ref: 3.9-6.1 MWh). Root cause: the 5R1C
-/// solver is steady-state only and the zone balance does not yet
-/// correctly integrate solar gains + mass dynamics + HVAC cooling. Per
-/// AGENTS.md ("no parameter tuning, fix the math"), this test is
-/// `#[ignore]` until the underlying physics is corrected; it will be
-/// un-ignored automatically when the cooling load is brought within band.
-/// RE-IGNORED per wave orchestrator: physics gap (#1213) not resolved.
-#[ignore = "blocked by #1213 zone cooling physics + #672 epic v1.3"]
+/// The strict ±15% annual-energy tolerance gate (issue #1333) is wired
+/// in `.github/workflows/ashrae_140_strict_energy_gate.yml` and runs on
+/// every PR. This test is left `#[ignore]` until issue A#4 reports PASS
+/// (post-#1323 cooling-gap closure verification). When un-ignored, this
+/// test participates in the strict gate automatically — if the engine
+/// regresses outside ±15% of the ASHRAE 140 published band, the gate
+/// fails the build.
+///
+/// Engine values observed on the post-#1323 branch (this file,
+/// run with `cargo test --release --features ort
+/// -- --include-ignored test_case_600_annual_energy`):
+///   H=3.167 MWh outside band [4.314, 5.836]   FAIL (~27% below)
+///   C=2.672 MWh outside band [4.275, 5.784]   FAIL (~38% below)
+///
+/// Per AGENTS.md ("no parameter tuning, fix the math"), the fix is owned
+/// by the physics layer (CTF transient wall modeling follow-up), not by
+/// loosening the band or adjusting the engine constants.
+#[ignore = "Issue #1333 strict gate wired; un-ignore pending A#4 closure \
+            verification (post-#1323 cooling-gap regression on Case 600 \
+            annual heating/cooling — see PR #1367 / issue #1333)."]
 #[test]
 fn test_case_600_annual_energy_ashrae140_tolerance() {
     let spec = ASHRAE140Case::Case600.spec();
@@ -900,9 +911,29 @@ fn test_case_900_blind_energy_infrastructure() {
     assert!(c_lo > 0.0 && c_hi > c_lo, "malformed cooling reference");
 }
 
-/// Case 900 STRICT ASHRAE 140 tolerance — IGNORED pending physics fix.
-/// Blocked by: #1213 (90% cooling underestimate), #672 epic (v1.3 blind validation).
-#[ignore = "blocked by #1213 cooling physics + #672 epic v1.3"]
+/// Case 900 STRICT ASHRAE 140 tolerance — IGNORED pending A#4 closure.
+///
+/// The strict ±15% annual-energy tolerance gate (issue #1333) is wired
+/// in `.github/workflows/ashrae_140_strict_energy_gate.yml` and runs on
+/// every PR. This test is left `#[ignore]` until issue A#4 reports PASS
+/// (post-#1323 cooling-gap closure verification). When un-ignored, this
+/// test participates in the strict gate automatically — if the engine
+/// regresses outside ±15% of the ASHRAE 140 published band, the gate
+/// fails the build.
+///
+/// Engine values observed on the post-#1323 branch (this file,
+/// run with `cargo test --release --features ort
+/// -- --include-ignored test_case_900_annual_energy`):
+///   H=1.626 MWh within band [1.364, 1.846]   PASS
+///   C=1.203 MWh outside band [7.862, 10.637] FAIL (~85% below)
+///
+/// Per AGENTS.md ("no parameter tuning, fix the math"), the residual
+/// cooling gap is owned by the physics layer (CTF transient wall modeling
+/// follow-up per #1328 verification hand-off), not by loosening the band.
+#[ignore = "Issue #1333 strict gate wired; un-ignore pending A#4 closure \
+            verification (post-#1323 cooling-gap regression on Case 900 \
+            annual cooling — peak 1.03 kW vs 2.10 kW band lower bound, \
+            see PR #1367 / issue #1333 / #1328 closure report)."]
 #[test]
 fn test_case_900_annual_energy_ashrae140_tolerance() {
     let spec = ASHRAE140Case::Case900.spec();


### PR DESCRIPTION
fixes #1333

## What this PR does

Wires the durable ASHRAE 140 strict annual-energy regression guard so the post-#1323 roof-solar physics fix (PR #1356) cannot silently regress. Layered on top of the #1295 energy-conservation invariant CI pattern (rust-tests.yml::energy-conservation).

### 1. New workflow — `.github/workflows/ashrae_140_strict_energy_gate.yml`

Runs four explicitly-named tests on every PR + push to `main`. Each test runs in its own `cargo` invocation with `--release` + `--features ort` (Case 900 needs `ort` for the 9R4C MultiNodeSolver arm; per #1294). The gate fails the build if any test reports `FAILED`.

| # | Test | File | Filter (substring) |
|---|------|------|---------------------|
| 1 | `test_case_600_annual_energy_ashrae140_tolerance` | `tests/zone_balance_eplus_isolation.rs` | `_case_600_annual_energy_ashrae140_tolerance` |
| 2 | `test_case_900_annual_energy_ashrae140_tolerance` | `tests/zone_balance_eplus_isolation.rs` | `_case_900_annual_energy_ashrae140_tolerance` |
| 3 | `test_blind_mode_case_600_infrastructure` | `tests/ashrae_140_blind_validation.rs` | `_blind_mode_case_600_infrastructure` |
| 4 | `test_blind_mode_case_900_infrastructure` | `tests/ashrae_140_blind_validation.rs` | `_blind_mode_case_900_infrastructure` |

A coverage-check step greps the combined `cargo` output for each of the 4 names (`... ok`, `... ignored`, or `... FAILED`) and fails the build if any name is missing — guards against silent refactor-induced drops from the gate's coverage.

### 2. `release_gates.yaml` — new `ci.required_checks` + `ci.workflow_index`

Adds the gate job name (`ASHRAE 140 Strict Energy Gate (Issue #1333)`) to the required status-checks list. Mirrors the #1295 pattern. The new `ci.workflow_index` lets `scripts/release_gate_checker.py` keep the required-checks list in sync with the `.github/workflows/` directory.

### 3. `tests/zone_balance_eplus_isolation.rs` — updated `#[ignore]` reasons on the 2 strict tolerance tests

Replaces the stale `#1213 zone cooling physics + #672 epic v1.3` reasons on lines 841 (Case 600) and 905 (Case 900) with reasons that cite #1333 + record the current post-#1323 engine values vs. ASHRAE 140 band edges. The `#[ignore]` attributes **stay in place** pending A#4 closure verification — see decision rationale below.

### 4. `.agents/results/issue-B5-strict-gate.py` — Python verification artifact

Reproduces the Rust `EnergyReference::annual_*_band` math (midpoint ± 15% of midpoint of `[min, max]`). Asserts the Python band matches the Rust printed assertion message to 3 decimal places for all 4 (case × metric) combinations. Exit 0 = math matches Rust; non-zero = mismatch.

```
$ python3 .agents/results/issue-B5-strict-gate.py
...
=== Math-matches-Rust assertion (3-dp) ===
  Case 600 cooling band       Python=[4.275, 5.784]   Rust=[4.275, 5.784]   MATCH
  Case 900 cooling band       Python=[7.862, 10.637]  Rust=[7.862, 10.637]  MATCH
  Case 600 heating band       Python=[4.314, 5.836]   Rust=[4.314, 5.836]   MATCH
  Case 900 heating band       Python=[1.364, 1.846]   Rust=[1.364, 1.846]   MATCH

SMOKE-TEST RESULT: PASS — Python band math matches Rust test.
```

## Decision rationale: keep the 2 strict tolerance tests `#[ignore]` pending A#4

The issue body states the rollout happens **AFTER** A#4 reports verification PASS. A#4 has not yet reported PASS on this branch — measured by running the tests directly:

| Case | Metric | Engine | Band (±15%) | Status |
|------|--------|--------|-------------|--------|
| 600 | Heating | 3.167 MWh | [4.314, 5.836] | **FAIL** (~27% below) |
| 600 | Cooling | 2.672 MWh | [4.275, 5.784] | **FAIL** (~38% below) |
| 900 | Heating | 1.626 MWh | [1.364, 1.846] | PASS |
| 900 | Cooling | 1.203 MWh | [7.862, 10.637] | **FAIL** (~85% below) |

Per AGENTS.md "no parameter tuning, fix the math", loosening the band is forbidden (#1271 closed investigation). Per the Blocker Protocol, un-ignoring the tests now would make the strict gate fail and block merges — exactly the "fail honestly" model, but it doesn't deliver the issue's acceptance criterion of "all 4 tests pass". The right move is to wire the durable CI infrastructure **now** (this PR), then un-ignore in a follow-up issue once A#4 reports PASS. When the `#[ignore]` attributes are removed, the same `cargo` invocation in the workflow will run the strict tests and fail the build if they regress.

## Issue-body line-number discrepancy (documented)

The issue body cites `ashrae_140_blind_validation.rs:843` and `:907` as additional `#[ignore]` sites, but:

- **Line 843** is inside a doc comment (the heating-band-zero explanation for Cases 950/960).
- **Line 907** is inside a `println!` macro's format arguments (the value of `blind.annual_cooling_max`).

Neither is an `#[ignore]` line. The actual `#[ignore]` markers in that file are at lines 1167, 1194, 1221, 1248, 1276 — these gate Cases 800/810/920/950/960 on pending EnergyPlus reference CSV regeneration (#1331 / #1168) and are explicitly out-of-scope for #1333 per the issue's "Out of scope" section. The two Blind-mode tests named in this workflow (`test_blind_mode_case_{600,900}_infrastructure`) already run today (no `#[ignore]`) and serve as the API-level companions to the strict tolerance tests per #1283.

## Cargo test output (post-#1323 branch, --release --features ort)

```
=== Test 1/4: Case 600 strict tolerance ===
running 1 test
test test_case_600_annual_energy_ashrae140_tolerance ... ignored, Issue #1333 strict gate wired; un-ignore pending A#4 closure verification...
test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 19 filtered out

=== Test 2/4: Case 900 strict tolerance ===
running 1 test
test test_case_900_annual_energy_ashrae140_tolerance ... ignored, Issue #1333 strict gate wired; un-ignore pending A#4 closure verification...
test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 19 filtered out

=== Test 3/4: Blind Case 600 infrastructure ===
running 1 test
test test_blind_mode_case_600_infrastructure ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 14 filtered out

=== Test 4/4: Blind Case 900 infrastructure ===
running 1 test
test test_blind_mode_case_900_infrastructure ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 14 filtered out
```

Gate contract: every named test appears in the output (`ok`, `ignored`, or `FAILED`). The 2 `ignored` results are the deliberate `#[ignore]` markers; the gate stays green until they are un-ignored in the A#4 follow-up. If a future PR un-ignores them while physics is broken, the gate fails honestly.

## Acceptance criteria status

- [x] `.github/workflows/ashrae_140_strict_energy_gate.yml` exists, ±15% tolerance, fails on FAILED, triggers on PR + push to main.
- [x] Listed in `release_gates.yaml::ci.required_checks`.
- [x] 4 named tests compile and execute under `cargo test` (2 active, 2 `#[ignore]`).
- [x] Python verification artifact confirms ±15% tolerance math (Python ↔ Rust match to 3 dp).
- [ ] All 4 tests pass — **pending A#4** (out of scope for this rollout per the issue's "Land AFTER A#4 reports verification PASS" prerequisite).

## Linked issues

#1323 (roof-solar fix merged in Wave 1, PR #1356) · #1328 (Case 900 peak-cooling closure) · #1295 (energy-conservation CI pattern) · #1147 (ASHRAE 140 blind baseline) · #1283 (ValidationMode::Blind) · #1332 (extended Blind coverage) · #1331 (Cases 920/950/960 CSV generators) · #1168 (E+ CSV regeneration)

## Out of scope (per issue body)

- Loosening ±15% tolerance band (#1271 closed investigation + AGENTS.md).
- Patching underlying cooling physics (CTF transient wall modeling follow-up per #1328).
- Verifying the cooling gap closed (A#4 — separate wave).
- Cases 920/950/960 ±15% rollout (depends on B#3 + E#3/E#4).
