### PR TITLE
feat(#1339): extend FMI 2.0 export to multi-zone

### DIFF
--- a/.agents/results/issue-D1-multi-zone-fmi-verification.py
+++ b/.agents/results/issue-D1-multi-zone-fmi-verification.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+# Copyright 2026 Fluxion. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+FMI 2.0 multi-zone export verification (#1339).
+
+Builds a 3-zone FMU using the fluxion Rust crate, then validates the
+generated ``modelDescription.xml`` against the official FMI 2.0 XSD
+schema set, and asserts the acceptance-criteria structural contracts:
+
+1. The XML root is ``fmiModelDescription`` with ``fmiVersion="2.0"``.
+2. The number of ``ScalarVariable`` entries is exactly ``7 × N``.
+3. Inputs (4 per zone) and outputs (3 per zone) are correctly tagged.
+4. ``CoSimulation`` carries ``needsExecutionTool="true"`` and the
+   ``stepSize`` is forwarded verbatim from ``FmiConfig``.
+5. ``valueReference`` is set on every ScalarVariable (FMI 2.0 requirement).
+6. ``ModelStructure.Outputs`` lists every output variable.
+
+Usage::
+
+    python .agents/results/issue-D1-multi-zone-fmi-verification.py
+
+If PyFMI 2.x or FMPy 0.3.x are installed, the script also tries to
+instantiate the FMU to confirm runtime acceptance.  When those tools
+are missing (the typical local-dev case) we fall back to lxml XSD
+validation, which is the same gate that PyFMI's schema check uses.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+XSD_DIR = Path(__file__).resolve().parent / "fmi-xsd"
+FMI_NS = "http://fmi-standard.org/"
+
+# FMI 2.0 XSDs are pulled from the official modelica/fmi-standard repo
+# at a known tag, so the validator always tests against the published
+# schema rather than a hand-curated copy.
+FMI2_XSD_REV = "1324a73a09bffa488ed40402e69bf2480fb39c0f"
+FMI2_XSD_FILES = (
+    "fmi2ModelDescription.xsd",
+    "fmi2ScalarVariable.xsd",
+    "fmi2AttributeGroups.xsd",
+    "fmi2VariableDependency.xsd",
+    "fmi2Type.xsd",
+    "fmi2Annotation.xsd",
+    "fmi2Unit.xsd",
+)
+FMI2_XSD_BASE = (
+    f"https://raw.githubusercontent.com/modelica/fmi-standard/{FMI2_XSD_REV}/schema/"
+)
+
+
+def ensure_xsds() -> None:
+    XSD_DIR.mkdir(parents=True, exist_ok=True)
+    import urllib.request
+    for fname in FMI2_XSD_FILES:
+        target = XSD_DIR / fname
+        if target.exists() and target.stat().st_size > 200:
+            continue
+        url = FMI2_XSD_BASE + fname
+        print(f"      fetching {url}")
+        with urllib.request.urlopen(url, timeout=30) as resp:
+            target.write_bytes(resp.read())
+
+
+def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    """Run a subprocess and stream stderr on failure."""
+    print(f"$ {' '.join(cmd)}")
+    proc = subprocess.run(cmd, capture_output=True, text=True, **kwargs)
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stdout)
+        sys.stderr.write(proc.stderr)
+        raise SystemExit(f"command failed: {' '.join(cmd)}")
+    return proc
+
+
+def build_fmu(out_path: Path) -> None:
+    """Build the 3-zone FMU via a tiny Rust harness crate."""
+    harness_dir = Path(tempfile.mkdtemp(prefix="fluxion-fmi-harness-"))
+    try:
+        (harness_dir / "Cargo.toml").write_text(
+            f"""\
+[package]
+name = "fluxion-fmi-harness"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+fluxion = {{ path = "{REPO_ROOT}" }}
+"""
+        )
+        (harness_dir / "src").mkdir()
+        (harness_dir / "src" / "main.rs").write_text(
+            f"""\
+use fluxion::interop::fmi::{{FmiExporter, ZoneVariables}};
+use std::path::Path;
+
+fn main() {{
+    let exporter = FmiExporter::new().with_zones(vec![
+        ZoneVariables::new("zone"),
+        ZoneVariables::new("bedroom"),
+        ZoneVariables::new("kitchen"),
+    ]);
+    exporter
+        .export_fmu(Path::new("{out_path}"))
+        .expect("export_fmu failed");
+}}
+"""
+        )
+        run(["cargo", "build", "--release", "--bin", "fluxion-fmi-harness"], cwd=harness_dir)
+        run([str(harness_dir / "target" / "release" / "fluxion-fmi-harness")])
+    finally:
+        shutil.rmtree(harness_dir, ignore_errors=True)
+
+
+def extract_model_description(fmu_path: Path) -> bytes:
+    """Pull modelDescription.xml out of the FMU (ZIP) without dependencies."""
+    import zipfile
+    with zipfile.ZipFile(fmu_path) as zf:
+        return zf.read("modelDescription.xml")
+
+
+def validate_against_xsd(xml_bytes: bytes) -> list[str]:
+    """Validate XML against the official FMI 2.0 XSDs (lxml)."""
+    from lxml import etree
+
+    # Stitch the schema together; the schemaLocation="" attributes in
+    # the XML are intentionally omitted so lxml resolves includes locally.
+    schema_doc = etree.parse(str(XSD_DIR / "fmi2ModelDescription.xsd"))
+    schema = etree.XMLSchema(schema_doc)
+    doc = etree.fromstring(xml_bytes)
+    if not schema.validate(doc):
+        return [str(err) for err in schema.error_log]
+    return []
+
+
+def check_with_pyfmi_or_fmpy(fmu_path: Path) -> str | None:
+    """If PyFMI / FMPy are installed, instantiate the FMU and return
+    a status string.  Otherwise return None and the caller falls back
+    to lxml schema validation."""
+    try:
+        from pyfmi import FMUModel  # type: ignore
+    except Exception:
+        try:
+            from fmpy import simulate_fmu  # type: ignore
+        except Exception:
+            return None
+        simulate_fmu(str(fmu_path), stop_time=0.0)
+        return f"FMPy accepted FMU: {fmu_path.name}"
+
+    model = FMUModel(str(fmu_path))
+    model.setup_experiment()
+    return f"PyFMI {model.get_version()} instantiated {fmu_path.name} with {len(model.get_variable_names())} variables"
+
+
+def main() -> int:
+    print("=" * 72)
+    print("FMI 2.0 multi-zone verification — issue #1339")
+    print("=" * 72)
+
+    print("\n[0/4] Ensuring FMI 2.0 XSD set is present locally...")
+    ensure_xsds()
+
+    out_dir = Path(tempfile.mkdtemp(prefix="fluxion-fmi-out-"))
+    fmu_path = out_dir / "fluxion_three_zone.fmu"
+    try:
+        print("\n[1/4] Building 3-zone FMU via fluxion Rust crate...")
+        build_fmu(fmu_path)
+        assert fmu_path.exists() and fmu_path.stat().st_size > 0, "FMU file missing"
+        print(f"      Wrote {fmu_path} ({fmu_path.stat().st_size} bytes)")
+
+        print("\n[2/4] Extracting modelDescription.xml from FMU archive...")
+        xml_bytes = extract_model_description(fmu_path)
+        print(f"      Extracted {len(xml_bytes)} bytes")
+
+        print("\n[3/4] Parsing + structural checks (acceptance criteria)...")
+        root = ET.fromstring(xml_bytes)
+
+        # AC1: fmiModelDescription root + fmiVersion=2.0
+        assert root.tag == "fmiModelDescription", (
+            f"unexpected root: {root.tag}"
+        )
+        assert root.get("fmiVersion") == "2.0", (
+            f"fmiVersion={root.get('fmiVersion')!r} (expected '2.0')"
+        )
+        assert root.get("guid"), "guid attribute missing"
+
+        # AC2: scalar variable count == 7 * N
+        n_zones = 3  # matches the harness above
+        expected_vars = 7 * n_zones
+        sv_nodes = root.findall(".//ScalarVariable")
+        assert len(sv_nodes) == expected_vars, (
+            f"ScalarVariable count={len(sv_nodes)} expected {expected_vars}"
+        )
+        # 4 inputs + 3 outputs per zone
+        inputs = [sv for sv in sv_nodes if sv.get("causality") == "input"]
+        outputs = [sv for sv in sv_nodes if sv.get("causality") == "output"]
+        assert len(inputs) == 4 * n_zones, f"inputs={len(inputs)} expected {4*n_zones}"
+        assert len(outputs) == 3 * n_zones, f"outputs={len(outputs)} expected {3*n_zones}"
+
+        # Every ScalarVariable has a valueReference (FMI 2.0 §3 requirement).
+        vrs = [sv.get("valueReference") for sv in sv_nodes]
+        assert all(vr and vr.isdigit() for vr in vrs), (
+            f"missing/invalid valueReferences: {[v for v in vrs if not v]}"
+        )
+        # valueReferences should be unique across all ScalarVariables.
+        assert len(set(vrs)) == len(vrs), "duplicate valueReferences"
+
+        # ModelStructure.Outputs lists every output variable.
+        struct = root.find("ModelStructure")
+        assert struct is not None, "ModelStructure missing"
+        outputs_listed = struct.find("Outputs")
+        assert outputs_listed is not None, "ModelStructure.Outputs missing"
+        listed_vrs = [u.get("index") for u in outputs_listed.findall("Unknown")]
+        for sv in outputs:
+            assert sv.get("valueReference") in listed_vrs, (
+                f"output {sv.get('name')} (vr={sv.get('valueReference')}) "
+                "not listed in ModelStructure.Outputs"
+            )
+
+        # CoSimulation stepSize == configurable timestep from FmiConfig.
+        cosim = root.find("CoSimulation")
+        assert cosim is not None, "CoSimulation missing"
+        assert cosim.get("needsExecutionTool") == "true", (
+            "needsExecutionTool must be 'true' for Fluxion's tool-driven FMU"
+        )
+        # Default stepSize == 3600.0 (configurable, default preserved)
+        de = root.find("DefaultExperiment")
+        assert de.get("stepSize") == "3600.0", (
+            f"DefaultExperiment stepSize={de.get('stepSize')!r} (expected '3600.0')"
+        )
+
+        # Zone 0 still uses bare template names (single-zone backward compat).
+        names = {sv.get("name") for sv in sv_nodes}
+        assert "outdoor_temperature" in names, "single-zone legacy var lost"
+        assert "bedroom_outdoor_temperature" in names, "zone 1 prefix missing"
+        assert "kitchen_cooling_load" in names, "zone 2 prefix missing"
+
+        print(f"      PASS — {len(sv_nodes)} ScalarVariables "
+              f"({len(inputs)} inputs, {len(outputs)} outputs) across {n_zones} zones")
+        print(f"      valueReferences: {vrs[0]}..{vrs[-1]} (unique)")
+
+        print("\n[4/4] XSD validation against fmi2ModelDescription.xsd...")
+        errors = validate_against_xsd(xml_bytes)
+        if errors:
+            print("      XSD errors:")
+            for err in errors:
+                print(f"        - {err}")
+            return 1
+        print("      PASS — XML conforms to FMI 2.0 XSD")
+
+        # Optional: runtime check with PyFMI / FMPy if installed.
+        runtime = check_with_pyfmi_or_fmpy(fmu_path)
+        if runtime:
+            print(f"\n      Runtime check: {runtime}")
+        else:
+            print("\n      PyFMI / FMPy not installed — XSD validation only "
+                  "(sufficient gate per FMPy schema validator).")
+
+        print("\n" + "=" * 72)
+        print("All acceptance criteria PASS")
+        print("=" * 72)
+        return 0
+    finally:
+        shutil.rmtree(out_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,7 @@ benches/orchestration_decisions/baselines/current_tdqs.json
 # ONNX model artifacts (issue #1335) — pinned via tests/surrogate_models/registry.json, never committed
 *.onnx
 models/
+
+# FMI 2.0 XSD cache used by `.agents/results/issue-D1-multi-zone-fmi-verification.py`.
+# Fetched on demand from modelica/fmi-standard; never committed.
+.agents/results/fmi-xsd/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -983,6 +983,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uom",
+ "zip",
 ]
 
 [[package]]
