### PR TITLE
test(#1340): add OSM writer→reader round-trip parity test

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -461,7 +461,7 @@ Import/export bridges live under `src/interop/`. Each is gated behind the module
 
 | Module | Path | Status | Notes |
 |--------|------|--------|-------|
-| OpenStudio OSM | `interop/osm/` | Implemented (#1130) | Reader (884 LoC) + Writer (505 LoC) + types; `import_osm` / `export_osm` |
+| OpenStudio OSM | `interop/osm/` | Implemented + round-trip stable (#1130, #1340) | Reader (884 LoC) + Writer (505 LoC) + types; `import_osm` / `export_osm`. Writer→reader round-trip is **stable** for single- and multi-zone schemas within the supported subset — see `src/interop/osm/mod.rs` for the lossless-field list and round-trip test entry points. |
 | gbXML | `interop/gbxml/` | Implemented (#1126) | Reader + Writer + types; `import_gbxml` / `export_gbxml`; BIM integration |
 | FMI Co-Simulation | `interop/fmi/` | Implemented — spike (#1125) | FMU export, single-zone, fixed 1h timestep; `FmiExporter`, `FmiConfig` |
 | EnergyPlus IDF/epJSON | `docs/idf-import-design.md` | **Scaffold landed** (#1341) | `src/io/idf/` (lexer + parser for the 10 MVP objects from design §4.1); `IdfFile` → `SimulationSchema` conversion pending (design §4.3 follow-up) |
@@ -470,9 +470,49 @@ Import/export bridges live under `src/interop/`. Each is gated behind the module
 ### Language Bindings
 
 | Binding | Path | Feature Flag | Status |
-|---------|------|--------------|--------|
+|---------|------|--------------|
 | Python (PyO3) | `src/python/` | `python-bindings` | Implemented (#1123); multi-zone + HVAC bindings |
 | Node.js (NAPI) | `src/napi/` | `napi-bindings` | Implemented; coexists with Python bindings |
+
+### OSM Round-Trip Lossless Contract (issue #1340)
+
+The OSM writer→reader round-trip is **stable** for single- and multi-zone schemas within the supported subset. Tests live in `src/interop/osm/writer.rs::tests`:
+
+- `test_roundtrip_single_zone` — 1 zone, default `ConstructionSet`
+- `test_roundtrip_two_zones` — 2 zones, mixed floor areas
+- `test_roundtrip_four_zones` — 4 zones (upper end of supported subset)
+- `test_roundtrip_no_windows` — edge case: zone with 0 windows, 1 floor, 4 walls
+- `test_roundtrip_exhaustive_diff_report` — asserts every supported field matches; emits a per-field diff on failure
+
+**Lossless fields** (f64 comparison within `1e-6` absolute or relative tolerance):
+
+| Field | OSM path |
+|-------|----------|
+| `metadata.name` | `OS:Building.Name` |
+| `geometry.zones[*].name` | `OS:ThermalZone.Name` |
+| `geometry.zones[*].floor_area` | `OS:Space.Floor Area` |
+| `geometry.zones[*].volume` | `OS:Space.Volume` |
+| `geometry.zones[*].height` | derived from `volume / floor_area` |
+| `geometry.total_floor_area` | sum of zone values |
+| `geometry.total_volume` | sum of zone values |
+| `geometry.number_of_floors` | `OS:Building.Number of Floors` |
+| `geometry.floor_height` | derived from `total_volume / total_floor_area` |
+| `constructions.{wall,roof,floor}.layers[*].name` | `OS:Material.Name` (referenced by `OS:Construction.Layer N`) |
+| `constructions.{wall,roof,floor}.layers[*].thickness` | `OS:Material.Thickness` |
+| `constructions.{wall,roof,floor}.layers[*].conductivity` | `OS:Material.Conductivity` |
+| `constructions.{wall,roof,floor}.layers[*].density` | `OS:Material.Density` |
+| `constructions.{wall,roof,floor}.layers[*].specific_heat` | `OS:Material.Specific Heat` |
+| `weather` (`TmyLocation` variant only) | `OS:Site.Latitude`, `OS:Site.Longitude` (lat/lon f64 pair, within tolerance) |
+
+**Known lossy fields** (fall back to `Default` on read; out of scope for issue #1340):
+
+- `metadata.description`, `.author`, `.created_at`
+- `schedules.*` (no `OS:Schedule:*` emission)
+- `controls.{heating,cooling}_setpoint` (no `OS:Thermostat` emission; reader falls back to 20 °C / 24 °C)
+- `constructions.{wall,roof,floor}.window` (no `OS:SubSurface` emission)
+- `constructions.interzone`
+- `weather` for `EpwFile` and `Inline` variants
+- `output.*` (simulation results, not part of model file)
 
 ---
 

--- a/src/interop/osm/mod.rs
+++ b/src/interop/osm/mod.rs
@@ -20,6 +20,44 @@
 //! ## Export (Fluxion -> OSM)
 //! - Serialize fluxion model back to OSM for round-trip or hand-off to OpenStudio Measures
 //!
+//! # Round-Trip Stability (issue #1340)
+//!
+//! Writer→reader round-trip is **stable** for single- and multi-zone schemas
+//! within the supported subset. Tests live in
+//! `src/interop/osm/writer.rs::tests` (`test_roundtrip_single_zone`,
+//! `test_roundtrip_two_zones`, `test_roundtrip_four_zones`,
+//! `test_roundtrip_no_windows`, `test_roundtrip_exhaustive_diff_report`).
+//!
+//! ## Lossless fields
+//!
+//! The following `SimulationSchemaV1` fields round-trip byte-equivalent
+//! field-wise (f64 comparisons within `1e-6` absolute or relative tolerance):
+//!
+//! - `metadata.name` (via `OS:Building.Name`)
+//! - `geometry.zones[*].name`, `.floor_area`, `.volume`, `.height`
+//!   (via `OS:ThermalZone.Name` and `OS:Space.Floor Area` / `Volume`)
+//! - `geometry.total_floor_area`, `.total_volume` (sum of zone values)
+//! - `geometry.number_of_floors` (via `OS:Building.Number of Floors`)
+//! - `geometry.floor_height` (computed from `total_volume / total_floor_area`)
+//! - `constructions.{wall,roof,floor}.layers[*]`
+//!   (`.name`, `.thickness`, `.conductivity`, `.density`, `.specific_heat`)
+//! - `weather` for the `TmyLocation` variant (lat/lon pair, within tolerance)
+//!
+//! ## Known lossy fields
+//!
+//! The following fields are NOT guaranteed to round-trip; they fall back to
+//! `Default` during read:
+//!
+//! - `metadata.description`, `.author`, `.created_at`
+//! - `schedules.*` (writer does not yet emit `OS:Schedule:*`)
+//! - `controls.{heating,cooling}_setpoint` (no `OS:Thermostat` emission;
+//!   reader falls back to 20 °C / 24 °C)
+//! - `constructions.{wall,roof,floor}.window`
+//!   (no `OS:SubSurface` emission in the supported subset)
+//! - `constructions.interzone` (not emitted)
+//! - `weather` for the `EpwFile` and `Inline` variants
+//! - `output.*` (simulation results, not part of model file)
+//!
 //! # OSM Format
 //!
 //! OSM files use a line-oriented key-value format similar to IDF but with

--- a/src/interop/osm/reader.rs
+++ b/src/interop/osm/reader.rs
@@ -107,7 +107,30 @@ impl OsmReader {
                 continue;
             }
 
+            // An object terminator in OpenStudio IDD is either:
+            //   1) a line containing only ";"
+            //   2) the last field of an object whose source line contains ";"
+            //      before the trailing ", !- <comment>" annotation, e.g.
+            //      "  2.7; !- Floor Height {m}" — the writer emits `;`
+            //      on the same line as the last value to terminate the object.
+            //
+            // Both forms must be recognized here; otherwise parse_object would
+            // bleed into the next object. (Fix for issue #1340 round-trip.)
+            let line_has_terminator = line.contains(';') || line == ";";
+
             if line == ";" {
+                break;
+            }
+
+            // If a line begins with "OS:" / "OSM:" it is the start of the next
+            // object; the current object is complete. (This guard is needed
+            // because the writer sometimes omits the explicit `;` terminator
+            // line; we still need to stop cleanly.)
+            if line.starts_with("OS:") || line.starts_with("OSM:") {
+                // Step back so the outer loop picks up this line as a new object.
+                if *idx > 0 {
+                    *idx -= 1;
+                }
                 break;
             }
 
@@ -119,8 +142,14 @@ impl OsmReader {
 
             let field_value = self.extract_field_value(line, field_idx)?;
             let field_name = self.get_field_name(&object_type, field_idx);
-            obj.fields.insert(field_name.to_string(), field_value);
+            obj.fields.insert(field_name, field_value);
             field_idx += 1;
+
+            // After consuming a field whose source line carried the
+            // terminating ";" (case 2 above), the object is done.
+            if line_has_terminator {
+                break;
+            }
         }
 
         Ok(obj)
@@ -144,137 +173,157 @@ impl OsmReader {
     }
 
     fn extract_field_value(&self, line: &str, _field_idx: usize) -> Result<String, OsmError> {
+        // Strip the trailing comment of the form ", !- <comment>" (OpenStudio
+        // IDD field annotation). Example input: "  Test Building, !- Name"
+        // produces value "Test Building".
         let line = line.trim_end_matches(',').trim();
 
-        if line.ends_with(';') {
-            let value = line.strip_suffix(';').unwrap();
-            return Ok(value.trim().to_string());
-        }
+        // Strip trailing semicolon first (last field of an object ends with
+        // "<value>;" e.g. "  2.7; !- Floor Height {m}" -> "2.7").
+        let line = if let Some(idx) = line.rfind(';') {
+            &line[..idx]
+        } else {
+            line
+        };
 
-        Ok(line.to_string())
+        // Now strip the ", !- <comment>" suffix if present. Some fields have
+        // empty values written as just ",", which would have been collapsed
+        // by trim_end_matches(',') above; that's fine, we want empty.
+        if let Some(idx) = line.find(", !-") {
+            Ok(line[..idx].trim().to_string())
+        } else {
+            // No trailing comma-comment; could be a numeric-only value or a
+            // bare string without the comment. Just trim and return.
+            Ok(line.trim().to_string())
+        }
     }
 
-    fn get_field_name(&self, object_type: &str, field_idx: usize) -> &'static str {
+    fn get_field_name(&self, object_type: &str, field_idx: usize) -> String {
         match object_type {
             "OS:Material" => match field_idx {
-                0 => "handle",
-                1 => "name",
-                2 => "roughness",
-                3 => "thickness",
-                4 => "conductivity",
-                5 => "density",
-                6 => "specific_heat",
-                7 => "emissivity",
-                8 => "vapor_transmission",
-                _ => "extra",
+                0 => "handle".to_string(),
+                1 => "name".to_string(),
+                2 => "roughness".to_string(),
+                3 => "thickness".to_string(),
+                4 => "conductivity".to_string(),
+                5 => "density".to_string(),
+                6 => "specific_heat".to_string(),
+                7 => "emissivity".to_string(),
+                8 => "vapor_transmission".to_string(),
+                _ => "extra".to_string(),
             },
             "OS:Construction" => match field_idx {
-                0 => "handle",
-                1 => "name",
-                _ => "layer",
+                0 => "handle".to_string(),
+                1 => "name".to_string(),
+                // Layers (Layer N, Outside Layer, Inside Layer) — give each
+                // a distinct storage key so we don't lose any to HashMap
+                // overwrites. Issue #1340 round-trip.
+                n => format!("layer_{}", n - 2),
             },
             "OS:BuildingStory" => match field_idx {
-                0 => "handle",
-                1 => "name",
-                2 => "level",
-                3 => "height",
-                _ => "extra",
+                0 => "handle".to_string(),
+                1 => "name".to_string(),
+                2 => "level".to_string(),
+                3 => "height".to_string(),
+                _ => "extra".to_string(),
             },
             "OS:Space" => match field_idx {
-                0 => "handle",
-                1 => "name",
-                2 => "zone_handle",
-                3 => "building_story_handle",
-                4 => "x_origin",
-                5 => "y_origin",
-                6 => "z_origin",
-                _ => "extra",
+                0 => "handle".to_string(),
+                1 => "name".to_string(),
+                2 => "zone_handle".to_string(),
+                3 => "building_story_handle".to_string(),
+                4 => "floor_area".to_string(),
+                5 => "volume".to_string(),
+                6 => "x_origin".to_string(),
+                7 => "y_origin".to_string(),
+                8 => "z_origin".to_string(),
+                _ => "extra".to_string(),
             },
             "OS:Surface" => match field_idx {
-                0 => "handle",
-                1 => "name",
-                2 => "surface_type",
-                3 => "construction_handle",
-                4 => "building_boundary",
-                5 => "outside_boundary_condition",
-                6 => "sun_exposure",
-                7 => "wind_exposure",
-                _ => "extra",
+                0 => "handle".to_string(),
+                1 => "name".to_string(),
+                2 => "surface_type".to_string(),
+                3 => "construction_handle".to_string(),
+                4 => "building_boundary".to_string(),
+                5 => "outside_boundary_condition".to_string(),
+                6 => "sun_exposure".to_string(),
+                7 => "wind_exposure".to_string(),
+                _ => "extra".to_string(),
             },
             "OS:SubSurface" => match field_idx {
-                0 => "handle",
-                1 => "name",
-                2 => "surface_handle",
-                3 => "construction_handle",
-                4 => "window_type",
-                _ => "extra",
+                0 => "handle".to_string(),
+                1 => "name".to_string(),
+                2 => "surface_handle".to_string(),
+                3 => "construction_handle".to_string(),
+                4 => "window_type".to_string(),
+                _ => "extra".to_string(),
             },
             "OS:ThermalZone" => match field_idx {
-                0 => "handle",
-                1 => "name",
-                2 => "thermostat_handle",
-                3 => "multiplier",
-                _ => "extra",
+                0 => "handle".to_string(),
+                1 => "name".to_string(),
+                2 => "thermostat_handle".to_string(),
+                3 => "multiplier".to_string(),
+                _ => "extra".to_string(),
             },
             "OS:Site" => match field_idx {
-                0 => "handle",
-                1 => "name",
-                2 => "latitude",
-                3 => "longitude",
-                4 => "elevation",
-                5 => "time_zone",
-                _ => "extra",
+                0 => "handle".to_string(),
+                1 => "name".to_string(),
+                2 => "latitude".to_string(),
+                3 => "longitude".to_string(),
+                4 => "elevation".to_string(),
+                5 => "time_zone".to_string(),
+                _ => "extra".to_string(),
             },
             "OS:Building" => match field_idx {
-                0 => "handle",
-                1 => "name",
-                2 => "building_story_handles",
-                3 => "zone_handles",
-                4 => "area",
-                5 => "number_of_floors",
-                6 => "floor_height",
-                _ => "extra",
+                0 => "handle".to_string(),
+                1 => "name".to_string(),
+                2 => "building_story_handles".to_string(),
+                3 => "zone_handles".to_string(),
+                4 => "area".to_string(),
+                5 => "number_of_floors".to_string(),
+                6 => "floor_height".to_string(),
+                _ => "extra".to_string(),
             },
             "OS:Thermostat" => match field_idx {
-                0 => "handle",
-                1 => "name",
-                2 => "heating_setpoint",
-                3 => "cooling_setpoint",
-                _ => "extra",
+                0 => "handle".to_string(),
+                1 => "name".to_string(),
+                2 => "heating_setpoint".to_string(),
+                3 => "cooling_setpoint".to_string(),
+                _ => "extra".to_string(),
             },
             "OS:Lights" => match field_idx {
-                0 => "handle",
-                1 => "name",
-                2 => "zone_handle",
-                3 => "design_level",
-                _ => "extra",
+                0 => "handle".to_string(),
+                1 => "name".to_string(),
+                2 => "zone_handle".to_string(),
+                3 => "design_level".to_string(),
+                _ => "extra".to_string(),
             },
             "OS:ElectricEquipment" => match field_idx {
-                0 => "handle",
-                1 => "name",
-                2 => "zone_handle",
-                3 => "design_level",
-                _ => "extra",
+                0 => "handle".to_string(),
+                1 => "name".to_string(),
+                2 => "zone_handle".to_string(),
+                3 => "design_level".to_string(),
+                _ => "extra".to_string(),
             },
             "OS:People" => match field_idx {
-                0 => "handle",
-                1 => "name",
-                2 => "zone_handle",
-                3 => "number_of_people",
-                _ => "extra",
+                0 => "handle".to_string(),
+                1 => "name".to_string(),
+                2 => "zone_handle".to_string(),
+                3 => "number_of_people".to_string(),
+                _ => "extra".to_string(),
             },
             "OS:Schedule:Constant" => match field_idx {
-                0 => "handle",
-                1 => "name",
-                2 => "schedule_type",
-                3 => "value",
-                _ => "extra",
+                0 => "handle".to_string(),
+                1 => "name".to_string(),
+                2 => "schedule_type".to_string(),
+                3 => "value".to_string(),
+                _ => "extra".to_string(),
             },
             "OS:Version" => match field_idx {
-                0 => "version_identifier",
-                _ => "extra",
+                0 => "version_identifier".to_string(),
+                _ => "extra".to_string(),
             },
-            _ => "field",
+            _ => "field".to_string(),
         }
     }
 
@@ -382,24 +431,40 @@ impl OsmReader {
     }
 
     fn parse_construction(&self, obj: &OsmObject) -> Construction {
-        let mut layer_handles = Vec::new();
+        let mut indexed_layers: Vec<(usize, String)> = Vec::new();
+        let mut outside_layer: Option<String> = None;
+        let mut inside_layer: Option<String> = None;
+
         for (key, val) in &obj.fields {
-            if key.starts_with("layer")
-                || key == "outside_layer"
-                || key == "inside_layer" && !val.is_empty() && val != "OS:Material"
-            {
-                layer_handles.push(val.clone());
-            }
-        }
-        if layer_handles.is_empty() && obj.fields.len() > 2 {
-            for i in 2..obj.fields.len() {
-                let field_key = format!("layer_{}", i - 2);
-                if let Some(val) = obj.fields.get(&field_key) {
+            if let Some(idx_str) = key.strip_prefix("layer_") {
+                if let Ok(idx) = idx_str.parse::<usize>() {
                     if !val.is_empty() {
-                        layer_handles.push(val.clone());
+                        indexed_layers.push((idx, val.clone()));
                     }
                 }
+            } else if key == "outside_layer" && !val.is_empty() && val != "OS:Material" {
+                outside_layer = Some(val.clone());
+            } else if key == "inside_layer" && !val.is_empty() && val != "OS:Material" {
+                inside_layer = Some(val.clone());
+            } else if key == "layer" {
+                // Backwards-compatible single-layer form (legacy OSM files).
+                indexed_layers.push((indexed_layers.len(), val.clone()));
             }
+        }
+
+        // Sort by index so layer order is deterministic regardless of
+        // HashMap iteration order (issue #1340 round-trip).
+        indexed_layers.sort_by_key(|(idx, _)| *idx);
+        let mut layer_handles: Vec<String> =
+            indexed_layers.into_iter().map(|(_, v)| v).collect();
+
+        // Prepend outside_layer / append inside_layer if present (OpenStudio
+        // order convention; empty if not set).
+        if let Some(ol) = outside_layer {
+            layer_handles.insert(0, ol);
+        }
+        if let Some(il) = inside_layer {
+            layer_handles.push(il);
         }
 
         Construction {
@@ -425,8 +490,8 @@ impl OsmReader {
             name: obj.fields.get("name").cloned().unwrap_or_default(),
             zone_handle: obj.fields.get("zone_handle").cloned(),
             story_handle: obj.fields.get("building_story_handle").cloned(),
-            area: None,
-            volume: None,
+            area: self.parse_f64(obj.fields.get("floor_area")),
+            volume: self.parse_f64(obj.fields.get("volume")),
             surfaces: Vec::new(),
         }
     }
@@ -627,27 +692,41 @@ impl OsmReader {
             .and_then(|b| b.number_of_floors)
             .unwrap_or(1) as usize;
 
-        for space in self.ctx.spaces.values() {
-            let zone_name = space
-                .zone_handle
-                .as_ref()
-                .and_then(|zh| self.ctx.thermal_zones.get(zh))
-                .map(|tz| tz.name.clone())
-                .unwrap_or_else(|| space.name.clone());
-
-            let area = space.area.unwrap_or(48.0);
-            let volume = space.volume.unwrap_or(area * 2.7);
-
-            total_floor_area += area;
-            total_volume += volume;
-
-            zones.push(ZoneGeometry {
-                name: zone_name,
-                floor_area: area,
-                volume,
-                height: if area > 0.0 { volume / area } else { 2.7 },
+        // Iterate spaces in a deterministic order so the resulting zone list
+            // preserves the original insertion order. We sort by the
+            // trailing numeric index of the handle (e.g. "{space-0}" -> 0)
+            // to match the order the writer emits zones. Issue #1340.
+            let mut ordered_spaces: Vec<&Space> = self.ctx.spaces.values().collect();
+            ordered_spaces.sort_by_key(|s| {
+                // Extract trailing integer from handle like "{space-12}" -> 12.
+                s.handle
+                    .rsplit('-')
+                    .next()
+                    .and_then(|n| n.trim_end_matches('}').parse::<usize>().ok())
+                    .unwrap_or(usize::MAX)
             });
-        }
+
+            for space in ordered_spaces {
+                let zone_name = space
+                    .zone_handle
+                    .as_ref()
+                    .and_then(|zh| self.ctx.thermal_zones.get(zh))
+                    .map(|tz| tz.name.clone())
+                    .unwrap_or_else(|| space.name.clone());
+
+                let area = space.area.unwrap_or(48.0);
+                let volume = space.volume.unwrap_or(area * 2.7);
+
+                total_floor_area += area;
+                total_volume += volume;
+
+                zones.push(ZoneGeometry {
+                    name: zone_name,
+                    floor_area: area,
+                    volume,
+                    height: if area > 0.0 { volume / area } else { 2.7 },
+                });
+            }
 
         if zones.is_empty() {
             zones.push(ZoneGeometry::default());
@@ -695,6 +774,8 @@ impl OsmReader {
                 if let Some(const_handle) = &surface.construction_handle {
                     if let Some(construction) = self.ctx.constructions.get(const_handle) {
                         for layer_handle in &construction.layer_handles {
+                            // Try the strict OpenStudio structure first:
+                            // OS:Construction.layer_handle -> OS:Material:Layer.material_handles -> OS:Material
                             if let Some(layer) = self.ctx.layers.get(layer_handle) {
                                 for mat_handle in &layer.material_handles {
                                     if let Some(material) = self.ctx.materials.get(mat_handle) {
@@ -702,6 +783,15 @@ impl OsmReader {
                                             layers.push(layer);
                                         }
                                     }
+                                }
+                            } else if let Some(material) = self.ctx.materials.get(layer_handle) {
+                                // Fallback: layer_handle IS a material_handle.
+                                // This is the case for OSM files emitted by the fluxion
+                                // writer, which references {mat-w0..} directly from
+                                // OS:Construction without an intermediate Layer object.
+                                // Required for lossless round-trip (issue #1340).
+                                if let Some(layer) = material.to_construction_layer() {
+                                    layers.push(layer);
                                 }
                             }
                         }

--- a/src/interop/osm/writer.rs
+++ b/src/interop/osm/writer.rs
@@ -238,54 +238,42 @@ impl OsmWriter {
         Ok(())
     }
 
+    /// Write the three OS:Construction objects (Wall / Roof / Floor).
+    ///
+    /// Each surface type gets a stable handle (`{cons-w0}`, `{cons-r0}`, `{cons-f0}`)
+    /// matching what `write_surfaces` references, so round-trip is lossless.
+    /// We always emit all three constructions — even when the layers are identical
+    /// across types — because `write_surfaces` references distinct handles per type
+    /// and the reader resolves constructions by handle.
     fn write_constructions(
         &mut self,
         writer: &mut dyn Write,
         schema: &SimulationSchemaV1,
     ) -> Result<(), OsmError> {
-        self.write_construction(writer, "ExtWall", &schema.constructions.wall)?;
-
-        if schema.constructions.wall.layers.len() != schema.constructions.roof.layers.len()
-            || schema
-                .constructions
-                .wall
-                .layers
-                .iter()
-                .zip(schema.constructions.roof.layers.iter())
-                .any(|(a, b)| a.name != b.name)
-        {
-            self.write_construction(writer, "Roof", &schema.constructions.roof)?;
-        }
-
-        if schema.constructions.wall.layers.len() != schema.constructions.floor.layers.len()
-            || schema
-                .constructions
-                .wall
-                .layers
-                .iter()
-                .zip(schema.constructions.floor.layers.iter())
-                .any(|(a, b)| a.name != b.name)
-        {
-            self.write_construction(writer, "Floor", &schema.constructions.floor)?;
-        }
-
+        // Map each construction type to a (handle-prefix, name-prefix) pair so that
+        // material handles written by `write_materials` ({mat-w0..}, {mat-r0..},
+        // {mat-f0..}) match the layer handles written here.
+        self.write_construction(writer, "w", "ExtWall", &schema.constructions.wall)?;
+        self.write_construction(writer, "r", "Roof", &schema.constructions.roof)?;
+        self.write_construction(writer, "f", "Floor", &schema.constructions.floor)?;
         Ok(())
     }
 
     fn write_construction(
         &mut self,
         writer: &mut dyn Write,
+        prefix: &str,
         name: &str,
         surface: &crate::api::schema::SurfaceConstruction,
     ) -> Result<(), OsmError> {
         writeln!(writer, "OS:Construction,").map_err(|e| OsmError::ExportError(e.to_string()))?;
-        writeln!(writer, "  {{cons-{}}}, !- Handle", self.handle_counter())
+        writeln!(writer, "  {{cons-{0}0}}, !- Handle", prefix)
             .map_err(|e| OsmError::ExportError(e.to_string()))?;
         writeln!(writer, "  {}, !- Name", name)
             .map_err(|e| OsmError::ExportError(e.to_string()))?;
 
         for (i, _layer) in surface.layers.iter().enumerate() {
-            let mat_handle = format!("{{mat-{}{}}}", &name[..1].to_lowercase(), i);
+            let mat_handle = format!("{{mat-{}{}}}", prefix, i);
             if i == surface.layers.len() - 1 {
                 writeln!(writer, "  {}; !- Layer {}", mat_handle, i + 1)
                     .map_err(|e| OsmError::ExportError(e.to_string()))?;
@@ -333,6 +321,12 @@ impl OsmWriter {
             writeln!(writer, "  {{zone-{}}}, !- Zone Handle", i)
                 .map_err(|e| OsmError::ExportError(e.to_string()))?;
             writeln!(writer, "  , !- Building Story Handle")
+                .map_err(|e| OsmError::ExportError(e.to_string()))?;
+            // Emit area and volume so round-trip preserves zone dimensions.
+            // OS:Space.area and .volume are read back by the reader (issue #1340).
+            writeln!(writer, "  {}, !- Floor Area {{m2}}", zone.floor_area)
+                .map_err(|e| OsmError::ExportError(e.to_string()))?;
+            writeln!(writer, "  {}, !- Volume {{m3}}", zone.volume)
                 .map_err(|e| OsmError::ExportError(e.to_string()))?;
             writeln!(writer, "  0, !- X Origin {{m}}")
                 .map_err(|e| OsmError::ExportError(e.to_string()))?;
@@ -437,6 +431,7 @@ mod tests {
         ConstructionSet, ControlSet, Geometry, SchemaMetadata, SchemaVersion, SimulationOutput,
         SimulationSchemaV1, SurfaceConstruction, WeatherData, ZoneGeometry,
     };
+    use crate::interop::osm::reader::OsmReader;
 
     fn create_test_schema() -> SimulationSchemaV1 {
         SimulationSchemaV1 {
@@ -501,5 +496,777 @@ mod tests {
 
         let content = std::fs::read_to_string(&path).expect("Should read");
         assert!(content.contains("Test Building"));
+    }
+
+    // ------------------------------------------------------------------
+    // Issue #1340 — OSM writer→reader round-trip parity tests
+    //
+    // These tests assert lossless round-trip for the supported subset of
+    // SimulationSchemaV1 fields. On failure they print a structured
+    // per-field diff so OSM Measure authors can debug exactly which
+    // field mismatched (and not just see a generic boolean failure).
+    //
+    // Lossless fields (issue #1340 contract):
+    //   - metadata.name                  (via OS:Building.Name)
+    //   - geometry.zones[*].name         (via OS:ThermalZone.Name)
+    //   - geometry.zones[*].floor_area   (via OS:Space.Floor Area)
+    //   - geometry.zones[*].volume       (via OS:Space.Volume)
+    //   - geometry.total_floor_area      (= sum of zone floor areas)
+    //   - geometry.total_volume          (= sum of zone volumes)
+    //   - geometry.number_of_floors      (via OS:Building.Number of Floors)
+    //   - geometry.floor_height          (computed from total_volume/total_floor_area)
+    //   - constructions.{wall,roof,floor}.layers[*]
+    //         name, thickness, conductivity, density, specific_heat
+    //   - weather (TmyLocation only)     (via OS:Site.Latitude/Longitude)
+    //
+    // Known lossy fields (documented; intentionally NOT asserted):
+    //   - metadata.description, metadata.author, metadata.created_at
+    //     (OS:Building/Description is not emitted by the writer)
+    //   - schedules (no OS:Schedule emission in writer; reader falls back to defaults)
+    //   - controls.{heating,cooling}_setpoint
+    //     (no OS:Thermostat emission; reader falls back to defaults 20/24)
+    //   - constructions.window            (no OS:SubSurface or window construction
+    //                                      emission in the supported subset)
+    //   - constructions.interzone         (not emitted)
+    //   - output.*                        (results, not part of model file)
+    // ------------------------------------------------------------------
+
+    /// Run a full writer → reader round-trip and return the re-parsed schema.
+    fn roundtrip_schema(schema: &SimulationSchemaV1) -> SimulationSchemaV1 {
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let path = temp_dir.path().join("roundtrip.osm");
+
+        let mut writer = OsmWriter::new();
+        writer
+            .export_osm(schema, &path)
+            .expect("writer: should export schema");
+
+        let content = std::fs::read_to_string(&path).expect("Should read exported OSM");
+
+        let mut reader = OsmReader::new();
+        reader
+            .parse(&content)
+            .expect("reader: should re-parse exported OSM")
+    }
+
+    /// Build a structured per-field diff report.
+    ///
+    /// Returns an empty `Vec` when the two schemas match on every asserted
+    /// field, or one `String` per mismatched field for use in `assert!`.
+    fn diff_schemas(
+        original: &SimulationSchemaV1,
+        re_parsed: &SimulationSchemaV1,
+    ) -> Vec<String> {
+        let mut mismatches: Vec<String> = Vec::new();
+
+        // metadata.name round-trips via OS:Building.Name
+        if original.metadata.name != re_parsed.metadata.name {
+            mismatches.push(format!(
+                "metadata.name: '{}' -> '{}'",
+                original.metadata.name, re_parsed.metadata.name
+            ));
+        }
+
+        // geometry.zones — count and field-by-field
+        if original.geometry.zones.len() != re_parsed.geometry.zones.len() {
+            mismatches.push(format!(
+                "geometry.zones.len: {} -> {}",
+                original.geometry.zones.len(),
+                re_parsed.geometry.zones.len()
+            ));
+        } else {
+            for (i, (orig, new)) in original
+                .geometry
+                .zones
+                .iter()
+                .zip(re_parsed.geometry.zones.iter())
+                .enumerate()
+            {
+                if orig.name != new.name {
+                    mismatches.push(format!(
+                        "geometry.zones[{i}].name: '{}' -> '{}'",
+                        orig.name, new.name
+                    ));
+                }
+                if !approx_eq(orig.floor_area, new.floor_area) {
+                    mismatches.push(format!(
+                        "geometry.zones[{i}].floor_area: {} -> {}",
+                        orig.floor_area, new.floor_area
+                    ));
+                }
+                if !approx_eq(orig.volume, new.volume) {
+                    mismatches.push(format!(
+                        "geometry.zones[{i}].volume: {} -> {}",
+                        orig.volume, new.volume
+                    ));
+                }
+                // height is derived from volume/area; should round-trip if both round-trip
+                if !approx_eq(orig.height, new.height) {
+                    mismatches.push(format!(
+                        "geometry.zones[{i}].height: {} -> {}",
+                        orig.height, new.height
+                    ));
+                }
+            }
+        }
+
+        // geometry totals (sum of zone values)
+        let expected_total_area: f64 = original.geometry.zones.iter().map(|z| z.floor_area).sum();
+        let expected_total_volume: f64 = original.geometry.zones.iter().map(|z| z.volume).sum();
+        if !approx_eq(expected_total_area, re_parsed.geometry.total_floor_area) {
+            mismatches.push(format!(
+                "geometry.total_floor_area: {} -> {}",
+                expected_total_area, re_parsed.geometry.total_floor_area
+            ));
+        }
+        if !approx_eq(expected_total_volume, re_parsed.geometry.total_volume) {
+            mismatches.push(format!(
+                "geometry.total_volume: {} -> {}",
+                expected_total_volume, re_parsed.geometry.total_volume
+            ));
+        }
+        if original.geometry.number_of_floors != re_parsed.geometry.number_of_floors {
+            mismatches.push(format!(
+                "geometry.number_of_floors: {} -> {}",
+                original.geometry.number_of_floors, re_parsed.geometry.number_of_floors
+            ));
+        }
+
+        // constructions.{wall, roof, floor}.layers — name + thermal properties
+        for (ctype, orig_sc, new_sc) in [
+            (
+                "wall",
+                &original.constructions.wall,
+                &re_parsed.constructions.wall,
+            ),
+            (
+                "roof",
+                &original.constructions.roof,
+                &re_parsed.constructions.roof,
+            ),
+            (
+                "floor",
+                &original.constructions.floor,
+                &re_parsed.constructions.floor,
+            ),
+        ] {
+            if orig_sc.layers.len() != new_sc.layers.len() {
+                mismatches.push(format!(
+                    "constructions.{ctype}.layers.len: {} -> {}",
+                    orig_sc.layers.len(),
+                    new_sc.layers.len()
+                ));
+            } else {
+                for (li, (a, b)) in orig_sc.layers.iter().zip(new_sc.layers.iter()).enumerate() {
+                    if a.name != b.name {
+                        mismatches.push(format!(
+                            "constructions.{ctype}.layers[{li}].name: '{}' -> '{}'",
+                            a.name, b.name
+                        ));
+                    }
+                    if !approx_eq(a.thickness, b.thickness) {
+                        mismatches.push(format!(
+                            "constructions.{ctype}.layers[{li}].thickness: {} -> {}",
+                            a.thickness, b.thickness
+                        ));
+                    }
+                    if !approx_eq(a.conductivity, b.conductivity) {
+                        mismatches.push(format!(
+                            "constructions.{ctype}.layers[{li}].conductivity: {} -> {}",
+                            a.conductivity, b.conductivity
+                        ));
+                    }
+                    if !approx_eq(a.density, b.density) {
+                        mismatches.push(format!(
+                            "constructions.{ctype}.layers[{li}].density: {} -> {}",
+                            a.density, b.density
+                        ));
+                    }
+                    if !approx_eq(a.specific_heat, b.specific_heat) {
+                        mismatches.push(format!(
+                            "constructions.{ctype}.layers[{li}].specific_heat: {} -> {}",
+                            a.specific_heat, b.specific_heat
+                        ));
+                    }
+                }
+            }
+        }
+
+        // weather (TmyLocation only) — compare as (lat, lon) f64 pairs with
+        // tolerance so the round-trip is robust to Display formatting
+        // differences (e.g. "40.0, -105.0" vs "40, -105"). The string form
+        // is not part of the lossless claim.
+        match (&original.weather, &re_parsed.weather) {
+            (
+                WeatherData::TmyLocation { location: a },
+                WeatherData::TmyLocation { location: b },
+            ) => {
+                let pa: Vec<&str> = a.split(',').collect();
+                let pb: Vec<&str> = b.split(',').collect();
+                if pa.len() != 2 || pb.len() != 2 {
+                    if a != b {
+                        mismatches.push(format!("weather.location: '{a}' -> '{b}'"));
+                    }
+                } else {
+                    let lat_a = pa[0].trim().parse::<f64>().ok();
+                    let lon_a = pa[1].trim().parse::<f64>().ok();
+                    let lat_b = pb[0].trim().parse::<f64>().ok();
+                    let lon_b = pb[1].trim().parse::<f64>().ok();
+                    match (lat_a, lon_a, lat_b, lon_b) {
+                        (Some(la), Some(lo), Some(lb), Some(lob))
+                            if approx_eq(la, lb) && approx_eq(lo, lob) =>
+                        {
+                            // OK
+                        }
+                        _ => {
+                            mismatches.push(format!("weather.location: '{a}' -> '{b}'"));
+                        }
+                    }
+                }
+            }
+            _ => mismatches.push("weather variant mismatch".to_string()),
+        }
+
+        mismatches
+    }
+
+    /// Absolute-or-relative tolerance for f64 round-trip comparisons.
+    fn approx_eq(a: f64, b: f64) -> bool {
+        const EPS_ABS: f64 = 1e-6;
+        const EPS_REL: f64 = 1e-6;
+        let diff = (a - b).abs();
+        if diff <= EPS_ABS {
+            return true;
+        }
+        let denom = a.abs().max(b.abs());
+        if denom == 0.0 {
+            return false;
+        }
+        diff / denom <= EPS_REL
+    }
+
+    /// Single-zone round-trip — mirrors gbxml/writer.rs:428 pattern.
+    /// Asserts zone name, floor_area, volume, and construction layers survive
+    /// byte-equivalent field-wise.
+    #[test]
+    fn test_roundtrip_single_zone() {
+        let schema = create_test_schema();
+        let re_parsed = roundtrip_schema(&schema);
+
+        let diffs = diff_schemas(&schema, &re_parsed);
+        assert!(
+            diffs.is_empty(),
+            "round-trip mismatch for single-zone schema:\n  - {}\n",
+            diffs.join("\n  - ")
+        );
+    }
+
+    /// Two-zone round-trip — exercises per-zone handle assignment and zone
+    /// geometry aggregation.
+    #[test]
+    fn test_roundtrip_two_zones() {
+        let mut schema = create_test_schema();
+        schema.geometry.zones = vec![
+            ZoneGeometry {
+                name: "Zone A".to_string(),
+                floor_area: 50.0,
+                volume: 135.0,
+                height: 2.7,
+            },
+            ZoneGeometry {
+                name: "Zone B".to_string(),
+                floor_area: 75.0,
+                volume: 202.5,
+                height: 2.7,
+            },
+        ];
+        schema.geometry.total_floor_area = 125.0;
+        schema.geometry.total_volume = 337.5;
+
+        let re_parsed = roundtrip_schema(&schema);
+
+        let diffs = diff_schemas(&schema, &re_parsed);
+        assert!(
+            diffs.is_empty(),
+            "round-trip mismatch for two-zone schema:\n  - {}\n",
+            diffs.join("\n  - ")
+        );
+    }
+
+    /// Four-zone round-trip — exercises the upper end of the supported
+    /// multi-zone subset.
+    #[test]
+    fn test_roundtrip_four_zones() {
+        let mut schema = create_test_schema();
+        schema.geometry.zones = (1..=4)
+            .map(|i| ZoneGeometry {
+                name: format!("Zone {i}"),
+                floor_area: 25.0 * i as f64,
+                volume: 67.5 * i as f64,
+                height: 2.7,
+            })
+            .collect();
+        schema.geometry.total_floor_area = schema.geometry.zones.iter().map(|z| z.floor_area).sum();
+        schema.geometry.total_volume = schema.geometry.zones.iter().map(|z| z.volume).sum();
+
+        let re_parsed = roundtrip_schema(&schema);
+
+        let diffs = diff_schemas(&schema, &re_parsed);
+        assert!(
+            diffs.is_empty(),
+            "round-trip mismatch for four-zone schema:\n  - {}\n",
+            diffs.join("\n  - ")
+        );
+    }
+
+    /// Edge case: zone with 0 windows (no OS:SubSurface), 1 floor, 4 walls.
+    /// Verifies the writer does not emit any window/window-construction fields
+    /// that the reader would misinterpret, and that the lossless claim holds
+    /// for the no-window case.
+    #[test]
+    fn test_roundtrip_no_windows() {
+        let mut schema = create_test_schema();
+        // Drop window specs from each construction to model 0 windows.
+        schema.constructions.wall.window = None;
+        schema.constructions.roof.window = None;
+        schema.constructions.floor.window = None;
+
+        let re_parsed = roundtrip_schema(&schema);
+
+        // The construction layers must still round-trip; windows are NOT in
+        // the lossless scope so we don't assert on them.
+        let diffs = diff_schemas(&schema, &re_parsed);
+        assert!(
+            diffs.is_empty(),
+            "round-trip mismatch for no-window schema:\n  - {}\n",
+            diffs.join("\n  - ")
+        );
+
+        // Sanity: no OS:SubSurface in the emitted file.
+        use tempfile::TempDir;
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let path = temp_dir.path().join("no_windows.osm");
+        let mut writer = OsmWriter::new();
+        writer.export_osm(&schema, &path).expect("Should export");
+        let content = std::fs::read_to_string(&path).expect("Should read");
+        assert!(
+            !content.contains("OS:SubSurface"),
+            "writer should not emit OS:SubSurface when no windows are present"
+        );
+    }
+
+    /// Exhaustive round-trip — assert ALL supported fields match, with a
+    /// structured diff printed on failure (per acceptance criteria).
+    ///
+    /// This complements the per-scenario tests above by failing fast with
+    /// every mismatched field listed, instead of stopping at the first.
+    #[test]
+    fn test_roundtrip_exhaustive_diff_report() {
+        let schema = create_test_schema();
+        let re_parsed = roundtrip_schema(&schema);
+
+        let diffs = diff_schemas(&schema, &re_parsed);
+
+        if !diffs.is_empty() {
+            eprintln!(
+                "OSM round-trip diff report ({} mismatch{}):",
+                diffs.len(),
+                if diffs.len() == 1 { "" } else { "es" }
+            );
+            for d in &diffs {
+                eprintln!("  - {d}");
+            }
+        }
+
+        assert!(
+            diffs.is_empty(),
+            "expected lossless round-trip for all declared fields; got {} mismatches (see stderr)",
+            diffs.len()
+        );
+    }
+
+    /// Verifies the written OSM XML is parseable by a structural linter
+    /// (sanity check that the writer emits a well-formed OSM structure:
+    /// every `OS:Construction.layer_handle` resolves to a material emitted
+    /// earlier in the file). This guards against future regressions where
+    /// new handle schemes are introduced but not kept in sync.
+    #[test]
+    fn test_written_osm_handle_consistency() {
+        use tempfile::TempDir;
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let path = temp_dir.path().join("handles.osm");
+        let mut writer = OsmWriter::new();
+        writer
+            .export_osm(&create_test_schema(), &path)
+            .expect("Should export");
+        let content = std::fs::read_to_string(&path).expect("Should read");
+
+        // Collect every material handle emitted by the writer.
+        let mut material_handles: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
+        for line in content.lines() {
+            let trimmed = line.trim();
+            // Format: "  {mat-w0}, !- Handle"
+            if trimmed.contains("!- Handle") && trimmed.starts_with('{') {
+                if let Some(handle_end) = trimmed.find('}') {
+                    let handle = trimmed[..=handle_end].to_string();
+                    if handle.starts_with("{mat-") {
+                        material_handles.insert(handle);
+                    }
+                }
+            }
+        }
+
+        // Every layer reference inside OS:Construction must resolve to a
+        // material handle actually emitted above.
+        let mut unresolved: Vec<String> = Vec::new();
+        let mut in_construction = false;
+        for line in content.lines() {
+            let trimmed = line.trim();
+            if trimmed.starts_with("OS:Construction,") {
+                in_construction = true;
+                continue;
+            }
+            if in_construction && trimmed == ";" {
+                in_construction = false;
+                continue;
+            }
+            if in_construction && trimmed.contains("!- Layer") {
+                // Extract the handle before the comma (e.g. "{mat-w0}")
+                if let Some(handle_end) = trimmed.find('}') {
+                    let handle = trimmed[..=handle_end].to_string();
+                    if !material_handles.contains(&handle) {
+                        unresolved.push(handle);
+                    }
+                }
+            }
+        }
+
+        assert!(
+            unresolved.is_empty(),
+            "writer emitted OS:Construction layer handles that don't resolve to any OS:Material:\n  - {}",
+            unresolved.join("\n  - ")
+        );
+        // And the inverse: every emitted material must be referenced by some
+        // OS:Construction layer (no orphans).
+        let mut referenced: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
+        let mut in_construction = false;
+        for line in content.lines() {
+            let trimmed = line.trim();
+            if trimmed.starts_with("OS:Construction,") {
+                in_construction = true;
+                continue;
+            }
+            if in_construction && trimmed == ";" {
+                in_construction = false;
+                continue;
+            }
+            if in_construction && trimmed.contains("!- Layer") {
+                if let Some(handle_end) = trimmed.find('}') {
+                    let handle = trimmed[..=handle_end].to_string();
+                    referenced.insert(handle);
+                }
+            }
+        }
+        let orphans: Vec<&String> = material_handles
+            .iter()
+            .filter(|h| !referenced.contains(*h))
+            .collect();
+        assert!(
+            orphans.is_empty(),
+            "writer emitted OS:Material handles never referenced by any OS:Construction:\n  - {}",
+            orphans
+                .iter()
+                .map(|s| s.as_str())
+                .collect::<Vec<_>>()
+                .join("\n  - ")
+        );
+    }
+
+    /// Pure structural OSM validation — runs against a writer-emitted file
+    /// and asserts the same invariants as `test_written_osm_handle_consistency`
+    /// but using a regex-driven check (closer to what a third-party OSM
+    /// validator would do). This is the "Python validator" counterpart called
+    /// out by the issue's hard rules: a structural linter view independent
+    /// of the in-tree reader.
+    #[test]
+    fn test_written_osm_structural_validation() {
+        use tempfile::TempDir;
+        use std::collections::HashMap;
+
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let path = temp_dir.path().join("structural.osm");
+        let mut writer = OsmWriter::new();
+        writer
+            .export_osm(&create_test_schema(), &path)
+            .expect("Should export");
+        let content = std::fs::read_to_string(&path).expect("Should read");
+
+        // Parse into (object_type -> [(handle, field_values...)]).
+        let mut objects: HashMap<String, Vec<(String, Vec<String>)>> = HashMap::new();
+        let mut current_type: Option<String> = None;
+        let mut current_handle: Option<String> = None;
+        let mut current_fields: Vec<String> = Vec::new();
+
+        fn flush(
+            objects: &mut HashMap<String, Vec<(String, Vec<String>)>>,
+            current_type: &mut Option<String>,
+            current_handle: &mut Option<String>,
+            current_fields: &mut Vec<String>,
+        ) {
+            if let (Some(t), Some(h)) = (current_type.take(), current_handle.take()) {
+                objects
+                    .entry(t)
+                    .or_default()
+                    .push((h, std::mem::take(current_fields)));
+            }
+        }
+
+        for line in content.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            if let Some(rest) = trimmed.strip_prefix("OS:").or_else(|| trimmed.strip_prefix("OSM:")) {
+                flush(
+                    &mut objects,
+                    &mut current_type,
+                    &mut current_handle,
+                    &mut current_fields,
+                );
+                let type_name = rest.trim_end_matches(',').to_string();
+                current_type = Some(type_name);
+                current_handle = None;
+                current_fields.clear();
+                continue;
+            }
+            if trimmed == ";" {
+                flush(
+                    &mut objects,
+                    &mut current_type,
+                    &mut current_handle,
+                    &mut current_fields,
+                );
+                continue;
+            }
+            let value = if let Some(idx) = trimmed.find(", !-") {
+                &trimmed[..idx]
+            } else if let Some(idx) = trimmed.find(';') {
+                &trimmed[..idx]
+            } else {
+                trimmed
+            }
+            .trim()
+            .trim_end_matches(',')
+            .trim()
+            .to_string();
+
+            if current_handle.is_none() && value.starts_with('{') && value.ends_with('}') {
+                current_handle = Some(value.clone());
+            } else {
+                current_fields.push(value);
+            }
+        }
+        flush(
+            &mut objects,
+            &mut current_type,
+            &mut current_handle,
+            &mut current_fields,
+        );
+
+        // Structural invariants:
+        let materials: std::collections::HashSet<String> = objects
+            .get("Material")
+            .map(|v| v.iter().map(|(h, _)| h.clone()).collect())
+            .unwrap_or_default();
+        let mut unresolved_layers: Vec<String> = Vec::new();
+        if let Some(constructions) = objects.get("Construction") {
+            for (_handle, fields) in constructions {
+                for f in fields.iter().skip(2) {
+                    if f.starts_with('{') && !materials.contains(f) {
+                        unresolved_layers.push(f.clone());
+                    }
+                }
+            }
+        }
+        assert!(
+            unresolved_layers.is_empty(),
+            "structural validator: OS:Construction layer references unresolved materials: {:?}",
+            unresolved_layers
+        );
+
+        assert!(
+            objects.contains_key("ThermalZone"),
+            "structural validator: writer did not emit OS:ThermalZone"
+        );
+
+        let zone_count = objects.get("ThermalZone").map(|v| v.len()).unwrap_or(0);
+        let space_count = objects.get("Space").map(|v| v.len()).unwrap_or(0);
+        assert_eq!(
+            zone_count, space_count,
+            "structural validator: OS:ThermalZone count ({zone_count}) != OS:Space count ({space_count})"
+        );
+
+        let surface_count = objects.get("Surface").map(|v| v.len()).unwrap_or(0);
+        assert!(
+            surface_count >= 6,
+            "structural validator: expected >= 6 OS:Surface entries (4 walls + roof + floor), got {surface_count}"
+        );
+    }
+
+    /// Python-driven structural validator: writes an OSM file from the writer
+    /// and runs an independent Python script against it (per the issue's
+    /// hard rule: "Use Python via `ctx_execute(language: \"python\", ...)` to
+    /// validate OSM XML structure"). This catches structural regressions
+    /// that the in-tree reader might silently mask.
+    #[test]
+    fn test_python_structural_validation() {
+        use std::io::Write;
+        use std::process::{Command, Stdio};
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let path = temp_dir.path().join("python_check.osm");
+        let mut writer = OsmWriter::new();
+        writer
+            .export_osm(&create_test_schema(), &path)
+            .expect("Should export");
+        let content = std::fs::read_to_string(&path).expect("Should read");
+
+        // Also write a copy to /tmp so external Python tooling (ctx_execute)
+        // can validate the structure independently.
+        let _ = std::fs::write("/tmp/osm_roundtrip_check.osm", &content);
+
+        // Inline Python validator script (kept inline so the test is
+        // self-contained — no external script file dependency).
+        let script = r#"
+import re
+import sys
+from collections import defaultdict
+
+content = sys.stdin.read()
+
+# Parse the OSM into a dict: {object_type: [(handle, [field_values])]}.
+objects = defaultdict(list)
+current_type = None
+current_handle = None
+current_fields = []
+
+def flush():
+    global current_type, current_handle, current_fields
+    if current_type and current_handle:
+        objects[current_type].append((current_handle, current_fields))
+    current_type = None
+    current_handle = None
+    current_fields = []
+
+for line in content.splitlines():
+    s = line.strip()
+    if not s:
+        continue
+    if s.startswith("OS:") or s.startswith("OSM:"):
+        flush()
+        current_type = s.split(",")[0]
+        if current_type.startswith("OSM:"):
+            current_type = current_type.replace("OSM:", "OS:", 1)
+        continue
+    if s == ";":
+        flush()
+        continue
+    # Extract value before ", !-" comment or ";" terminator.
+    if ", !-" in s:
+        value = s.split(", !-", 1)[0].strip().rstrip(",").strip()
+    elif ";" in s:
+        value = s.split(";", 1)[0].strip().rstrip(",").strip()
+    else:
+        value = s.strip().rstrip(",").strip()
+    if current_handle is None and value.startswith("{") and value.endswith("}"):
+        current_handle = value
+    else:
+        current_fields.append(value)
+flush()
+
+errors = []
+
+# 1. Construction layer references must resolve to a Material handle.
+materials = {h for h, _ in objects.get("OS:Material", [])}
+for handle, fields in objects.get("OS:Construction", []):
+    for f in fields[2:]:
+        if f.startswith("{") and f not in materials:
+            errors.append(f"OS:Construction {handle}: unresolved layer {f}")
+
+# 2. At least one zone + space pair.
+zones = objects.get("OS:ThermalZone", [])
+spaces = objects.get("OS:Space", [])
+if len(zones) != len(spaces):
+    errors.append(f"zone count {len(zones)} != space count {len(spaces)}")
+
+# 3. Every space references a valid zone handle (zone_handle is at index 2:
+#    fields = [name, zone_handle, building_story_handle, floor_area, ...]).
+zone_handles = {h for h, _ in zones}
+for sh, fields in spaces:
+    if len(fields) >= 2 and fields[1] not in zone_handles:
+        errors.append(f"OS:Space {sh}: zone_handle {fields[1]!r} not found")
+
+# 4. Every surface references a valid construction handle (construction_handle
+#    is at index 3: fields = [name, surface_type, construction_handle, ...]).
+cons_handles = {h for h, _ in objects.get("OS:Construction", [])}
+for sh, fields in objects.get("OS:Surface", []):
+    if len(fields) >= 3 and fields[2] not in cons_handles:
+        errors.append(f"OS:Surface {sh}: construction_handle {fields[2]!r} not found")
+
+# 5. f64 sanity: every OS:Material thickness, conductivity, density, specific_heat
+#    must parse as a positive number.
+for handle, fields in objects.get("OS:Material", []):
+    # fields: handle, name, roughness, thickness, conductivity, density, specific_heat, emissivity
+    for idx, name in [(2, "thickness"), (3, "conductivity"), (4, "density"), (5, "specific_heat")]:
+        if idx < len(fields):
+            try:
+                v = float(fields[idx])
+                if v <= 0:
+                    errors.append(f"OS:Material {handle}: {name}={v} not positive")
+            except ValueError:
+                errors.append(f"OS:Material {handle}: {name}={fields[idx]!r} not a number")
+
+if errors:
+    print("STRUCTURAL_FAIL:", file=sys.stderr)
+    for e in errors:
+        print(f"  - {e}", file=sys.stderr)
+    sys.exit(1)
+
+print(f"STRUCTURAL_OK: {sum(len(v) for v in objects.values())} objects validated")
+for t, items in sorted(objects.items()):
+    print(f"  {t}: {len(items)}")
+"#;
+
+        let mut child = Command::new("python3")
+            .arg("-c")
+            .arg(script)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("Failed to spawn python3");
+
+        if let Some(stdin) = child.stdin.as_mut() {
+            stdin.write_all(content.as_bytes()).expect("write stdin");
+        }
+
+        let output = child.wait_with_output().expect("wait python");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        eprintln!("--- Python validator stdout ---\n{stdout}");
+        if !stderr.is_empty() {
+            eprintln!("--- Python validator stderr ---\n{stderr}");
+        }
+
+        assert!(
+            output.status.success(),
+            "Python structural validator failed:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        );
     }
 }


### PR DESCRIPTION
fixes #1340

## Summary

Adds lossless round-trip testing for the OpenStudio Model (OSM) writer→reader
pipeline and surfaces the supported subset as an explicit lossless claim.

## Round-trip coverage

`test_roundtrip` in `src/interop/osm/writer.rs` (mirroring the gbxml pattern)
asserts the following `SimulationSchemaV1` fields round-trip byte-equivalent
field-wise (f64 within 1e-6 absolute/relative tolerance):

- `metadata.name` (via `OS:Building.Name`)
- `geometry.zones[*].name`, `.floor_area`, `.volume`, `.height`
- `geometry.total_floor_area`, `.total_volume`, `.number_of_floors`, `.floor_height`
- `constructions.{wall,roof,floor}.layers[*].name`, `.thickness`, `.conductivity`, `.density`, `.specific_heat`
- `weather` (`TmyLocation` variant only — lat/lon f64 pair)

## Tests

Five round-trip tests:

- `test_roundtrip_single_zone` — 1 zone, default `ConstructionSet`
- `test_roundtrip_two_zones` — 2 zones, mixed floor areas
- `test_roundtrip_four_zones` — 4 zones (upper end of supported subset)
- `test_roundtrip_no_windows` — edge case: zone with 0 windows, 1 floor, 4 walls
- `test_roundtrip_exhaustive_diff_report` — asserts every supported field matches; emits a per-field diff on failure

Plus two structural sanity tests:

- `test_written_osm_handle_consistency` — every `OS:Construction.layer_handle` resolves to an emitted `OS:Material`, and vice versa (no orphans).
- `test_written_osm_structural_validation` — Rust-side third-party-style structural validator.
- `test_python_structural_validation` — spawns an external `python3` subprocess that re-parses the OSM and asserts the same invariants independently of the in-tree reader.

## Lossless claim scope (documented in src/interop/osm/mod.rs and ARCHITECTURE.md)

**Lossless** for the supported subset (above).

**Known lossy** (fall back to `Default` on read; out of scope for #1340):
- `metadata.description`, `.author`, `.created_at`
- `schedules.*` (no `OS:Schedule:*` emission)
- `controls.{heating,cooling}_setpoint` (no `OS:Thermostat` emission)
- `constructions.{wall,roof,floor}.window` (no `OS:SubSurface` emission)
- `constructions.interzone`
- `weather` for `EpwFile` and `Inline` variants
- `output.*` (simulation results)

## Pre-existing bugs fixed

To make round-trip actually lossless, three pre-existing bugs surfaced by the
new tests are also fixed (see commit message for details):

1. Writer used inconsistent handle naming for `OS:Construction` (`{mat-e0}`
   vs `{mat-w0}`); now always emits `{cons-w0}`/`{cons-r0}`/`{cons-f0}`
   with matching `{mat-w*}`/`{mat-r*}`/`{mat-f*}` references.
2. Writer did not emit `OS:Space.Floor Area` / `Volume`, so the reader
   defaulted zones to 48.0/129.6 regardless of the schema.
3. Reader kept the `, !- <comment>` annotation in field values, so every
   `parse_f64` silently failed and the reader fell back to defaults.

Additional reader fixes: `OS:Space` field map updated for area/volume;
`get_field_name` returns `String` so construction layers don't collide in
the HashMap; `parse_construction` sorts layers by index for determinism;
`extract_geometry` sorts spaces by trailing handle index for stable multi-zone
order; weather comparison uses f64 lat/lon with tolerance.

## Verification

```
cargo test --features ort --lib interop::osm
cargo clippy --lib --features ort -- -D warnings
cargo build --release --features ort
```

All green. 14 OSM tests pass (8 new). 64 interop tests pass.