### PR TITLE
chore(#1351): wire determinism_check as required PR gate

### DIFF
--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -1,0 +1,163 @@
+# Branch Protection Configuration
+
+> **Status:** Reference document. This file describes the GitHub branch
+> protection configuration that anchors the `main` branch's "Required
+> status checks" list. The configuration is enforced by GitHub and can
+> only be modified by a repository administrator in the GitHub web UI
+> (Settings → Branches → `main` → Require status checks to pass before
+> merging). This file does **not** enforce anything by itself — it is
+> the canonical spec that admins and the verification process check
+> against.
+
+This document was introduced by **issue #1351** to close the
+acceptance gap from **#1297** (cross-platform FP determinism CI gate).
+The previous gate had a working `Determinism Check` job inside
+`ashrae_validation.yml` but it was an OS-matrix job and was not
+listed in the branch-protection "Required status checks" — so a
+determinism failure on one OS could merge if the others passed (or
+the gate could pass if the in-workflow `compare-hashes` step did not
+catch a regression that the upstream `Cross-Platform Determinism CI`
+workflow did).
+
+The fix is two-layered:
+
+1. **In-workflow wiring (this repo, in this PR)** — add an explicit,
+   non-matrix `Fluxion Determinism Gate` listener job that observes
+   the upstream `Cross-Platform Determinism CI` workflow_run and
+   fails the ASHRAE 140 CI Gate workflow if the upstream concluded
+   `failure` / `cancelled` / `timed_out`.
+2. **Branch protection (manual admin step)** — add the listener job
+   name to the "Required status checks" list on `main` so the PR
+   cannot be merged without that check reporting `success`.
+
+---
+
+## Required status checks on `main`
+
+The `main` branch **must** require all of the following status checks
+to report `success` before any PR can be merged:
+
+| # | Status check name (exact)                            | Workflow / job                                              | Source issue |
+|---|------------------------------------------------------|-------------------------------------------------------------|--------------|
+| 1 | `ASHRAE 140 Strict Energy Gate (Issue #1333)`        | `.github/workflows/ashrae_140_strict_energy_gate.yml`       | #1333        |
+| 2 | `Fluxion Determinism Gate (Issue #1351)`             | `.github/workflows/ashrae_validation.yml` (`fluxion-determinism-gate` listener job) | #1351 / #1297 |
+
+The list is mirrored in `release_gates.yaml` under `ci.required_checks`
+and `ci.workflow_index`. The two sources **must** stay in sync — any
+change to one is a change to the other.
+
+### Why the determinism gate is a *non-matrix* job name
+
+The upstream `Determinism Check` job in `determinism_check.yml` runs
+on an OS matrix (`ubuntu-latest`, `windows-latest`, `macos-latest`),
+which GitHub exposes as three separate required-check rows. Branch
+protection can only reference one canonical name, so the gate wiring
+in `ashrae_validation.yml` adds a separate listener job
+(`fluxion-determinism-gate`, surfaced as
+`Fluxion Determinism Gate (Issue #1351)`) that fires **after** the
+upstream `Cross-Platform Determinism CI` workflow concludes on the
+same SHA. The listener is the single source of truth that branch
+protection references.
+
+### What happens if the listener fails
+
+The listener:
+
+1. Inspects `github.event.workflow_run.conclusion` for the upstream
+   `Cross-Platform Determinism CI` run on the same SHA.
+2. On `failure` / `cancelled` / `timed_out`, exits non-zero (so the
+   listener reports `failure` in the PR's checks list) **and** posts
+   a PR comment with the upstream run URL and a triage checklist.
+3. On `success` / `neutral` / `skipped`, exits zero.
+
+---
+
+## Manual admin step (one-time)
+
+The exact branch-protection list cannot be edited from a PR (it lives
+in GitHub repo settings). A repository administrator must:
+
+1. Open the GitHub repository → **Settings** → **Branches**.
+2. Click **Add rule** (or edit the existing `main` rule).
+3. Set **Branch name pattern** = `main`.
+4. Enable **Require status checks to pass before merging**.
+5. Click **Add checks** and search for / type the exact check names
+   listed in the table above.
+6. (Recommended) Enable **Require branches to be up to date before
+   merging** so the listener fires on the merge commit, not the
+   branch tip.
+7. Save the rule.
+
+The `main` rule's current state is also exposed via the GitHub API
+(`GET /repos/{owner}/{repo}/branches/main/protection`); a small
+verification script that compares the API's `required_status_checks`
+list to the table above lives at
+`scripts/check_branch_protection.py` (added in a follow-up to
+#1351).
+
+---
+
+## Verification path
+
+The acceptance criterion for #1351 requires an empirical test that
+a determinism failure actually blocks the PR. To verify after the
+manual admin step is applied:
+
+1. Create a temporary branch off `main` (e.g.
+   `chore/1351-verify-determinism-gate`).
+2. Modify `tests/case_900_determinism.rs` to compare one of the
+   determinism constants to a deliberately wrong value (e.g.
+   `assert_eq!(annual_heating_mwh, 0.0, ...)`).
+3. Open a PR. The PR's checks list must show
+   `Fluxion Determinism Gate (Issue #1351)` (and the in-workflow
+   `Compare Hashes` and the upstream `Cross-Platform Determinism CI`)
+   all reporting `failure`.
+4. **Without** merging, revert the assertion change and either
+   re-push (the listener re-fires on the new SHA) or close the PR.
+5. The merge button must be disabled while the listener is failing
+   — that is the gate blocking the merge.
+
+If the merge button is **not** disabled while the listener is
+failing, the manual admin step has not been applied correctly.
+Re-check the branch-protection rule's "Required status checks" list
+and ensure `Fluxion Determinism Gate (Issue #1351)` is present and
+exact (no extra whitespace, correct case).
+
+---
+
+## Out of scope (not changed by this document)
+
+- The independent `Cross-Platform Determinism CI` workflow
+  (`.github/workflows/determinism_check.yml`) is kept as the primary
+  entry point. Do not remove it.
+- The in-workflow `determinism-check` matrix + `compare-hashes` job
+  inside `ashrae_validation.yml` are kept as a fast first line of
+  defence. They mirror the upstream workflow but the listener is
+  the durable single-check anchor for branch protection.
+- Physics changes, determinism-failure root-cause fixes, and
+  expansion of the determinism test cases are all separate issues
+  (F# and B# verticals in the issue batch, see #1297 and #1351).
+
+---
+
+## Linked issues
+
+- **#1297** — original "Establish cross-platform FP determinism CI
+  gate" issue. Closed when the upstream `determinism_check.yml`
+  workflow landed. The acceptance gap ("the determinism gate must be
+  a *required* PR gate, not just an info check") is closed by this
+  document + the listener job wiring.
+- **#1351** — this issue. Wires the listener job as a required
+  status check, documents the manual admin step, and adds the
+  canonical `Fluxion Determinism Gate (Issue #1351)` check name.
+- **#1357** — Wave 1 follow-up that unblocked the determinism gate
+  by fixing the `ort` feature-gate import (PR #1357,
+  `fix(ci): gate ort imports + add drift-check permissions + fix
+  MultiNodeSolver false-positive`).
+- **#1063** — referenced by #1351's "Linked existing issues"
+  section. Predecessor determinism discussion.
+
+---
+
+_Last updated: 2026-06-27. Reviewed by: TBD. Maintained by: fluxion
+release-gate working group._

--- a/.github/workflows/ashrae_validation.yml
+++ b/.github/workflows/ashrae_validation.yml
@@ -1,9 +1,44 @@
+# ASHRAE 140 CI Gate (Issue #1351 — cross-workflow determinism listener)
+#
+# This workflow is the canonical validation gate for PRs to main. It owns:
+#   * the in-workflow determinism matrix (`determinism-check`) and
+#     cross-platform hash comparison (`compare-hashes`),
+#   * the ASHRAE 140 blind validation (`validate`),
+#   * the module-isolation tests for Weather / Solar / Conduction /
+#     Ventilation / Zone Balance.
+#
+# PR gate wiring (Issue #1351, closes #1297 acceptance gap)
+# --------------------------------------------------------
+# GitHub branch protection requires a single canonical "Required status
+# check" name. The matrix `determinism-check` job expands into three OS-
+# specific rows (ubuntu/windows/macOS) and the `compare-hashes` job is the
+# only place that actually fails the build on hash divergence. To give
+# branch protection a single, stable, non-matrix check name, this
+# workflow also exposes a `workflow_run` listener job (`fluxion-determinism-gate`)
+# that fires after `Cross-Platform Determinism CI` completes for the same
+# SHA and fails the build if the upstream concluded `failure` or
+# `cancelled`. Add that job name to the branch-protection required list
+# (also recorded in `release_gates.yaml::ci.required_checks`).
+#
+# The in-workflow `determinism-check` + `compare-hashes` jobs are kept
+# as a fast first line of defence (they run inline with the rest of the
+# gate) — they are the actual source of truth, and the listener job is
+# the durable cross-workflow mirror that branch protection can name.
+
 name: ASHRAE 140 CI Gate
 
 on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
+  # Issue #1351: mirror the Cross-Platform Determinism CI conclusion
+  # into this workflow as a single non-matrix "Fluxion Determinism Gate"
+  # check that branch protection can reference. The listener only fires
+  # for the same SHA on the same branch, so spurious upstream runs on
+  # unrelated branches are ignored.
+  workflow_run:
+    workflows: ["Cross-Platform Determinism CI"]
+    types: [completed]
 
 concurrency:
   group: ashrae-ci-gate-${{ github.ref }}
@@ -221,6 +256,12 @@ jobs:
     name: ASHRAE 140 Blind Validation
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # Issue #1351: the explicit `needs: compare-hashes` makes the
+    # ASHRAE 140 validate job block on cross-platform determinism
+    # (compare-hashes itself needs determinism-check, so this is a
+    # transitive gate on the entire determinism matrix). The new
+    # `fluxion-determinism-gate` workflow_run listener is the canonical
+    # non-matrix check that branch protection references.
     needs: compare-hashes
     steps:
       - name: Checkout code
@@ -420,10 +461,15 @@ jobs:
           echo "❌ ASHRAE 140 CI gate failed on ${{ github.event_name }}"
           exit 1
 
-  # Module isolation tests - each module must match EnergyPlus within 1% tolerance
+  # Module isolation tests - each module must match EnergyPlus within 1% tolerance.
+  # Issue #1351: every isolation job now explicitly `needs: compare-hashes` so the
+  # whole gate (not just the ASHRAE 140 validate job) blocks on cross-platform
+  # determinism. Without this, a determinism regression would surface only via
+  # the `validate` job, and the isolation jobs could still report PASS.
   isolation-weather:
     name: Weather Isolation
     runs-on: ubuntu-latest
+    needs: compare-hashes
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -449,6 +495,7 @@ jobs:
   isolation-solar:
     name: Solar Isolation
     runs-on: ubuntu-latest
+    needs: compare-hashes
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -474,6 +521,7 @@ jobs:
   isolation-conduction:
     name: Conduction Isolation
     runs-on: ubuntu-latest
+    needs: compare-hashes
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -499,6 +547,7 @@ jobs:
   isolation-ventilation:
     name: Ventilation Isolation
     runs-on: ubuntu-latest
+    needs: compare-hashes
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -524,6 +573,7 @@ jobs:
   isolation-zone-balance:
     name: Zone Balance Isolation
     runs-on: ubuntu-latest
+    needs: compare-hashes
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -545,3 +595,107 @@ jobs:
             ${{ runner.os }}-cargo-
       - name: Run Zone Balance Isolation Tests
         run: cargo test --test zone_balance_eplus_isolation --release
+
+  # =====================================================================
+  # Issue #1351 — Cross-workflow determinism gate listener
+  # =====================================================================
+  # This job fires after the `Cross-Platform Determinism CI` workflow
+  # completes for the same SHA. It exists so branch protection can name
+  # a single, non-matrix required check (`Fluxion Determinism Gate`) and
+  # the PR can be blocked at the gate even if the in-workflow
+  # `compare-hashes` job and the upstream `compare-hashes` job ever
+  # disagree (e.g. one runs on a stale fork SHA, the other doesn't).
+  #
+  # The listener is intentionally minimal: it does NOT re-run the
+  # determinism test — it just observes the upstream `conclusion` and
+  # surfaces a clear PR comment + branch-protection check name.
+  # =====================================================================
+  fluxion-determinism-gate:
+    name: "Fluxion Determinism Gate (Issue #1351)"
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion != 'skipped'
+    permissions:
+      contents: read
+      checks: read
+      pull-requests: write
+      actions: read
+    steps:
+      - name: Verify upstream conclusion and post PR comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPSTREAM_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          UPSTREAM_RUN_ID: ${{ github.event.workflow_run.id }}
+          UPSTREAM_RUN_URL: ${{ github.event.workflow_run.html_url }}
+          UPSTREAM_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          UPSTREAM_HEAD_REF: ${{ github.event.workflow_run.head_branch }}
+          UPSTREAM_NAME: ${{ github.event.workflow_run.name }}
+        run: |
+          set -euo pipefail
+          echo "Upstream workflow: ${UPSTREAM_NAME}"
+          echo "Upstream run ID:   ${UPSTREAM_RUN_ID}"
+          echo "Upstream head SHA: ${UPSTREAM_HEAD_SHA}"
+          echo "Upstream head ref: ${UPSTREAM_HEAD_REF}"
+          echo "Upstream conclusion: ${UPSTREAM_CONCLUSION}"
+
+          # Pull-request number lookup — workflow_run events do not carry
+          # the PR number directly. We find the PR for the head SHA and
+          # use that for the failure comment.
+          PR_NUMBER="$(gh pr list --state open --head "${UPSTREAM_HEAD_REF}" --json number --jq '.[0].number // empty' || true)"
+
+          case "${UPSTREAM_CONCLUSION}" in
+            success)
+              echo "::notice::Determinism gate PASSED — upstream workflow succeeded."
+              exit 0
+              ;;
+            failure|cancelled|timed_out)
+              echo "::error::Determinism gate FAILED — upstream workflow concluded '${UPSTREAM_CONCLUSION}'."
+              echo "::error::See upstream run: ${UPSTREAM_RUN_URL}"
+              if [ -n "${PR_NUMBER:-}" ]; then
+                COMMENT_FILE="$(mktemp -t determinism-gate-comment.XXXXXX.md)"
+                UPSTREAM_CONCLUSION="${UPSTREAM_CONCLUSION}" \
+                UPSTREAM_RUN_URL="${UPSTREAM_RUN_URL}" \
+                UPSTREAM_HEAD_SHA="${UPSTREAM_HEAD_SHA}" \
+                COMMENT_FILE="${COMMENT_FILE}" \
+                python3 <<'PYEOF'
+                import os
+                lines = [
+                  "## :rotating_light: Cross-Platform Determinism Gate FAILED",
+                  "",
+                  f"The `Cross-Platform Determinism CI` workflow concluded **{os.environ['UPSTREAM_CONCLUSION']}** for commit `{os.environ['UPSTREAM_HEAD_SHA']}` on this PR. The PR cannot be merged until the determinism check passes on **all three OS matrix entries** (ubuntu-latest, windows-latest, macos-latest).",
+                  "",
+                  f"**Upstream run:** {os.environ['UPSTREAM_RUN_URL']}",
+                  "",
+                  "### Common causes",
+                  "- A new `HashMap` / `HashSet` was introduced where a deterministic `BTreeMap` is required (see #1297).",
+                  "- A non-deterministic `f32` reduction path (SIMD reordering, parallel reduction) was added.",
+                  "- A new dependency pulled in non-portable FP code (rebuild against `--release --features wiring-tracing` to reproduce).",
+                  "",
+                  "### Re-run",
+                  "Push a new commit to this branch to re-trigger the upstream `Cross-Platform Determinism CI` workflow.",
+                  "",
+                  "---",
+                  "*This comment is auto-posted by the `Fluxion Determinism Gate` listener job (issue #1351, closing #1297 acceptance gap).*",
+                ]
+                with open(os.environ["COMMENT_FILE"], "w") as f:
+                    f.write("\n".join(lines))
+                PYEOF
+                gh pr comment "${PR_NUMBER}" --body-file "${COMMENT_FILE}" \
+                  || echo "::warning::Failed to post PR comment for PR #${PR_NUMBER}"
+                rm -f "${COMMENT_FILE}"
+              else
+                echo "::warning::No open PR found for ref ${UPSTREAM_HEAD_REF}; skipping PR comment."
+              fi
+              exit 1
+              ;;
+            *)
+              # 'neutral' / 'skipped' / unknown — do not block the gate.
+              echo "::notice::Upstream determinism workflow concluded '${UPSTREAM_CONCLUSION}' — not blocking the gate."
+              exit 0
+              ;;
+          esac
+
+      - name: Hard fail on upstream non-success
+        if: github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'cancelled' || github.event.workflow_run.conclusion == 'timed_out'
+        run: |
+          echo "::error::Determinism gate hard fail — see upstream run ${{ github.event.workflow_run.html_url }}"
+          exit 1

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -330,6 +330,55 @@ let random_value = rng.gen::<f64>();
 - Run tests multiple times to verify determinism
 - Use `--test-threads=1` to catch race conditions
 
+#### Cross-Platform Determinism CI Gate (Issue #1351)
+
+A pull-request to `main` **cannot be merged** if the cross-platform
+floating-point determinism check fails. The gate is wired in two
+places:
+
+1. `Cross-Platform Determinism CI` workflow
+   (`.github/workflows/determinism_check.yml`) — runs Case 900
+   determinism on `ubuntu-latest`, `windows-latest`, and
+   `macos-latest` and compares the SHA-256 of the extracted values
+   to confirm the simulation produces byte-identical output on all
+   three operating systems.
+2. `ASHRAE 140 CI Gate` workflow
+   (`.github/workflows/ashrae_validation.yml`) — exposes a
+   `workflow_run` listener job
+   (`Fluxion Determinism Gate (Issue #1351)`) that fails the
+   PR's checks list and posts a comment with the upstream run URL
+   if the `Cross-Platform Determinism CI` workflow concluded
+   `failure` / `cancelled` / `timed_out` for the same SHA. This
+   listener is the canonical non-matrix required check that
+   branch protection references.
+
+The required status check list lives in
+`release_gates.yaml::ci.required_checks` and is mirrored in
+[`.github/BRANCH_PROTECTION.md`](../.github/BRANCH_PROTECTION.md)
+alongside the manual admin steps to add the check to GitHub
+branch protection.
+
+**Common ways a PR can trip the gate (issue #1297 fix list):**
+
+- A new `HashMap` / `HashSet` is used where a deterministic
+  `BTreeMap` is required (non-deterministic iteration order across
+  platforms).
+- A non-deterministic `f32` reduction path (SIMD reordering,
+  parallel reduction with non-associative orderings) is added
+  without an explicit `BTreeMap`/sorted-iterator wrapper.
+- A new dependency pulls in non-portable FP code. Rebuild against
+  `--release --features wiring-tracing` to reproduce.
+
+**Local repro recipe** (matches the upstream workflow's RUSTFLAGS):
+
+```bash
+RUSTFLAGS="-C opt-level=3 -C debug-assertions=no" \
+  cargo test --test case_900_determinism --release -- --nocapture
+```
+
+The expected canonical hash for the three-OS matrix is published in
+the `Determinism Check (ubuntu-latest)` step summary on `main`.
+
 ### Coverage Measurement
 
 Fluxion uses `cargo-llvm-cov` for coverage measurement:

--- a/release_gates.yaml
+++ b/release_gates.yaml
@@ -192,6 +192,19 @@ ci:
     # enforce the ±15% band automatically.
     - "ASHRAE 140 Strict Energy Gate (Issue #1333)"
 
+    # Cross-platform floating-point determinism (issues #1351 / #1297).
+    # The listener job is defined in `.github/workflows/ashrae_validation.yml`
+    # under the `fluxion-determinism-gate` id and is triggered by the
+    # `Cross-Platform Determinism CI` workflow_run completion. It is the
+    # canonical non-matrix check name that branch protection references
+    # (the upstream `determinism-check` job expands into three OS matrix
+    # rows and is not a stable branch-protection target on its own).
+    # The listener exits non-zero on `failure` / `cancelled` / `timed_out`
+    # upstream conclusions and posts a PR comment linking the upstream
+    # run URL — closing the #1297 acceptance gap that allowed a
+    # determinism failure to slip through with a green `validate` job.
+    - "Fluxion Determinism Gate (Issue #1351)"
+
   # Job-to-workflow map (informational; branch-protection reads job
   # names directly). Used by `scripts/release_gate_checker.py` to verify
   # the required_checks list is in sync with the workflows directory.
@@ -200,3 +213,13 @@ ci:
       workflow: ".github/workflows/ashrae_140_strict_energy_gate.yml"
       issue: 1333
       triggered_by: "PR + push to main"
+
+    - job: "Fluxion Determinism Gate (Issue #1351)"
+      # The listener job is defined in `ashrae_validation.yml`; it
+      # observes completion of the upstream workflow named below.
+      workflow: ".github/workflows/ashrae_validation.yml"
+      observes_workflow: "Cross-Platform Determinism CI"
+      observes_workflow_file: ".github/workflows/determinism_check.yml"
+      issue: 1351
+      depends_on: 1297
+      triggered_by: "workflow_run on Cross-Platform Determinism CI completion"


### PR DESCRIPTION
fixes #1351

## Summary

Wires the `Cross-Platform Determinism CI` workflow conclusion as a single, non-matrix required PR gate (`Fluxion Determinism Gate (Issue #1351)`) that branch protection on `main` can reference. Closes the acceptance gap from #1297.

## What this PR does

1. **`.github/workflows/ashrae_validation.yml`** — adds a `workflow_run` trigger and a `fluxion-determinism-gate` listener job that:
   - fires after `Cross-Platform Determinism CI` completes for the same SHA,
   - exits 0 on `success` / `neutral` / `skipped` upstream conclusions,
   - exits 1 and posts a PR comment with the upstream run URL on `failure` / `cancelled` / `timed_out` upstream conclusions.

2. **Same file** — adds explicit `needs: compare-hashes` to every isolation job (weather, solar, conduction, ventilation, zone-balance) so the whole gate (not just the `validate` job) blocks on cross-platform determinism.

3. **`release_gates.yaml`** — adds `Fluxion Determinism Gate (Issue #1351)` to `ci.required_checks` and a matching entry in `ci.workflow_index` with the new `observes_workflow` field documenting the cross-workflow relationship. Mirrors the existing #1333 strict-energy-gate pattern from PR #1368.

4. **`.github/BRANCH_PROTECTION.md`** (new) — admin runbook documenting the manual branch-protection step, the canonical check name, the listener behaviour, the verification procedure (synthetic broken-determinism PR), and the linked issues (#1297, #1351, #1357, #1063).

5. **`docs/CONTRIBUTING.md`** — new "Cross-Platform Determinism CI Gate" subsection under "Deterministic Testing" with the local repro recipe matching the upstream `RUSTFLAGS`.

## Manual step required (not in this PR)

GitHub branch protection is repository-side config that cannot be modified from a PR. A repository administrator must:

1. Open the repository → **Settings** → **Branches** → `main` rule → **Require status checks to pass before merging**.
2. Add the exact check name: `Fluxion Determinism Gate (Issue #1351)`.
3. (Recommended) enable **Require branches to be up to date before merging** so the listener fires on the merge commit.

Full step-by-step is in `.github/BRANCH_PROTECTION.md`. Once applied, the verification procedure in that doc walks through a synthetic broken-determinism PR to confirm the gate actually blocks a merge.

## Verification

- `python3 -c "yaml.safe_load_all(...)"` parses both modified YAML files cleanly.
- Job-graph inspection: every isolation job now has `needs: compare-hashes`; new listener job has no upstream `needs:` (fires from `workflow_run`).
- No Rust changes — `cargo build --release --features wiring-tracing` not run (no Rust source modified).

## Out of scope

- No physics changes.
- No parameter tuning.
- The upstream `.github/workflows/determinism_check.yml` is unchanged (kept as the primary entry point per #1351 scope).
- The `scripts/check_branch_protection.py` referenced in `BRANCH_PROTECTION.md` is a follow-up, not part of this PR.

## Linked issues

- Fixes #1351
- Closes #1297 (acceptance gap)
- Depends on #1357 (Wave 1 `ort` feature-gate fix that unblocked the determinism check)
- References #1063