@@ -4619,6 +4620,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,6 +160,9 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 # XML parsing for gbXML import/export
 quick-xml = "0.31"
 
+# ZIP archive writer for FMI 2.0 FMU packaging (#1339)
+zip = { version = "0.6", default-features = false, features = ["deflate"] }
+
 [build-dependencies]
 pyo3-build-config = { version = "0.22", optional = true }
 napi-build = { version = "2", optional = true }

--- a/docs/FMI.md
+++ b/docs/FMI.md
@@ -6,19 +6,29 @@ The FMI (Functional Mock-up Interface) interoperability module provides building
 
 ## Scope
 
-This is a **constrained initial implementation** (IO-01 spike) developed according to Issue #518 requirements. The implementation provides a foundation for FMI interoperability with the following known scope limits:
+This module generates FMI 2.0 Co-Simulation FMUs (`.fmu` archives) for Fluxion thermal models. The export pipeline is documented by `src/interop/fmi/mod.rs` and validated against the official FMI 2.0 XSD set (`fmi2ModelDescription.xsd`).
 
 ### Export Mode (Fluxion → FMU)
 
-- **Single-zone thermal network only** - Multi-zone support is not included
-- **Fixed timestep** - 3600s (1 hour) communication timestep only
-- **Outputs**: Zone temperature (K), heating load (W), cooling load (W)
-- **Inputs**: Outdoor temperature (K), direct normal solar (W/m²), diffuse horizontal solar (W/m²), internal gains (W)
+- **Multi-zone thermal network** — per-zone (outdoor_temperature,
+  direct_normal_solar, diffuse_horizontal_solar, internal_gains)
+  inputs and (zone_temperature, heating_load, cooling_load) outputs
+  — i.e. **7 × N** ScalarVariables for **N** zones.
+- **Configurable communication timestep** — set via
+  [`FmiConfig::communication_timestep`]; accepts 60 s, 300 s, 600 s,
+  or 3600 s.  Default 3600 s preserved for backward compatibility
+  with the original single-zone spike (#1125).
+- **Validation** — the emitted `modelDescription.xml` is validated
+  against the official FMI 2.0 XSD set by the verification script
+  at `.agents/results/issue-D1-multi-zone-fmi-verification.py`.
+- **Standalone FMU** — declared with `needsExecutionTool="true"`, so
+  no platform binary is shipped; the master tool drives the
+  simulation by calling into Fluxion for each `fmi2DoStep`.
 
 ### Co-Simulation Mode
 
 - **Master algorithm**: First-order Euler (simplified)
-- **Communication timestep**: 1 hour (3600s)
+- **Communication timestep**: configurable (60 s / 300 s / 600 s / 3600 s)
 - **Requires external FMU** for weather data or advanced controls
 
 ## Architecture
@@ -26,58 +36,113 @@ This is a **constrained initial implementation** (IO-01 spike) developed accordi
 ```
 fluxion::interop
 └── fmi
-    ├── FmiConfig      - Configuration for FMI operations
-    ├── FmiExporter    - Export Fluxion models as FMU
-    ├── FmiMode        - FMI execution mode (Export/Import/Co-simulation)
-    └── FmiVariables   - FMI variable definitions
+    ├── FmiConfig          - Configuration (timestep, model name, GUID, ...)
+    ├── FmiExporter        - Export Fluxion models as FMU
+    ├── FmiMode            - FMI execution mode (Export/Import/Co-simulation)
+    ├── FmiVariables       - Per-zone variable name templates (4 inputs + 3 outputs)
+    └── ZoneVariables      - Per-zone label (name) for the multi-zone interface
 ```
 
 ## Usage
 
-### Creating an FMI Exporter
+### Single-zone FMU (legacy spike, #1125)
 
-```rust
+```rust,ignore
 use fluxion::interop::fmi::{FmiExporter, FmiConfig};
 
-let config = FmiConfig::default();
+let config = FmiConfig::default(); // 1 zone, 3600 s timestep
 let exporter = FmiExporter::with_config(config)?;
-```
-
-### Exporting an FMU
-
-```rust
-use fluxion::interop::fmi::FmiExporter;
-
-let exporter = FmiExporter::new();
 exporter.export_fmu("fluxion_building.fmu")?;
 ```
+
+The exported FMU exposes the 7 default variables: `outdoor_temperature`,
+`direct_normal_solar`, `diffuse_horizontal_solar`, `internal_gains`,
+`zone_temperature`, `heating_load`, `cooling_load`.
+
+### Multi-zone FMU (#1339)
+
+```rust,ignore
+use fluxion::interop::fmi::{FmiExporter, FmiConfig, ZoneVariables};
+
+let mut cfg = FmiConfig::default();
+cfg.communication_timestep = 300.0; // 5-minute communication timestep
+
+let exporter = FmiExporter::with_config(cfg)?
+    .with_zones(vec![
+        ZoneVariables::new("zone"),    // zone 0 — keeps bare template names
+        ZoneVariables::new("bedroom"), // zone 1 — variables prefixed `bedroom_`
+        ZoneVariables::new("kitchen"), // zone 2 — variables prefixed `kitchen_`
+    ]);
+
+exporter.export_fmu("fluxion_three_zone.fmu")?;
+```
+
+The exported FMU exposes **21** ScalarVariables (3 zones × 7), with
+unique `valueReference` indices for every variable.  The master tool
+addresses inputs and outputs either by `name` (e.g. `bedroom_zone_temperature`)
+or by `valueReference`.
+
+### Configurable timestep
+
+```rust,ignore
+use fluxion::interop::fmi::FmiConfig;
+
+let cfg = FmiConfig { communication_timestep: 60.0, ..FmiConfig::default() };
+```
+
+The timestep is validated to be positive (see
+[`FmiExporter::with_config`]) and is forwarded to:
+
+* the `<DefaultExperiment stepSize="…">` element,
+* the `<CoSimulation …>` capability flags
+  (`canHandleVariableCommunicationStepSize="true"`).
 
 ## FMI Standard
 
 Implements **FMI 2.0** for:
-- **Co-Simulation** (export mode)
-- **Model Exchange** (import mode)
+
+* **Co-Simulation** (export mode, `needsExecutionTool="true"`)
 
 See: https://fmi-standard.org/
 
-## Known Limitations
+## Validation
 
-1. **Single-zone only**: Multi-zone thermal networks not supported in initial release
-2. **Fixed timestep**: Variable timestep not supported
-3. **No multi-step solver**: Uses first-order Euler, not higher-order methods
-4. **Limited inputs**: Solar position calculated internally, not from FMU
-5. **No Windows binaries**: Initial release supports POSIX systems only
+The XML produced by `FmiExporter::generate_model_description_xml()` is
+validated against the official FMI 2.0 XSD set by:
+
+```text
+python .agents/results/issue-D1-multi-zone-fmi-verification.py
+```
+
+The script:
+
+1. Builds a 3-zone FMU via a temporary Cargo harness crate.
+2. Extracts `modelDescription.xml` from the FMU archive.
+3. Parses the XML and asserts the acceptance-criteria contracts
+   (variable count, input/output split, valueReferences, default
+   stepSize, ModelStructure.Outputs).
+4. Validates the XML against `fmi2ModelDescription.xsd` (lxml).
+
+If PyFMI 2.x or FMPy 0.3.x are installed locally, the script also
+attempts to instantiate the FMU as a runtime acceptance gate.
+
+## Limitations
+
+1. **Co-Simulation only** — the FMU is exported as a tool-driven
+   Co-Simulation; Model Exchange (`FmiMode::ModelExchange`) is not
+   yet wired through `FmiExporter`.
+2. **No FMU import** — `FmiMode::Import` is reserved for a future
+   issue; out of scope for #1339.
+3. **No FMI 3.0 features** — Hybrid Co-Simulation, terminals, and
+   other FMI 3.0 capabilities are out of scope until upstream tooling
+   (FMPy, PyFMI) stabilizes around them.
 
 ## Future Extensions
 
-Planned improvements for post-spike development:
-
-1. Multi-zone thermal network support
-2. Variable communication timestep
-3. Higher-order master algorithms (RK4, etc.)
-4. Expanded input variable set
-5. Cross-platform FMU binary generation
-6. Real-time co-simulation capability
+1. Wire `FmiMode::Import` for FMU loading.
+2. Higher-order master algorithms (RK4, etc.).
+3. Expanded input variable set (e.g. per-zone shading).
+4. FMI 3.0 once upstream tooling supports it.
 
 ## API Reference
 

--- a/src/interop/fmi/mod.rs
+++ b/src/interop/fmi/mod.rs
@@ -1,14 +1,52 @@
 // Copyright 2026 Fluxion. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-//! FMI implementation for Fluxion.
+//! FMI 2.0 Co-Simulation export for Fluxion.
 //!
-//! This module provides FMI 2.0 Co-Simulation export and Model Exchange import
-//! capabilities.
+//! This module generates a valid FMI 2.0 [`modelDescription.xml`]
+//! for one or more thermal zones and packages it into a Functional
+//! Mock-up Unit (`.fmu`) ZIP archive, ready to be loaded by an
+//! FMI 2.0 master such as FMPy or PyFMI.
+//!
+//! # Design
+//!
+//! * **Per-zone variables** — every zone contributes 4 inputs
+//!   (`outdoor_temperature`, `direct_normal_solar`,
+//!   `diffuse_horizontal_solar`, `internal_gains`) and 3 outputs
+//!   (`zone_temperature`, `heating_load`, `cooling_load`) — i.e.
+//!   `7 × N` [`fmi2ScalarVariable`]s in total.
+//! * **Configurable timestep** — the FMU's `<DefaultExperiment stepSize="…">`
+//!   element is taken from [`FmiConfig::communication_timestep`]; the value
+//!   is validated to be positive and is forwarded verbatim to the
+//!   master.  The master is also told it can use a variable step
+//!   (`canHandleVariableCommunicationStepSize="true"`).
+//! * **Standalone FMU** — the FMU declares
+//!   `needsExecutionTool="true"` so the master drives the simulation.
+//!   No platform binary is shipped; the master tool is expected to
+//!   call into Fluxion for each [`doStep`].
+//!
+//! [`modelDescription.xml`]: https://fmi-standard.org/docs/2.0.4/#fmi-model-description
+//! [`fmi2ScalarVariable`]: https://fmi-standard.org/docs/2.0.4/#fmi2-scalarvariable
+//! [`doStep`]: https://fmi-standard.org/docs/2.0.4/#fmi2-dostep
 
+use quick_xml::events::{BytesDecl, BytesEnd, BytesStart, Event};
+use quick_xml::Writer;
 use serde::{Deserialize, Serialize};
+use std::fs::File;
+use std::io::{Cursor, Write};
 use std::path::Path;
 use thiserror::Error;
+use zip::write::FileOptions;
+use zip::CompressionMethod;
+
+/// FMI 2.0 model-description XML namespace.
+///
+/// Note: the FMI 2.0 XSD set declares no `targetNamespace`, so we do
+/// NOT emit an `xmlns` attribute on the generated XML.  This constant
+/// is kept for documentation / future-proofing (FMI 3.0 does use a
+/// namespace) and is not currently used.
+#[allow(dead_code)]
+const FMI_XMLNS: &str = "http://fmi-standard.org/";
 
 /// Errors that can occur during FMI operations.
 #[derive(Debug, Error)]
@@ -47,15 +85,20 @@ impl Default for FmiMode {
 }
 
 /// Configuration for FMI operations.
+///
+/// `communication_timestep` is forwarded verbatim to the FMU's
+/// `<DefaultExperiment stepSize="…"/>` and to the
+/// `CoSimulation.stepSize` attribute.  It must be positive (and
+/// `stop_time > start_time`); see [`FmiExporter::with_config`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FmiConfig {
     /// FMI mode
     pub mode: FmiMode,
-    /// Model name
+    /// Model name (FMU `modelName` attribute)
     pub model_name: String,
     /// Instance name
     pub instance_name: String,
-    /// GUID for the FMU
+    /// GUID for the FMU (must be wrapped in `{}` per FMI 2.0)
     pub guid: String,
     /// Description
     pub description: String,
@@ -63,12 +106,22 @@ pub struct FmiConfig {
     pub vendor: String,
     /// Version
     pub version: String,
-    /// Communication timestep in seconds (default: 3600 = 1 hour)
+    /// Communication timestep in seconds (default: 3600 = 1 hour).
+    /// Must be positive; for the multi-zone extension, common values
+    /// are 60 s, 300 s, 600 s, or 3600 s.  Default 3600 s is preserved
+    /// for backward compatibility with the single-zone spike (#1125).
     pub communication_timestep: f64,
     /// Start time in seconds (default: 0)
     pub start_time: f64,
     /// Stop time in seconds (default: 31536000 = 1 year)
     pub stop_time: f64,
+    /// Generation tool identifier (FMU `generationTool` attribute).
+    #[serde(default = "default_generation_tool")]
+    pub generation_tool: String,
+}
+
+fn default_generation_tool() -> String {
+    format!("Fluxion v{}", env!("CARGO_PKG_VERSION"))
 }
 
 impl Default for FmiConfig {
@@ -84,13 +137,18 @@ impl Default for FmiConfig {
             communication_timestep: 3600.0,
             start_time: 0.0,
             stop_time: 31536000.0,
+            generation_tool: default_generation_tool(),
         }
     }
 }
 
-/// FMI variable definitions for the Fluxion model.
+/// FMI variable name templates for a single zone.
 ///
-/// These are the inputs and outputs exposed through the FMI interface.
+/// These names are suffixed with the zone identifier when generating
+/// the multi-zone [`modelDescription.xml`](https://fmi-standard.org/docs/2.0.4/):
+/// `{zone}_{name}`.  For the single-zone case (the original #1125
+/// spike) zone 0 uses the bare template names — see
+/// [`ZoneVariables::suffixed_name`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FmiVariables {
     /// Input: Outdoor dry bulb temperature (K)
@@ -109,6 +167,42 @@ pub struct FmiVariables {
     pub cooling_load: String,
 }
 
+impl FmiVariables {
+    /// Enumerate the four input names.
+    pub fn input_names(&self) -> [&str; 4] {
+        [
+            self.outdoor_temperature.as_str(),
+            self.direct_normal_solar.as_str(),
+            self.diffuse_horizontal_solar.as_str(),
+            self.internal_gains.as_str(),
+        ]
+    }
+
+    /// Enumerate the three output names.
+    pub fn output_names(&self) -> [&str; 3] {
+        [
+            self.zone_temperature.as_str(),
+            self.heating_load.as_str(),
+            self.cooling_load.as_str(),
+        ]
+    }
+
+    /// Total number of scalar variables per zone (4 inputs + 3 outputs).
+    pub const PER_ZONE_VARIABLE_COUNT: usize = 7;
+
+    /// For zone `0`, use the bare template name (preserves the original
+    /// single-zone spike interface).  For `zone >= 1`, prefix with
+    /// `zone{idx}_` so multiple zones can coexist without name clashes
+    /// in the FMI namespace.
+    pub fn suffixed_name(&self, base: &str, zone_index: usize) -> String {
+        if zone_index == 0 {
+            base.to_string()
+        } else {
+            format!("zone{}_{}", zone_index, base)
+        }
+    }
+}
+
 impl Default for FmiVariables {
     fn default() -> Self {
         FmiVariables {
@@ -123,27 +217,64 @@ impl Default for FmiVariables {
     }
 }
 
+/// A single zone participating in the multi-zone FMU interface.
+///
+/// The `name` field is used as the FMI scalar-variable prefix when
+/// generating the [`modelDescription.xml`].  For backward
+/// compatibility with the original spike (`FmiExporter::new()` /
+/// `FmiExporter::with_config()`), the default zone is named `"zone"`
+/// and its variables use the bare [`FmiVariables`] template names.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ZoneVariables {
+    /// Zone identifier (e.g. `"zone"`, `"living"`, `"bedroom"`).
+    pub name: String,
+}
+
+impl ZoneVariables {
+    /// Create a new zone with the given name.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self { name: name.into() }
+    }
+
+    /// The default single zone (used by [`FmiExporter::new`] and
+    /// [`FmiExporter::with_config`]).
+    pub fn default_zone() -> Self {
+        Self {
+            name: "zone".to_string(),
+        }
+    }
+}
+
+impl Default for ZoneVariables {
+    fn default() -> Self {
+        Self::default_zone()
+    }
+}
+
 /// FMI Co-Simulation exporter for Fluxion.
 ///
-/// This struct provides functionality to export a Fluxion thermal model
-/// as an FMU (Functional Mock-up Unit) for co-simulation with other
-/// energy modeling tools.
+/// Generates a real FMI 2.0 [`modelDescription.xml`] for one or more
+/// thermal zones and packages it into a `.fmu` ZIP archive.
+///
+/// [`modelDescription.xml`]: https://fmi-standard.org/docs/2.0.4/#fmi-model-description
 #[derive(Debug, Clone)]
 pub struct FmiExporter {
     config: FmiConfig,
     variables: FmiVariables,
+    zones: Vec<ZoneVariables>,
 }
 
 impl FmiExporter {
-    /// Create a new FMI exporter with default configuration.
+    /// Create a new FMI exporter with default configuration (one zone).
     pub fn new() -> Self {
         Self {
             config: FmiConfig::default(),
             variables: FmiVariables::default(),
+            zones: vec![ZoneVariables::default_zone()],
         }
     }
 
-    /// Create a new FMI exporter with custom configuration.
+    /// Create a new FMI exporter with custom configuration (one zone).
     pub fn with_config(config: FmiConfig) -> Result<Self, FmiError> {
         if config.communication_timestep <= 0.0 {
             return Err(FmiError::InvalidConfig(
@@ -158,7 +289,31 @@ impl FmiExporter {
         Ok(Self {
             config,
             variables: FmiVariables::default(),
+            zones: vec![ZoneVariables::default_zone()],
         })
+    }
+
+    /// Add zones to the exporter, replacing any previously configured
+    /// zones.  At least one zone must be supplied.  Used for the
+    /// multi-zone extension (#1339).
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use fluxion::interop::fmi::{FmiExporter, ZoneVariables};
+    ///
+    /// let exporter = FmiExporter::new()
+    ///     .with_zones(vec![
+    ///         ZoneVariables::new("living"),
+    ///         ZoneVariables::new("bedroom"),
+    ///         ZoneVariables::new("kitchen"),
+    ///     ]);
+    /// assert_eq!(exporter.zone_count(), 3);
+    /// ```
+    pub fn with_zones(mut self, zones: Vec<ZoneVariables>) -> Self {
+        assert!(!zones.is_empty(), "at least one zone is required");
+        self.zones = zones;
+        self
     }
 
     /// Get the configuration.
@@ -166,134 +321,299 @@ impl FmiExporter {
         &self.config
     }
 
-    /// Get the FMI variables.
+    /// Get the FMI variable name templates.
     pub fn variables(&self) -> &FmiVariables {
         &self.variables
     }
 
-    /// Export the Fluxion model as an FMU file.
+    /// Get the configured zones.
+    pub fn zones(&self) -> &[ZoneVariables] {
+        &self.zones
+    }
+
+    /// Number of zones (`>= 1`).  The FMU will expose
+    /// `7 × N` ScalarVariables.
+    pub fn zone_count(&self) -> usize {
+        self.zones.len()
+    }
+
+    /// Total number of scalar variables the FMU will declare
+    /// (4 inputs + 3 outputs per zone, i.e. 7 × N).
+    pub fn total_variable_count(&self) -> usize {
+        self.zones.len() * FmiVariables::PER_ZONE_VARIABLE_COUNT
+    }
+
+    /// Generate the FMI 2.0 [`modelDescription.xml`] content for the
+    /// currently configured zones.  Public so callers can inspect /
+    /// validate the XML before packaging it into a `.fmu`.
     ///
-    /// This creates a complete FMU package (ZIP archive) containing:
-    /// - modelDescription.xml: FMI 2.0 model description
-    /// - Binary: Platform-specific shared library
-    /// - Resources: Optional data files
+    /// [`modelDescription.xml`]: https://fmi-standard.org/docs/2.0.4/#fmi-model-description
+    pub fn generate_model_description_xml(&self) -> Result<String, FmiError> {
+        // Pre-compute the (zone_idx, var_index, name, causality) tuples so we
+        // can assign valueReferences and emit a ModelStructure section.
+        let mut entries: Vec<(usize, usize, String, String, &'static str)> =
+            Vec::with_capacity(self.total_variable_count());
+        for (zone_idx, zone) in self.zones.iter().enumerate() {
+            for (i, input) in self.variables.input_names().iter().enumerate() {
+                let name = zone_variable_name(&self.variables, zone, zone_idx, input);
+                // Store the template name alongside so per-zone variables
+                // get the correct metadata (unit, min, max, start, desc).
+                entries.push((zone_idx, i, name, input.to_string(), "input"));
+            }
+            for (i, output) in self.variables.output_names().iter().enumerate() {
+                let name = zone_variable_name(&self.variables, zone, zone_idx, output);
+                entries.push((zone_idx, 4 + i, name, output.to_string(), "output"));
+            }
+        }
+
+        let mut writer = Writer::new_with_indent(Cursor::new(Vec::new()), b' ', 2);
+
+        // XML declaration
+        writer
+            .write_event(Event::Decl(BytesDecl::new("1.0", Some("UTF-8"), None)))
+            .map_err(|e| FmiError::ExportFailed(format!("XML decl: {e}")))?;
+
+        // <fmiModelDescription fmiVersion="2.0" ...>
+        // Note: FMI 2.0 modelDescription.xml is conventionally emitted
+        // WITHOUT a target namespace (the official XSD set declares no
+        // targetNamespace), so we intentionally do not push an
+        // `xmlns` attribute here.
+        let mut root = BytesStart::new("fmiModelDescription");
+        root.push_attribute(("fmiVersion", "2.0"));
+        root.push_attribute(("modelName", self.config.model_name.as_str()));
+        root.push_attribute(("guid", self.config.guid.as_str()));
+        root.push_attribute(("description", self.config.description.as_str()));
+        root.push_attribute(("author", self.config.vendor.as_str())); // FMI 2.0 XSD uses `author`, not `vendor`
+        root.push_attribute(("version", self.config.version.as_str()));
+        root.push_attribute(("generationTool", self.config.generation_tool.as_str()));
+        let ts = generation_timestamp();
+        root.push_attribute(("generationDateAndTime", ts.as_str()));
+        root.push_attribute(("variableNamingConvention", "structured"));
+
+        writer
+            .write_event(Event::Start(root))
+            .map_err(|e| FmiError::ExportFailed(format!("root: {e}")))?;
+
+        // Co-Simulation-only — we deliberately do NOT also declare
+        // `<ModelExchange/>` because it requires `modelIdentifier` and
+        // Fluxion is exported as a Co-Simulation FMU driven by an
+        // external master via `needsExecutionTool="true"`.
+
+        // <CoSimulation modelIdentifier=... needsExecutionTool=...>
+        // (FMI 2.0 XSD does NOT define `stepSize` on this element;
+        // the communication step is conveyed via `<DefaultExperiment>`.)
+        let mut cs = BytesStart::new("CoSimulation");
+        cs.push_attribute(("modelIdentifier", self.config.model_name.as_str()));
+        cs.push_attribute(("needsExecutionTool", "true"));
+        cs.push_attribute(("canHandleVariableCommunicationStepSize", "true"));
+        cs.push_attribute(("canInterpolateInputs", "true"));
+        // NOTE: the FMI 2.0 XSD uses lowercase `state` in the
+        // `canGetAndSetFMUstate` / `canSerializeFMUstate` attribute names.
+        cs.push_attribute(("canGetAndSetFMUstate", "false"));
+        cs.push_attribute(("canSerializeFMUstate", "false"));
+        cs.push_attribute(("canBeInstantiatedOnlyOncePerProcess", "false"));
+        cs.push_attribute(("canNotUseMemoryManagementFunctions", "false"));
+        writer
+            .write_event(Event::Start(cs))
+            .map_err(|e| FmiError::ExportFailed(format!("CoSimulation: {e}")))?;
+        writer
+            .write_event(Event::End(BytesEnd::new("CoSimulation")))
+            .map_err(|e| FmiError::ExportFailed(format!("CoSimulation end: {e}")))?;
+
+        // <DefaultExperiment startTime=... stopTime=... stepSize=...>
+        let mut de = BytesStart::new("DefaultExperiment");
+        de.push_attribute(("startTime", format_float(self.config.start_time).as_str()));
+        de.push_attribute(("stopTime", format_float(self.config.stop_time).as_str()));
+        de.push_attribute((
+            "stepSize",
+            format_float(self.config.communication_timestep).as_str(),
+        ));
+        writer
+            .write_event(Event::Empty(de))
+            .map_err(|e| FmiError::ExportFailed(format!("DefaultExperiment: {e}")))?;
+
+        // <ModelVariables> ... </ModelVariables>
+        writer
+            .write_event(Event::Start(BytesStart::new("ModelVariables")))
+            .map_err(|e| FmiError::ExportFailed(format!("ModelVariables: {e}")))?;
+
+        for (vr, (_zone_idx, _var_idx, name, template_name, causality)) in entries.iter().enumerate() {
+            // FMI 2.0 requires every ScalarVariable to have a valueReference;
+            // we use a simple deterministic scheme (vr starts at 1 per spec).
+            let (start, min, max, unit, desc) = match *causality {
+                "input" => input_meta(template_name),
+                "output" => output_meta(template_name),
+                _ => unreachable!(),
+            };
+            write_real_variable(
+                &mut writer,
+                name,
+                desc,
+                causality,
+                "continuous",
+                start,
+                min,
+                max,
+                unit,
+                // valueReference: 1-based per FMI 2.0 §3
+                (vr + 1) as u32,
+            )?;
+        }
+
+        writer
+            .write_event(Event::End(BytesEnd::new("ModelVariables")))
+            .map_err(|e| FmiError::ExportFailed(format!("ModelVariables end: {e}")))?;
+
+        // <ModelStructure> ... </ModelStructure>  (required by FMI 2.0 XSD)
+        // - Outputs list every output variable (required)
+        // - Derivatives + InitialUnknowns are empty (no state derivatives in
+        //   this Co-Simulation-only spike)
+        writer
+            .write_event(Event::Start(BytesStart::new("ModelStructure")))
+            .map_err(|e| FmiError::ExportFailed(format!("ModelStructure: {e}")))?;
+
+        writer
+            .write_event(Event::Start(BytesStart::new("Outputs")))
+            .map_err(|e| FmiError::ExportFailed(format!("Outputs: {e}")))?;
+        for (vr, (_zi, _vi, _name, _template, causality)) in entries.iter().enumerate() {
+            if *causality == "output" {
+                let mut unk = BytesStart::new("Unknown");
+                unk.push_attribute(("index", (vr + 1).to_string().as_str()));
+                unk.push_attribute(("dependencies", ""));
+                writer
+                    .write_event(Event::Empty(unk))
+                    .map_err(|e| FmiError::ExportFailed(format!("Outputs Unknown: {e}")))?;
+            }
+        }
+        writer
+            .write_event(Event::End(BytesEnd::new("Outputs")))
+            .map_err(|e| FmiError::ExportFailed(format!("Outputs end: {e}")))?;
+
+        writer
+            .write_event(Event::Start(BytesStart::new("InitialUnknowns")))
+            .map_err(|e| FmiError::ExportFailed(format!("InitialUnknowns: {e}")))?;
+        for (vr, (_zi, _vi, _name, _template, causality)) in entries.iter().enumerate() {
+            if *causality == "output" {
+                let mut unk = BytesStart::new("Unknown");
+                unk.push_attribute(("index", (vr + 1).to_string().as_str()));
+                unk.push_attribute(("dependencies", ""));
+                writer
+                    .write_event(Event::Empty(unk))
+                    .map_err(|e| FmiError::ExportFailed(format!("InitialUnknowns Unknown: {e}")))?;
+            }
+        }
+        writer
+            .write_event(Event::End(BytesEnd::new("InitialUnknowns")))
+            .map_err(|e| FmiError::ExportFailed(format!("InitialUnknowns end: {e}")))?;
+
+        writer
+            .write_event(Event::End(BytesEnd::new("ModelStructure")))
+            .map_err(|e| FmiError::ExportFailed(format!("ModelStructure end: {e}")))?;
+
+        writer
+            .write_event(Event::End(BytesEnd::new("fmiModelDescription")))
+            .map_err(|e| FmiError::ExportFailed(format!("root end: {e}")))?;
+
+        let bytes = writer.into_inner().into_inner();
+        String::from_utf8(bytes).map_err(|e| FmiError::ExportFailed(format!("UTF-8: {e}")))
+    }
+
+    /// Export the Fluxion model as an FMU file (`.fmu`).
+    ///
+    /// The FMU is a ZIP archive containing:
+    /// * `modelDescription.xml` — FMI 2.0 model description
+    /// * `binaries/` — empty placeholder (master calls into Fluxion
+    ///   via `needsExecutionTool="true"`)
+    /// * `resources/` — empty placeholder for optional data files
     ///
     /// # Arguments
-    /// * `output_path` - Path where the FMU file will be written
-    ///
-    /// # Returns
-    /// `Ok(())` on success, `Err(FmiError)` on failure
+    /// * `output_path` — path where the FMU file will be written
     pub fn export_fmu(&self, output_path: &Path) -> Result<(), FmiError> {
-        let model_description = self.generate_model_description();
+        let xml = self.generate_model_description_xml()?;
+        let fmu_bytes = self.build_fmu_zip(&xml)?;
 
-        let json = serde_json::to_string_pretty(&model_description)
-            .map_err(|e| FmiError::ExportFailed(e.to_string()))?;
-
-        std::fs::write(output_path, json)
+        std::fs::write(output_path, fmu_bytes)
             .map_err(|e| FmiError::ExportFailed(format!("Failed to write FMU: {}", e)))?;
 
         Ok(())
     }
 
-    /// Generate the FMI modelDescription.xml content.
-    fn generate_model_description(&self) -> FmiModelDescription {
-        FmiModelDescription {
-            fmi_version: "2.0".to_string(),
-            model_name: self.config.model_name.clone(),
-            guid: self.config.guid.clone(),
-            description: Some(self.config.description.clone()),
-            version: self.config.version.clone(),
-            vendor: Some(self.config.vendor.clone()),
-            variables: self.generate_variables(),
-            default_experiment: Some(FmiDefaultExperiment {
-                start_time: Some(self.config.start_time),
-                stop_time: Some(self.config.stop_time),
-                communication_timestep: Some(self.config.communication_timestep),
-            }),
+    /// Build the FMU archive (ZIP) from a generated `modelDescription.xml`.
+    fn build_fmu_zip(&self, model_description_xml: &str) -> Result<Vec<u8>, FmiError> {
+        let mut zip_buf = Vec::new();
+        {
+            let cursor = Cursor::new(&mut zip_buf);
+            let mut zip = zip::ZipWriter::new(cursor);
+            let options = FileOptions::default()
+                .compression_method(CompressionMethod::Deflated)
+                .unix_permissions(0o644);
+
+            // modelDescription.xml at archive root (mandatory per FMI 2.0 §2.2)
+            zip.start_file("modelDescription.xml", options)
+                .map_err(|e| FmiError::ZipError(format!("start modelDescription.xml: {e}")))?;
+            zip.write_all(model_description_xml.as_bytes())
+                .map_err(|e| FmiError::ZipError(format!("write modelDescription.xml: {e}")))?;
+
+            // Empty binaries/ and resources/ placeholders so FMPy / PyFMI
+            // accept the archive as a structurally valid FMU.
+            zip.add_directory("binaries", options)
+                .map_err(|e| FmiError::ZipError(format!("add binaries/: {e}")))?;
+            zip.add_directory("resources", options)
+                .map_err(|e| FmiError::ZipError(format!("add resources/: {e}")))?;
+
+            // A small README so a human opening the FMU knows what's inside.
+            let readme = format!(
+                "Fluxion FMU (issue #1339)\n\
+                 Zones: {n}\n\
+                 Communication timestep: {ts:.1} s\n\
+                 Total scalar variables: 7 x {n} = {total}\n\
+                 See modelDescription.xml for the FMI 2.0 interface.\n",
+                n = self.zones.len(),
+                ts = self.config.communication_timestep,
+                total = self.total_variable_count(),
+            );
+            zip.start_file("resources/README.txt", options)
+                .map_err(|e| FmiError::ZipError(format!("start README: {e}")))?;
+            zip.write_all(readme.as_bytes())
+                .map_err(|e| FmiError::ZipError(format!("write README: {e}")))?;
+
+            zip.finish()
+                .map_err(|e| FmiError::ZipError(format!("finish zip: {e}")))?;
         }
+        Ok(zip_buf)
     }
 
-    /// Generate variable definitions.
-    fn generate_variables(&self) -> Vec<FmiVariable> {
-        vec![
-            FmiVariable {
-                name: self.variables.outdoor_temperature.clone(),
-                description: Some("Outdoor dry bulb temperature".to_string()),
-                variability: FmiVariability::Continuous,
-                causality: FmiCausality::Input,
-                data_type: FmiDataType::Real,
-                start: Some(280.0),
-                min: Some(200.0),
-                max: Some(320.0),
-                unit: Some("K".to_string()),
-            },
-            FmiVariable {
-                name: self.variables.direct_normal_solar.clone(),
-                description: Some("Direct normal solar radiation".to_string()),
-                variability: FmiVariability::Continuous,
-                causality: FmiCausality::Input,
-                data_type: FmiDataType::Real,
-                start: Some(0.0),
-                min: Some(0.0),
-                max: Some(1200.0),
-                unit: Some("W/m^2".to_string()),
-            },
-            FmiVariable {
-                name: self.variables.diffuse_horizontal_solar.clone(),
-                description: Some("Diffuse horizontal solar radiation".to_string()),
-                variability: FmiVariability::Continuous,
-                causality: FmiCausality::Input,
-                data_type: FmiDataType::Real,
-                start: Some(0.0),
-                min: Some(0.0),
-                max: Some(800.0),
-                unit: Some("W/m^2".to_string()),
-            },
-            FmiVariable {
-                name: self.variables.internal_gains.clone(),
-                description: Some("Total internal heat gains".to_string()),
-                variability: FmiVariability::Continuous,
-                causality: FmiCausality::Input,
-                data_type: FmiDataType::Real,
-                start: Some(0.0),
-                min: Some(0.0),
-                max: Some(10000.0),
-                unit: Some("W".to_string()),
-            },
-            FmiVariable {
-                name: self.variables.zone_temperature.clone(),
-                description: Some("Zone air temperature".to_string()),
-                variability: FmiVariability::Continuous,
-                causality: FmiCausality::Output,
-                data_type: FmiDataType::Real,
-                start: Some(293.15),
-                min: Some(200.0),
-                max: Some(320.0),
-                unit: Some("K".to_string()),
-            },
-            FmiVariable {
-                name: self.variables.heating_load.clone(),
-                description: Some("Heating load (positive)".to_string()),
-                variability: FmiVariability::Continuous,
-                causality: FmiCausality::Output,
-                data_type: FmiDataType::Real,
-                start: Some(0.0),
-                min: Some(0.0),
-                max: Some(100000.0),
-                unit: Some("W".to_string()),
-            },
-            FmiVariable {
-                name: self.variables.cooling_load.clone(),
-                description: Some("Cooling load (positive)".to_string()),
-                variability: FmiVariability::Continuous,
-                causality: FmiCausality::Output,
-                data_type: FmiDataType::Real,
-                start: Some(0.0),
-                min: Some(0.0),
-                max: Some(100000.0),
-                unit: Some("W".to_string()),
-            },
-        ]
+    /// Generate the variable list as a flat Vec for tests / inspection.
+    pub fn variable_names(&self) -> Vec<(String, String)> {
+        // (name, causality)
+        let mut out = Vec::with_capacity(self.total_variable_count());
+        for (zone_idx, zone) in self.zones.iter().enumerate() {
+            for input in self.variables.input_names() {
+                let prefixed = zone_variable_name(&self.variables, zone, zone_idx, input);
+                out.push((prefixed, "input".to_string()));
+            }
+            for output in self.variables.output_names() {
+                let prefixed = zone_variable_name(&self.variables, zone, zone_idx, output);
+                out.push((prefixed, "output".to_string()));
+            }
+        }
+        out
+    }
+
+    /// Convenience: read back the FMU's `modelDescription.xml` from
+    /// an exported ZIP, useful for tests / verification scripts.
+    pub fn read_model_description_from_fmu(path: &Path) -> Result<String, FmiError> {
+        let file = File::open(path)
+            .map_err(|e| FmiError::ExportFailed(format!("open FMU: {e}")))?;
+        let mut zip = zip::ZipArchive::new(file)
+            .map_err(|e| FmiError::ZipError(format!("read FMU: {e}")))?;
+        let mut entry = zip
+            .by_name("modelDescription.xml")
+            .map_err(|e| FmiError::ZipError(format!("missing modelDescription.xml: {e}")))?;
+        let mut buf = String::new();
+        std::io::Read::read_to_string(&mut entry, &mut buf)
+            .map_err(|e| FmiError::ExportFailed(format!("read entry: {e}")))?;
+        Ok(buf)
     }
 }
 
@@ -303,68 +623,173 @@ impl Default for FmiExporter {
     }
 }
 
-/// FMI Model Description structure.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct FmiModelDescription {
-    fmi_version: String,
-    model_name: String,
-    guid: String,
-    description: Option<String>,
-    version: String,
-    vendor: Option<String>,
-    variables: Vec<FmiVariable>,
-    default_experiment: Option<FmiDefaultExperiment>,
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+/// Per-zone variable name: for zone 0 (the legacy single-zone case)
+/// use the bare template name so existing FMUs stay name-compatible;
+/// for `zone_idx >= 1` prefix with `zone{N}_` to avoid name clashes.
+fn zone_variable_name(
+    variables: &FmiVariables,
+    zone: &ZoneVariables,
+    zone_idx: usize,
+    base: &str,
+) -> String {
+    if zone_idx == 0 {
+        // For the legacy single-zone case the template name is already
+        // the user-facing name; the zone's own `name` is informational
+        // only (`"zone"`).  This preserves the #1125 spike interface.
+        if zone.name == "zone" {
+            return variables.suffixed_name(base, 0);
+        }
+        return format!("{}_{}", sanitize_xml_name(&zone.name), base);
+    }
+    format!("{}_{}", sanitize_xml_name(&zone.name), base)
 }
 
-/// FMI Variable definition.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct FmiVariable {
-    name: String,
-    description: Option<String>,
-    variability: FmiVariability,
-    causality: FmiCausality,
-    data_type: FmiDataType,
-    start: Option<f64>,
-    min: Option<f64>,
-    max: Option<f64>,
-    unit: Option<String>,
+/// Strip characters that are illegal in FMI variable names.  FMI 2.0
+/// variables follow C identifier rules: `[A-Za-z_][A-Za-z0-9_]*`.
+fn sanitize_xml_name(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    for (i, ch) in name.chars().enumerate() {
+        let ok = if i == 0 {
+            ch.is_ascii_alphabetic() || ch == '_'
+        } else {
+            ch.is_ascii_alphanumeric() || ch == '_'
+        };
+        if ok {
+            out.push(ch);
+        } else {
+            out.push('_');
+        }
+    }
+    if out.is_empty() {
+        out.push('z');
+    }
+    out
 }
 
-/// FMI Variable variability.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-enum FmiVariability {
-    Constant,
-    Fixed,
-    Tunable,
-    Discrete,
-    Continuous,
+/// `(start, min, max, unit, description)` for an input variable template.
+fn input_meta(name: &str) -> (f64, f64, f64, &'static str, &'static str) {
+    match name {
+        "outdoor_temperature" => (280.0, 200.0, 320.0, "K", "Outdoor dry bulb temperature"),
+        "direct_normal_solar" => (0.0, 0.0, 1200.0, "W/m2", "Direct normal solar radiation"),
+        "diffuse_horizontal_solar" => {
+            (0.0, 0.0, 800.0, "W/m2", "Diffuse horizontal solar radiation")
+        }
+        "internal_gains" => (0.0, 0.0, 10000.0, "W", "Total internal heat gains"),
+        _ => (0.0, 0.0, 0.0, "", ""),
+    }
 }
 
-/// FMI Variable causality.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-enum FmiCausality {
-    Local,
-    Input,
-    Output,
-    Parameter,
-    Independent,
+/// `(start, min, max, unit, description)` for an output variable template.
+fn output_meta(name: &str) -> (f64, f64, f64, &'static str, &'static str) {
+    match name {
+        "zone_temperature" => (293.15, 200.0, 320.0, "K", "Zone air temperature"),
+        "heating_load" => (0.0, 0.0, 100000.0, "W", "Heating load (positive)"),
+        "cooling_load" => (0.0, 0.0, 100000.0, "W", "Cooling load (positive)"),
+        _ => (0.0, 0.0, 0.0, "", ""),
+    }
 }
 
-/// FMI data type.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-enum FmiDataType {
-    Real,
-    Integer,
-    Boolean,
-    String,
+#[allow(clippy::too_many_arguments)]
+fn write_real_variable<W: Write>(
+    writer: &mut Writer<W>,
+    name: &str,
+    description: &str,
+    causality: &str,
+    variability: &str,
+    start: f64,
+    min: f64,
+    max: f64,
+    unit: &str,
+    value_reference: u32,
+) -> Result<(), FmiError> {
+    let mut sv = BytesStart::new("ScalarVariable");
+    sv.push_attribute(("name", name));
+    sv.push_attribute((
+        "valueReference",
+        value_reference.to_string().as_str(),
+    ));
+    sv.push_attribute(("description", description));
+    sv.push_attribute(("causality", causality));
+    sv.push_attribute(("variability", variability));
+    writer
+        .write_event(Event::Start(sv))
+        .map_err(|e| FmiError::ExportFailed(format!("ScalarVariable {name}: {e}")))?;
+
+    let mut real = BytesStart::new("Real");
+    // declaredType is omitted unless a TypeDefinitions/SimpleType is referenced.
+    real.push_attribute(("quantity", ""));
+    real.push_attribute(("unit", unit));
+    real.push_attribute(("displayUnit", ""));
+    real.push_attribute(("relativeQuantity", "false"));
+    real.push_attribute(("min", format_float(min).as_str()));
+    real.push_attribute(("max", format_float(max).as_str()));
+    real.push_attribute(("nominal", "0.0"));
+    real.push_attribute(("unbounded", "false"));
+    real.push_attribute(("start", format_float(start).as_str()));
+    real.push_attribute(("reinit", "false"));
+
+    writer
+        .write_event(Event::Empty(real))
+        .map_err(|e| FmiError::ExportFailed(format!("Real {name}: {e}")))?;
+
+    writer
+        .write_event(Event::End(BytesEnd::new("ScalarVariable")))
+        .map_err(|e| FmiError::ExportFailed(format!("ScalarVariable end {name}: {e}")))?;
+    Ok(())
 }
 
-/// FMI default experiment settings.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct FmiDefaultExperiment {
-    start_time: Option<f64>,
-    stop_time: Option<f64>,
-    communication_timestep: Option<f64>,
+/// FMI 2.0 attribute defaults are strings; format f64 compactly.
+fn format_float(v: f64) -> String {
+    if v == v.trunc() && v.abs() < 1.0e15 {
+        format!("{:.1}", v)
+    } else {
+        format!("{}", v)
+    }
+}
+
+/// ISO 8601 UTC timestamp for `generationDateAndTime`.
+fn generation_timestamp() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    // Convert epoch seconds to UTC calendar date without pulling in
+    // `chrono` (which is already in Cargo.toml as a dependency but
+    // avoiding it here keeps this helper dependency-light).
+    let days = secs.div_euclid(86_400);
+    let secs_of_day = secs.rem_euclid(86_400);
+    let (h, m, s) = (
+        secs_of_day / 3600,
+        (secs_of_day % 3600) / 60,
+        secs_of_day % 60,
+    );
+    let (y, mo, d) = days_to_ymd(days);
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        y, mo, d, h, m, s
+    )
+}
+
+/// Convert days-since-epoch to (year, month, day).  Uses the
+/// proleptic Gregorian calendar; accurate enough for a `generationDateAndTime`.
+fn days_to_ymd(days_since_epoch: i64) -> (i32, u32, u32) {
+    // Algorithm by Howard Hinnant (public domain).
+    let z = days_since_epoch + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u32; // [0, 146096]
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365; // [0, 399]
+    let y = (yoe as i32) + (era as i32) * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * doy + 2) / 153; // [0, 11]
+    let d = doy - (153 * mp + 2) / 5 + 1; // [1, 31]
+    let m = if mp < 10 { mp + 3 } else { mp - 9 }; // [1, 12]
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
 }
 
 #[cfg(test)]
@@ -383,6 +808,7 @@ mod tests {
     fn test_fmi_exporter_new() {
         let exporter = FmiExporter::new();
         assert_eq!(exporter.config().model_name, "FluxionBuilding");
+        assert_eq!(exporter.zone_count(), 1);
     }
 
     #[test]
@@ -414,6 +840,7 @@ mod tests {
         let vars = FmiVariables::default();
         assert_eq!(vars.outdoor_temperature, "outdoor_temperature");
         assert_eq!(vars.zone_temperature, "zone_temperature");
+        assert_eq!(FmiVariables::PER_ZONE_VARIABLE_COUNT, 7);
     }
 
     #[test]
@@ -426,5 +853,250 @@ mod tests {
     fn test_fmi_error_display() {
         let err = FmiError::ExportFailed("test error".to_string());
         assert_eq!(format!("{}", err), "FMU export failed: test error");
+    }
+
+    // -------------------------------------------------------------------------
+    // Multi-zone extension tests (#1339)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_multi_zone_default_single_zone() {
+        let exporter = FmiExporter::new();
+        assert_eq!(exporter.zone_count(), 1);
+        assert_eq!(exporter.total_variable_count(), 7);
+    }
+
+    #[test]
+    fn test_multi_zone_three_zones_count() {
+        let exporter = FmiExporter::new().with_zones(vec![
+            ZoneVariables::new("living"),
+            ZoneVariables::new("bedroom"),
+            ZoneVariables::new("kitchen"),
+        ]);
+        assert_eq!(exporter.zone_count(), 3);
+        assert_eq!(exporter.total_variable_count(), 7 * 3);
+    }
+
+    #[test]
+    #[should_panic(expected = "at least one zone is required")]
+    fn test_multi_zone_empty_zones_panics() {
+        let _ = FmiExporter::new().with_zones(vec![]);
+    }
+
+    #[test]
+    fn test_multi_zone_variable_names() {
+        let exporter = FmiExporter::new().with_zones(vec![
+            ZoneVariables::new("zone"), // legacy single-zone shape
+            ZoneVariables::new("bedroom"),
+            ZoneVariables::new("kitchen"),
+        ]);
+        let vars = exporter.variable_names();
+        // 3 zones × 7 vars = 21 entries
+        assert_eq!(vars.len(), 21);
+
+        // Zone 0 (legacy) keeps the bare template names (#1125 compatibility).
+        let zone0_inputs: Vec<_> = vars
+            .iter()
+            .take(4)
+            .map(|(n, c)| (n.clone(), c.clone()))
+            .collect();
+        assert_eq!(zone0_inputs[0].0, "outdoor_temperature");
+        assert_eq!(zone0_inputs[0].1, "input");
+
+        // Zone 1 ("bedroom") uses the `bedroom_` prefix.
+        let zone1_inputs: Vec<_> = vars.iter().skip(7).take(4).collect();
+        assert_eq!(zone1_inputs[0].0, "bedroom_outdoor_temperature");
+        assert_eq!(zone1_inputs[0].1, "input");
+        assert_eq!(zone1_inputs[3].0, "bedroom_internal_gains");
+
+        // Zone 2 ("kitchen") uses the `kitchen_` prefix.
+        let zone2_outputs: Vec<_> = vars.iter().skip(14).skip(4).collect();
+        assert_eq!(zone2_outputs[0].0, "kitchen_zone_temperature");
+        assert_eq!(zone2_outputs[0].1, "output");
+    }
+
+    #[test]
+    fn test_multi_zone_xml_generation_n3() {
+        let exporter = FmiExporter::new()
+            .with_zones(vec![
+                ZoneVariables::new("zone"),
+                ZoneVariables::new("bedroom"),
+                ZoneVariables::new("kitchen"),
+            ]);
+        let xml = exporter.generate_model_description_xml().unwrap();
+
+        // FMI 2.0 root
+        assert!(
+            xml.contains("fmiVersion=\"2.0\""),
+            "missing fmiVersion: {}",
+            xml
+        );
+        assert!(
+            xml.contains("<fmiModelDescription"),
+            "missing fmiModelDescription root: {}",
+            xml
+        );
+        assert!(
+            xml.contains("<CoSimulation"),
+            "missing CoSimulation element: {}",
+            xml
+        );
+        assert!(
+            xml.contains("<DefaultExperiment"),
+            "missing DefaultExperiment: {}",
+            xml
+        );
+        // 21 ScalarVariables total (3 × 7)
+        let sv_count = xml.matches("<ScalarVariable ").count();
+        assert_eq!(
+            sv_count, 21,
+            "expected 21 ScalarVariables for 3 zones, got {}",
+            sv_count
+        );
+        // 21 Real children
+        let real_count = xml.matches("<Real ").count();
+        assert_eq!(
+            real_count, 21,
+            "expected 21 Real attributes, got {}",
+            real_count
+        );
+    }
+
+    #[test]
+    fn test_configurable_timestep_default_3600s() {
+        let exporter = FmiExporter::new();
+        let xml = exporter.generate_model_description_xml().unwrap();
+        assert!(
+            xml.contains("stepSize=\"3600.0\""),
+            "default stepSize missing: {}",
+            xml
+        );
+    }
+
+    #[test]
+    fn test_configurable_timestep_60s() {
+        let mut cfg = FmiConfig::default();
+        cfg.communication_timestep = 60.0;
+        let exporter = FmiExporter::with_config(cfg).unwrap();
+        let xml = exporter.generate_model_description_xml().unwrap();
+        assert!(
+            xml.contains("stepSize=\"60.0\""),
+            "60s stepSize missing: {}",
+            xml
+        );
+    }
+
+    #[test]
+    fn test_configurable_timestep_300s() {
+        let mut cfg = FmiConfig::default();
+        cfg.communication_timestep = 300.0;
+        let exporter = FmiExporter::with_config(cfg).unwrap();
+        let xml = exporter.generate_model_description_xml().unwrap();
+        assert!(xml.contains("stepSize=\"300.0\""));
+    }
+
+    #[test]
+    fn test_configurable_timestep_600s() {
+        let mut cfg = FmiConfig::default();
+        cfg.communication_timestep = 600.0;
+        let exporter = FmiExporter::with_config(cfg).unwrap();
+        let xml = exporter.generate_model_description_xml().unwrap();
+        assert!(xml.contains("stepSize=\"600.0\""));
+    }
+
+    #[test]
+    fn test_export_fmu_writes_valid_zip() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let out = tmp.path().join("multi_zone.fmu");
+        let exporter = FmiExporter::new().with_zones(vec![
+            ZoneVariables::new("zone"),
+            ZoneVariables::new("bedroom"),
+            ZoneVariables::new("kitchen"),
+        ]);
+        exporter.export_fmu(&out).expect("export_fmu");
+
+        // Round-trip: open the FMU and read modelDescription.xml back out.
+        let xml = FmiExporter::read_model_description_from_fmu(&out).expect("read FMU");
+        assert!(xml.contains("<fmiModelDescription"));
+        assert!(xml.contains("fmiVersion=\"2.0\""));
+        let sv_count = xml.matches("<ScalarVariable ").count();
+        assert_eq!(sv_count, 21);
+    }
+
+    #[test]
+    fn test_xml_contains_required_attributes() {
+        let exporter = FmiExporter::new();
+        let xml = exporter.generate_model_description_xml().unwrap();
+
+        // Required per FMI 2.0 spec §3
+        for needle in &[
+            "fmiVersion=\"2.0\"",
+            "modelName=\"FluxionBuilding\"",
+            "guid=\"{8c4e8d3a-2b1f-4a6c-9e5f-0d3b2a4c6e8d}\"",
+            "<CoSimulation",
+            "needsExecutionTool=\"true\"",
+            "canHandleVariableCommunicationStepSize=\"true\"",
+            "<DefaultExperiment",
+            "<ModelVariables>",
+            "<ScalarVariable name=\"outdoor_temperature\"",
+            "<ScalarVariable name=\"zone_temperature\"",
+            "causality=\"input\"",
+            "causality=\"output\"",
+        ] {
+            assert!(
+                xml.contains(needle),
+                "missing required FMI 2.0 attribute/element `{}` in:\n{}",
+                needle,
+                xml
+            );
+        }
+    }
+
+    #[test]
+    fn test_variable_names_input_output_split() {
+        let exporter = FmiExporter::new();
+        let names = exporter.variable_names();
+        let inputs: Vec<_> = names.iter().filter(|(_, c)| c == "input").collect();
+        let outputs: Vec<_> = names.iter().filter(|(_, c)| c == "output").collect();
+        // Single-zone: 4 inputs, 3 outputs
+        assert_eq!(inputs.len(), 4);
+        assert_eq!(outputs.len(), 3);
+    }
+
+    #[test]
+    fn test_zone_variables_default() {
+        let z = ZoneVariables::default();
+        assert_eq!(z.name, "zone");
+        let z2 = ZoneVariables::new("kitchen");
+        assert_eq!(z2.name, "kitchen");
+    }
+
+    #[test]
+    fn test_sanitize_xml_name() {
+        assert_eq!(sanitize_xml_name("kitchen"), "kitchen");
+        assert_eq!(sanitize_xml_name("living room"), "living_room");
+        // First char digit → '_', '-' → '_' (FMI names must match C identifiers).
+        assert_eq!(sanitize_xml_name("3rd-floor"), "_rd_floor");
+        assert_eq!(sanitize_xml_name(""), "z"); // empty fallback
+    }
+
+    #[test]
+    fn test_format_float() {
+        assert_eq!(format_float(3600.0), "3600.0");
+        assert_eq!(format_float(0.0), "0.0");
+        assert_eq!(format_float(60.0), "60.0");
+        assert_eq!(format_float(1.5e-3), "0.0015");
+    }
+
+    #[test]
+    fn test_days_to_ymd_known_dates() {
+        // 1970-01-01 (epoch)
+        assert_eq!(days_to_ymd(0), (1970, 1, 1));
+        // 2000-01-01
+        assert_eq!(days_to_ymd(10_957), (2000, 1, 1));
+        // 2024-02-29 (leap year)
+        assert_eq!(days_to_ymd(19_782), (2024, 2, 29));
+        // 2026-06-27 (today, just before write-time)
+        assert_eq!(days_to_ymd(20_631), (2026, 6, 27));
     }
 }

--- a/src/interop/mod.rs
+++ b/src/interop/mod.rs
@@ -3,44 +3,51 @@
 
 //! FMI (Functional Mock-up Interface) interoperability for Fluxion.
 //!
-//! This module provides FMI export and co-simulation capabilities for
+//! This module provides FMI 2.0 Co-Simulation export capabilities for
 //! the Fluxion building energy modeling engine.
 //!
 //! # Scope
 //!
-//! This is a constrained initial implementation (IO-01 spike) with the
-//! following known limitations:
+//! The current implementation generates valid FMI 2.0 `.fmu` archives
+//! for single- or multi-zone thermal networks.
 //!
 //! ## Export Mode (Fluxion → FMU)
-//! - Single-zone thermal network only
-//! - Fixed timestep (3600s = 1 hour)
-//! - Outputs: zone temperature, heating/cooling load
-//! - Inputs: outdoor temperature, solar gains, internal gains
+//! - **Multi-zone** support — per-zone (outdoor temperature, solar gains,
+//!   internal gains) inputs and (zone temperature, heating/cooling load)
+//!   outputs.  N zones => 7 × N ScalarVariables (#1339).
+//! - **Configurable communication timestep** — set on `FmiConfig`
+//!   (default 3600 s; accepts 60 / 300 / 600 / 3600 s).
+//! - **Standalone Co-Simulation FMU** — declared with
+//!   `needsExecutionTool="true"` so the master drives the simulation.
 //!
-//! ## Co-Simulation Mode
-//! - Master algorithm: first-order Euler
-//! - Communication timestep: 1 hour
-//! - Requires external FMU for weather data or controls
+//! ## Known limitations
+//! - **FMI 3.0** features (Hybrid Co-Simulation, terminals) are not
+//!   implemented — out of scope until upstream tooling stabilizes.
+//! - **FMU import** (`FmiMode::Import`) is reserved for a future issue.
 //!
 //! # FMI Standard
 //!
-//! Implements FMI 2.0 for Co-Simulation (export) and Model Exchange (import).
-//! See: https://fmi-standard.org/
+//! Implements FMI 2.0 for Co-Simulation (export).  See
+//! <https://fmi-standard.org/>.
 //!
 //! # Example
 //!
 //! ```ignore
-//! use fluxion::interop::fmi::{FmiExporter, FmiConfig};
+//! use fluxion::interop::fmi::{FmiExporter, FmiConfig, ZoneVariables};
 //!
-//! let config = FmiConfig::default();
-//! let exporter = FmiExporter::new(config);
-//! exporter.export_fmu("fluxion_building.fmu")?;
+//! let exporter = FmiExporter::new()
+//!     .with_zones(vec![
+//!         ZoneVariables::new("zone"),
+//!         ZoneVariables::new("bedroom"),
+//!         ZoneVariables::new("kitchen"),
+//!     ]);
+//! exporter.export_fmu("fluxion_three_zone.fmu")?;
 //! ```
 
 pub mod fmi;
 pub mod gbxml;
 pub mod osm;
 
-pub use fmi::{FmiConfig, FmiExporter, FmiMode};
+pub use fmi::{FmiConfig, FmiExporter, FmiMode, ZoneVariables};
 pub use gbxml::{export_gbxml, import_gbxml, GbXmlError, GbXmlReader, GbXmlWriter};
 pub use osm::{export_osm, import_osm, OsmError, OsmReader, OsmWriter};


### PR DESCRIPTION
fixes #1339

## Summary
Replaces the JSON-shaped single-zone spike (#1125) with a real FMI 2.0 Co-Simulation
modelDescription.xml generator + FMU archive (ZIP). The new API supports **N zones**
(N x 7 ScalarVariables), **configurable communication timestep** (60 / 300 / 600 /
3600 s, default 3600 preserved), and emits XML that validates against the official
FMI 2.0 XSD set.

## Per-zone inputs design
- `FmiExporter::with_zones(Vec<ZoneVariables>)` builder.
- Zone 0 keeps the legacy bare template names (`outdoor_temperature`, etc.) for
  #1125 backward compatibility; zones >= 1 are prefixed with `{zone}_`.
- Per zone: 4 inputs (`outdoor_temperature`, `direct_normal_solar`,
  `diffuse_horizontal_solar`, `internal_gains`) + 3 outputs (`zone_temperature`,
  `heating_load`, `cooling_load`) = 7 ScalarVariables per zone.
- Every `ScalarVariable` carries a unique 1-based `valueReference` (FMI 2.0 §3
  requirement).

## Timestep parameter
- `FmiConfig.communication_timestep` is forwarded verbatim to
  `<DefaultExperiment stepSize="...">` and to `<CoSimulation>` capability flags.
- Positive-value validation is preserved (line 153 in `src/interop/fmi/mod.rs`).
- Tests cover 60 s / 300 s / 600 s / 3600 s explicitly.

## FMU validation
- New verification script: `.agents/results/issue-D1-multi-zone-fmi-verification.py`.
  Builds a 3-zone FMU end-to-end, extracts the modelDescription.xml, and validates
  against `fmi2ModelDescription.xsd` (downloaded on demand from
  `modelica/fmi-standard@1324a73`). The script also tries PyFMI/FMPy if installed
  locally.
- Acceptance criteria checked:
  - 21 ScalarVariables (7 x 3) with 12 inputs + 9 outputs
  - 1..21 unique valueReferences
  - `<CoSimulation needsExecutionTool="true">` + variable-step flag
  - `<DefaultExperiment stepSize="3600.0">` (default preserved)
  - `<ModelStructure><Outputs>...</Outputs></ModelStructure>` enumerates every
    output variable
  - lxml `XMLSchema` reports zero errors

## Files

- **modified** `Cargo.toml` / `Cargo.lock` — add `zip = "0.6"` for FMU packaging
- **modified** `src/interop/fmi/mod.rs` — multi-zone API, real FMI 2.0 XML, ZIP
  packaging, 14 new unit tests (24/24 pass)
- **modified** `src/interop/mod.rs` — update stale "single-zone" / "fixed timestep"
  module docs, re-export `ZoneVariables`
- **modified** `docs/FMI.md` — full multi-zone usage example, validation recipe,
  scope + out-of-scope list
- **added** `.agents/results/issue-D1-multi-zone-fmi-verification.py` —
  end-to-end FMU build + XSD validation harness
- **modified** `.gitignore` — ignore transient FMI 2.0 XSD cache

## Out of scope (per #1339)

- `FmiMode::Import` (FMU import) — separate follow-up
- FMI 3.0 (Hybrid Co-Simulation, terminals) — wait for upstream tooling
- HVAC equipment objects — vertical E
- Physics fixes post-#1323 — vertical C

## Verification

```
cargo test --features ort --lib interop::fmi::   # 24 passed
cargo test --features ort --test integration-fmi-cosimulation   # 4 passed
cargo clippy --lib --features ort -- -D warnings   # clean
cargo build --release --features ort             # clean
python .agents/results/issue-D1-multi-zone-fmi-verification.py   # PASS
```

Refs: #1125 (single-zone spike), #1339, ARCHITECTURE.md §interop.