### PR TITLE
test(#1353): add proptest edge-case coverage for ventilation ACH

### DIFF
--- a/.agents/results/issue-1353-ventilation-monotonicity.py
+++ b/.agents/results/issue-1353-ventilation-monotonicity.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Issue #1353 — ASHRAE combined-formula monotonicity bound derivation.
+
+This script verifies the monotonicity bound `combined >= max(wind, stack)` for
+fluxion's `calculate_combined_infiltration_ach`, mirroring the Rust source at
+`src/sim/ventilation.rs:35-110`.
+
+The bound is required by Issue #1353's proptest coverage. The implementer MUST
+derive the bound from the source code (not from memory) because fluxion's
+simplified additive form differs from the canonical ASHRAE Fundamentals
+combined-infiltration formula (`wind + stack - sqrt(wind*stack)`).
+
+Run:
+    python3 .agents/results/issue-1353-ventilation-monotonicity.py
+"""
+import math
+import random
+
+# Mirror src/sim/ventilation.rs (verified from source — see ventilation.rs:35-110)
+STACK_COEFFICIENT = 0.025
+AIR_DENSITY = 1.2
+AIR_SPECIFIC_HEAT = 1000.0
+
+
+def calculate_wind_infiltration_ach(wind_speed, building_height, shielding_factor):
+    """Mirror of fluxion::sim::ventilation::calculate_wind_infiltration_ach.
+
+    Source (src/sim/ventilation.rs:35-45):
+        shelter_coefficient = (1 - shielding_factor) * 0.4
+        height_factor       = (building_height / 3.0)^0.5
+        n_factor            = shelter_coefficient * height_factor
+        return n_factor * (wind_speed / 3.0)
+
+    Note: the source does NOT clamp negative wind speeds; physical inputs are
+    always wind_speed >= 0, so for physical inputs the output is non-negative
+    because height_factor >= 0 and (1 - shielding_factor) * 0.4 >= 0 when
+    shielding_factor <= 1.
+    """
+    shelter_coefficient = 0.0 + (1.0 - shielding_factor) * 0.4
+    height_factor = (building_height / 3.0) ** 0.5
+    base_wind_speed = 3.0
+    n_factor = shelter_coefficient * height_factor
+    return n_factor * (wind_speed / base_wind_speed)
+
+
+def calculate_stack_infiltration_ach(indoor_temp, outdoor_temp, height_diff,
+                                     opening_area, zone_volume):
+    """Mirror of fluxion::sim::ventilation::calculate_stack_infiltration_ach.
+
+    Source (src/sim/ventilation.rs:58-76):
+        if zone_volume <= 0 or height_diff <= 0: return 0
+        delta_t = abs(indoor - outdoor)
+        if delta_t < 0.5: return 0
+        flow_sqrt = sqrt(delta_t / height_diff)
+        q_vent    = STACK_COEFFICIENT * opening_area * flow_sqrt
+        return q_vent / zone_volume
+    """
+    if zone_volume <= 0.0 or height_diff <= 0.0:
+        return 0.0
+    delta_t = abs(indoor_temp - outdoor_temp)
+    if delta_t < 0.5:
+        return 0.0
+    flow_arg = delta_t / height_diff
+    flow_sqrt = math.sqrt(flow_arg) if flow_arg > 0.0 else 0.0
+    q_vent = STACK_COEFFICIENT * opening_area * flow_sqrt
+    return q_vent / zone_volume
+
+
+def calculate_combined_infiltration_ach(outdoor_temp, indoor_temp, wind_speed,
+                                        height_diff, opening_area, zone_volume,
+                                        shielding_factor):
+    """Mirror of fluxion::sim::ventilation::calculate_combined_infiltration_ach.
+
+    Source (src/sim/ventilation.rs:91-110):
+        wind_ach  = calculate_wind_infiltration_ach(...)
+        stack_ach = calculate_stack_infiltration_ach(...)
+        total_ach = wind_ach + stack_ach
+        return total_ach.max(0.0)
+    """
+    wind_ach = calculate_wind_infiltration_ach(wind_speed, height_diff, shielding_factor)
+    stack_ach = calculate_stack_infiltration_ach(
+        indoor_temp, outdoor_temp, height_diff, opening_area, zone_volume
+    )
+    total_ach = wind_ach + stack_ach
+    return max(total_ach, 0.0)
+
+
+def main():
+    random.seed(1353)
+
+    # =====================================================================
+    # Step 1: Verify non-negativity of wind_ach and stack_ach for
+    #         PHYSICAL inputs (wind_speed >= 0, height >= 0, etc.)
+    # =====================================================================
+    print("=" * 72)
+    print("Step 1: Wind and stack components are non-negative for physical inputs")
+    print("=" * 72)
+
+    violations_wind = 0
+    violations_stack = 0
+    for _ in range(100_000):
+        # Physical inputs only: non-negative wind speed, positive volume, etc.
+        ws = random.uniform(0.0, 30.0)
+        bh = random.uniform(0.5, 30.0)
+        sf = random.uniform(0.0, 1.0)
+        w = calculate_wind_infiltration_ach(ws, bh, sf)
+        if w < 0:
+            violations_wind += 1
+
+        ti = random.uniform(-30.0, 45.0)
+        to = random.uniform(-30.0, 45.0)
+        hd = random.uniform(0.5, 10.0)
+        oa = random.uniform(0.1, 5.0)
+        zv = random.uniform(50.0, 500.0)
+        s = calculate_stack_infiltration_ach(ti, to, hd, oa, zv)
+        if s < 0:
+            violations_stack += 1
+
+    print(f"wind_ach  < 0 violations: {violations_wind} / 100,000  "
+          f"(expected 0 for physical inputs)")
+    print(f"stack_ach < 0 violations: {violations_stack} / 100,000  "
+          f"(expected 0 for physical inputs)")
+    print()
+
+    # =====================================================================
+    # Step 2: Derive monotonicity bound from source code formula
+    # =====================================================================
+    print("=" * 72)
+    print("Step 2: Derive monotonicity bound combined >= max(wind, stack)")
+    print("=" * 72)
+    print("From source (src/sim/ventilation.rs:108-109):")
+    print("    total_ach = wind_ach + stack_ach")
+    print("    return total_ach.max(0.0)")
+    print()
+    print("For PHYSICAL inputs (Step 1), wind_ach >= 0 and stack_ach >= 0.")
+    print("Therefore:")
+    print("    combined = max(wind_ach + stack_ach, 0)")
+    print("           >= wind_ach + stack_ach")
+    print("           >= max(wind_ach, stack_ach)     (both terms non-negative)")
+    print()
+    print("BOUND: combined >= max(wind_ach, stack_ach)   OK")
+    print()
+
+    # =====================================================================
+    # Step 3: Empirical verification across 100k plausible physical inputs
+    # =====================================================================
+    print("=" * 72)
+    print("Step 3: Empirical verification of bound on 100k physical inputs")
+    print("=" * 72)
+
+    bound_violations = 0
+    max_combined = 0.0
+    max_wind = 0.0
+    max_stack = 0.0
+    for _ in range(100_000):
+        to = random.uniform(-30.0, 45.0)
+        ti = random.uniform(15.0, 30.0)
+        ws = random.uniform(0.0, 30.0)
+        bh = random.uniform(1.0, 30.0)
+        oa = random.uniform(0.1, 5.0)
+        zv = random.uniform(50.0, 500.0)
+        sf = random.uniform(0.0, 1.0)
+
+        w = calculate_wind_infiltration_ach(ws, bh, sf)
+        s = calculate_stack_infiltration_ach(ti, to, bh, oa, zv)
+        c = calculate_combined_infiltration_ach(to, ti, ws, bh, oa, zv, sf)
+
+        max_combined = max(max_combined, c)
+        max_wind = max(max_wind, w)
+        max_stack = max(max_stack, s)
+
+        # Use a tiny epsilon to absorb float rounding in the comparison.
+        if c + 1e-12 < max(w, s):
+            bound_violations += 1
+
+    print(f"combined < max(wind, stack) violations: "
+          f"{bound_violations} / 100,000  (expected 0)")
+    print(f"max wind_ach:    {max_wind:.4f}")
+    print(f"max stack_ach:   {max_stack:.4f}")
+    print(f"max combined_ach:{max_combined:.4f}")
+    print(f"=> bound holds in ALL 100,000 cases for plausible inputs.")
+    print()
+
+    # =====================================================================
+    # Step 4: Edge cases — zero wind, zero ΔT, zero height
+    # =====================================================================
+    print("=" * 72)
+    print("Step 4: Edge cases (zero wind, zero ΔT, zero height)")
+    print("=" * 72)
+    print("zero wind, delta_t=10, height=2.7:")
+    print(f"    wind_ach  = {calculate_wind_infiltration_ach(0.0, 2.7, 0.5):.6f}  "
+          f"(expected 0.0)")
+    print(f"    stack_ach = {calculate_stack_infiltration_ach(25.0, 15.0, 2.7, 1.0, 100.0):.6f}  "
+          f"(expected > 0)")
+    print()
+    print("zero delta_t, wind=5, height=2.7:")
+    print(f"    wind_ach  = {calculate_wind_infiltration_ach(5.0, 2.7, 0.5):.6f}  "
+          f"(expected > 0)")
+    print(f"    stack_ach = {calculate_stack_infiltration_ach(20.0, 20.0, 2.7, 1.0, 100.0):.6f}  "
+          f"(expected 0.0)")
+    print()
+    print("zero height (height_diff=0):")
+    print(f"    stack_ach = {calculate_stack_infiltration_ach(25.0, 15.0, 0.0, 1.0, 100.0):.6f}  "
+          f"(expected 0.0)")
+    print()
+
+    # =====================================================================
+    # Step 5: Summary
+    # =====================================================================
+    print("=" * 72)
+    print("Step 5: Summary — bound the proptest must check")
+    print("=" * 72)
+    print("""
+ASHRAE COMBINED-FORMULA MONOTONICITY BOUND (fluxion implementation):
+
+    Given fluxion's source code:
+        wind_ach  = ((1 - shielding_factor) * 0.4) * sqrt(building_height/3) * (wind_speed/3)
+                  >= 0  (for physical inputs wind_speed >= 0, building_height >= 0)
+        stack_ach = (returns 0 when zone_volume <= 0, height_diff <= 0, |dT| < 0.5)
+                  >= 0  (STACK_COEFFICIENT * opening_area * sqrt(...) / zone_volume)
+        combined  = max(wind_ach + stack_ach, 0.0)
+                  >= 0
+
+    THE BOUND IS:
+        combined >= max(wind_ach, stack_ach)
+
+    Derivation (algebraic, from the source code):
+        combined  = max(wind_ach + stack_ach, 0.0)
+                 >= wind_ach + stack_ach                    (clamp only truncates)
+                 >= max(wind_ach, stack_ach)                (both terms non-negative)
+
+This is the property the proptest block in tests/ventilation_isolation.rs
+must assert for `proptest_combined_infiltration_ach`.
+""")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/ventilation_isolation.rs
+++ b/tests/ventilation_isolation.rs
@@ -33,6 +33,8 @@ use fluxion::sim::ventilation::{
 };
 use fluxion::sim::ventilation::{VentilationSchedule, WeatherDependentVentilation};
 
+use proptest::prelude::*;
+
 // ============================================================================
 // ASHRAE 140 Case 900 spec constants
 // ============================================================================
@@ -394,4 +396,297 @@ fn test_ashrae_140_get_ach_weather_direct_matches_trait_dispatch() {
         max_abs_diff,
         worst_hour,
     );
+}
+
+// ============================================================================
+// Property-Based Tests (proptest)
+// Issue #1353 — proptest edge-case coverage for ventilation ACH formulas.
+//
+// These tests extend the deterministic CSV-based coverage above (PR #1327)
+// with 10,000 random cases per property. The bound `combined >= max(wind, stack)`
+// is derived from the fluxion source code at
+// `.agents/results/issue-1353-ventilation-monotonicity.py` (Steps 1-3).
+//
+// # Reference
+//
+// - Issue #1353 — extends proptest coverage from #1062 to ventilation
+// - Issue #1062 — original proptest pattern for solar_position, state_space_ctf,
+//   coupled_solver
+// - ARCHITECTURE.md Module 4 (Infiltration & Ventilation) — 1% tolerance target
+//
+// # Property matrix
+//
+// | Function                       | Property                                                    |
+// |--------------------------------|-------------------------------------------------------------|
+// | `calculate_wind_infiltration_ach` | finite, non-negative, monotonic non-decreasing in wind  |
+// | `calculate_stack_infiltration_ach`| finite, non-negative, zero when |ΔT|≈0, monotonic in h   |
+// | `calculate_combined_infiltration_ach`| finite, non-negative, combined ≥ max(wind, stack)       |
+// | `WeatherDependentVentilation::get_ach` | finite, non-negative, zero-wind and zero-ΔT cases     |
+//
+// All `prop_assume!` filters handle preconditions (e.g. shielding_factor ∈ [0, 1]
+// is required for the wind monotonicity property to hold) rather than failing.
+// ============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(10_000))]
+
+    // ------------------------------------------------------------------------
+    // calculate_wind_infiltration_ach
+    // ------------------------------------------------------------------------
+
+    /// Output is finite and non-negative for any physical input
+    /// (`wind_speed ≥ 0`, `building_height ≥ 0`, `shielding_factor ∈ [0, 1]`).
+    /// For these ranges the formula `n_factor × (wind/3)` with
+    /// `n_factor = (1 − shielding) × 0.4 × √(height/3)` yields a non-negative
+    /// result.
+    #[test]
+    fn proptest_wind_infiltration_finite_and_non_negative(
+        wind_speed in 0.0_f64..30.0,
+        building_height in 0.5_f64..30.0,
+        shielding_factor in 0.0_f64..1.0,
+    ) {
+        let ach = calculate_wind_infiltration_ach(wind_speed, building_height, shielding_factor);
+        prop_assert!(ach.is_finite(),
+            "wind_infiltration_ach must be finite; got {} for wind={}, height={}, shielding={}",
+            ach, wind_speed, building_height, shielding_factor);
+        prop_assert!(ach >= 0.0,
+            "wind_infiltration_ach must be non-negative; got {} for wind={}, height={}, shielding={}",
+            ach, wind_speed, building_height, shielding_factor);
+    }
+
+    /// Monotonic non-decreasing in `wind_speed` for fixed `(height, shielding)`.
+    /// The source formula is linear in `wind_speed` with non-negative slope
+    /// `n_factor / 3 ≥ 0` when `shielding ≤ 1` and `height ≥ 0`.
+    /// Generates `wind_lo` and a non-negative `wind_extra` so `wind_hi ≥ wind_lo`
+    /// is satisfied by construction (no `prop_assume!` rejection churn).
+    #[test]
+    fn proptest_wind_infiltration_monotonic_non_decreasing_in_wind(
+        wind_lo in 0.0_f64..15.0,
+        wind_extra in 0.0_f64..15.0,   // wind_hi = wind_lo + wind_extra ≥ wind_lo by construction
+        building_height in 0.5_f64..30.0,
+        shielding_factor in 0.0_f64..1.0,
+    ) {
+        let wind_hi = wind_lo + wind_extra;
+        let ach_lo = calculate_wind_infiltration_ach(wind_lo, building_height, shielding_factor);
+        let ach_hi = calculate_wind_infiltration_ach(wind_hi, building_height, shielding_factor);
+        prop_assert!(ach_hi + 1e-12 >= ach_lo,
+            "wind_infiltration_ach must be non-decreasing in wind_speed for fixed (height, shielding); \
+             wind_lo={} → ach_lo={}, wind_hi={} → ach_hi={}, height={}, shielding={}",
+            wind_lo, ach_lo, wind_hi, ach_hi, building_height, shielding_factor);
+    }
+
+    // ------------------------------------------------------------------------
+    // calculate_stack_infiltration_ach
+    // ------------------------------------------------------------------------
+
+    /// Output is finite and non-negative for physical inputs
+    /// (`height_diff > 0`, `zone_volume > 0`, any ΔT).
+    /// The source returns 0 when any precondition fails.
+    #[test]
+    fn proptest_stack_infiltration_finite_and_non_negative(
+        t_in in -30.0_f64..45.0,
+        t_out in -30.0_f64..45.0,
+        height_diff in 0.5_f64..10.0,
+        opening_area in 0.1_f64..5.0,
+        zone_volume in 50.0_f64..500.0,
+    ) {
+        let ach = calculate_stack_infiltration_ach(t_in, t_out, height_diff, opening_area, zone_volume);
+        prop_assert!(ach.is_finite(),
+            "stack_infiltration_ach must be finite; got {} for T_in={}, T_out={}, h={}, area={}, V={}",
+            ach, t_in, t_out, height_diff, opening_area, zone_volume);
+        prop_assert!(ach >= 0.0,
+            "stack_infiltration_ach must be non-negative; got {} for T_in={}, T_out={}, h={}, area={}, V={}",
+            ach, t_in, t_out, height_diff, opening_area, zone_volume);
+    }
+
+    /// Zero output when `|T_in - T_out| < 1e-6 K` (the source code returns 0
+    /// for `|ΔT| < 0.5 K`, which is a strict superset of `|ΔT| < 1e-6 K`).
+    /// Verifies graceful zero output — no NaN, no panic.
+    #[test]
+    fn proptest_stack_infiltration_zero_when_temperatures_approx_equal(
+        t_in in -30.0_f64..45.0,
+        height_diff in 0.5_f64..10.0,
+        opening_area in 0.1_f64..5.0,
+        zone_volume in 50.0_f64..500.0,
+    ) {
+        // T_out == T_in exactly ⇒ |ΔT| = 0 < 1e-6 ⇒ source returns 0
+        let t_out: f64 = t_in;
+        let ach = calculate_stack_infiltration_ach(t_in, t_out, height_diff, opening_area, zone_volume);
+        prop_assert_eq!(ach, 0.0,
+            "stack_infiltration_ach must be 0.0 when |T_in - T_out| < 1e-6 K (T_in={}, T_out={}); got {}",
+            t_in, t_out, ach);
+    }
+
+    /// Monotonic non-increasing in `height_diff` for fixed `(T_in, T_out, area, V)`.
+    /// Source: `STACK × area × sqrt(ΔT/h) / V` decreases as `h` grows
+    /// (square-root of `1/h`). Generates `height_diff_lo` and a non-negative
+    /// `height_extra` so `height_diff_hi ≥ height_diff_lo` holds by construction.
+    #[test]
+    fn proptest_stack_infiltration_monotonic_non_increasing_in_height(
+        t_in in 5.0_f64..30.0,
+        t_out in -30.0_f64..0.0,    // ensures ΔT > 0.5 K (above stack cutoff)
+        height_diff_lo in 0.5_f64..5.0,
+        height_extra in 0.0_f64..5.0, // height_diff_hi = lo + extra ≥ lo by construction
+        opening_area in 0.1_f64..5.0,
+        zone_volume in 50.0_f64..500.0,
+    ) {
+        let height_diff_hi = height_diff_lo + height_extra;
+        let ach_lo = calculate_stack_infiltration_ach(t_in, t_out, height_diff_lo, opening_area, zone_volume);
+        let ach_hi = calculate_stack_infiltration_ach(t_in, t_out, height_diff_hi, opening_area, zone_volume);
+        prop_assert!(ach_hi + 1e-12 <= ach_lo,
+            "stack_infiltration_ach must be non-increasing in height_diff for fixed (T_in, T_out, area, V); \
+             h_lo={} → ach_lo={}, h_hi={} → ach_hi={}, T_in={}, T_out={}",
+            height_diff_lo, ach_lo, height_diff_hi, ach_hi, t_in, t_out);
+    }
+
+    // ------------------------------------------------------------------------
+    // calculate_combined_infiltration_ach
+    // ------------------------------------------------------------------------
+
+    /// Output is finite and non-negative for physical inputs.
+    /// Source: `max(wind + stack, 0)` is non-negative by construction
+    /// (clamped at 0; both wind and stack are non-negative for physical inputs).
+    #[test]
+    fn proptest_combined_infiltration_finite_and_non_negative(
+        t_out in -30.0_f64..45.0,
+        t_in in 15.0_f64..30.0,
+        wind_speed in 0.0_f64..30.0,
+        height_diff in 0.5_f64..10.0,
+        opening_area in 0.1_f64..5.0,
+        zone_volume in 50.0_f64..500.0,
+        shielding_factor in 0.0_f64..1.0,
+    ) {
+        let ach = calculate_combined_infiltration_ach(
+            t_out, t_in, wind_speed, height_diff, opening_area, zone_volume, shielding_factor,
+        );
+        prop_assert!(ach.is_finite(),
+            "combined_infiltration_ach must be finite; got {} for wind={}, T_in={}, T_out={}",
+            ach, wind_speed, t_in, t_out);
+        prop_assert!(ach >= 0.0,
+            "combined_infiltration_ach must be non-negative; got {} for wind={}, T_in={}, T_out={}",
+            ach, wind_speed, t_in, t_out);
+    }
+
+    /// ASHRAE combined-formula monotonicity bound:
+    /// `combined >= max(wind_only, stack_only)`.
+    /// Derived in `.agents/results/issue-1353-ventilation-monotonicity.py`:
+    ///   combined = max(wind + stack, 0)
+    ///            >= wind + stack             (clamp only truncates)
+    ///            >= max(wind, stack)         (both terms non-negative)
+    /// Restricting `shielding_factor ∈ [0, 1]` and `wind_speed ≥ 0` keeps
+    /// `wind ≥ 0` so the bound holds for every case proptest draws.
+    #[test]
+    fn proptest_combined_infiltration_ge_max_components(
+        t_out in -30.0_f64..45.0,
+        t_in in 15.0_f64..30.0,
+        wind_speed in 0.0_f64..30.0,
+        height_diff in 0.5_f64..10.0,
+        opening_area in 0.1_f64..5.0,
+        zone_volume in 50.0_f64..500.0,
+        shielding_factor in 0.0_f64..1.0,
+    ) {
+        let wind = calculate_wind_infiltration_ach(wind_speed, height_diff, shielding_factor);
+        let stack = calculate_stack_infiltration_ach(t_in, t_out, height_diff, opening_area, zone_volume);
+        let combined = calculate_combined_infiltration_ach(
+            t_out, t_in, wind_speed, height_diff, opening_area, zone_volume, shielding_factor,
+        );
+        let max_components = wind.max(stack);
+        prop_assert!(combined + 1e-12 >= max_components,
+            "combined_infiltration_ach must satisfy combined >= max(wind, stack) (ASHRAE combined-formula bound); \
+             combined={}, wind={}, stack={}, max={}",
+            combined, wind, stack, max_components);
+    }
+
+    // ------------------------------------------------------------------------
+    // WeatherDependentVentilation::get_ach() — zero-wind & zero-ΔT cases
+    // ------------------------------------------------------------------------
+
+    /// Explicit `wind_speed = 0.0` case as required by Issue #1353
+    /// Acceptance Criteria. Verifies graceful zero wind-component output
+    /// (no NaN, no panic, no division-by-zero).
+    /// At `wind_speed = 0`, the wind-driven term `n_factor × (0/3) = 0`, so
+    /// `combined = max(stack, 0) = stack`, and `wind_benefit = 0`.
+    #[test]
+    fn proptest_weather_dependent_ventilation_zero_wind(
+        t_out in -30.0_f64..45.0,
+        t_in in 15.0_f64..30.0,
+        height_diff in 0.5_f64..10.0,
+        opening_area in 0.1_f64..5.0,
+        zone_volume in 50.0_f64..500.0,
+        shielding_factor in 0.0_f64..1.0,
+    ) {
+        let wind_speed: f64 = 0.0;
+        // Direct call to combined formula — must not panic and must be finite.
+        let combined = calculate_combined_infiltration_ach(
+            t_out, t_in, wind_speed, height_diff, opening_area, zone_volume, shielding_factor,
+        );
+        prop_assert!(combined.is_finite(),
+            "combined_infiltration_ach must be finite at wind_speed=0; got {}", combined);
+        prop_assert!(combined >= 0.0,
+            "combined_infiltration_ach must be non-negative at wind_speed=0; got {}", combined);
+        // Wind component must be exactly 0 at wind=0 (linear formula n_factor × 0 / 3 = 0)
+        let wind_only = calculate_wind_infiltration_ach(wind_speed, height_diff, shielding_factor);
+        prop_assert_eq!(wind_only, 0.0,
+            "wind_infiltration_ach must be exactly 0.0 at wind_speed=0; got {}", wind_only);
+
+        // WeatherDependentVentilation::get_ach() must also be finite at wind=0.
+        // We construct a vent with min_ach < max_ach so the spec value isn't
+        // trivially min_ach. max_ach > 0 ensures wind_benefit's `/max_ach` is
+        // well-defined.
+        let vent = WeatherDependentVentilation::new(
+            0.5,  // base_ach
+            0.3,  // min_ach
+            2.0,  // max_ach > 0
+            18.0, // start_temp
+            26.0, // full_open_temp
+        );
+        let ach = vent.get_ach(0, t_out, t_in, wind_speed, zone_volume);
+        prop_assert!(ach.is_finite(),
+            "WeatherDependentVentilation::get_ach() must be finite at wind_speed=0; got {}", ach);
+        prop_assert!(ach >= vent.min_ach,
+            "WeatherDependentVentilation::get_ach() must be >= min_ach ({}); got {} at wind=0",
+            vent.min_ach, ach);
+    }
+
+    /// `WeatherDependentVentilation::get_ach()` with `T_in ≈ T_out` (zero ΔT).
+    /// Stack component is 0.0 because `|ΔT| < 0.5` triggers the source cutoff.
+    /// Verifies no NaN, no panic, and the result is at least `min_ach`.
+    #[test]
+    fn proptest_weather_dependent_ventilation_zero_delta_t(
+        t_in in -30.0_f64..45.0,
+        wind_speed in 0.0_f64..30.0,
+        height_diff in 0.5_f64..10.0,
+        opening_area in 0.1_f64..5.0,
+        zone_volume in 50.0_f64..500.0,
+        shielding_factor in 0.0_f64..1.0,
+    ) {
+        // T_out == T_in ⇒ ΔT = 0 ⇒ stack component returns 0 (delta_t < 0.5)
+        let t_out: f64 = t_in;
+        let stack = calculate_stack_infiltration_ach(t_in, t_out, height_diff, opening_area, zone_volume);
+        prop_assert_eq!(stack, 0.0,
+            "stack_infiltration_ach must be exactly 0.0 when T_in == T_out; got {}", stack);
+
+        let combined = calculate_combined_infiltration_ach(
+            t_out, t_in, wind_speed, height_diff, opening_area, zone_volume, shielding_factor,
+        );
+        prop_assert!(combined.is_finite(),
+            "combined_infiltration_ach must be finite when T_in == T_out; got {}", combined);
+        prop_assert!(combined >= 0.0,
+            "combined_infiltration_ach must be non-negative when T_in == T_out; got {}", combined);
+
+        // WeatherDependentVentilation::get_ach() must be finite when T_in == T_out.
+        let vent = WeatherDependentVentilation::new(
+            0.5,  // base_ach
+            0.3,  // min_ach
+            2.0,  // max_ach > 0
+            18.0, // start_temp
+            26.0, // full_open_temp
+        );
+        let ach = vent.get_ach(0, t_out, t_in, wind_speed, zone_volume);
+        prop_assert!(ach.is_finite(),
+            "WeatherDependentVentilation::get_ach() must be finite when T_in == T_out; got {}", ach);
+        prop_assert!(ach >= vent.min_ach,
+            "WeatherDependentVentilation::get_ach() must be >= min_ach ({}); got {} at ΔT=0",
+            vent.min_ach, ach);
+    }
 }


### PR DESCRIPTION
fixes #1353

## Summary

Extends `tests/ventilation_isolation.rs` (added in PR #1327 / Wave 1) with 9 proptest blocks at `ProptestConfig::with_cases(10_000)`, mirroring the established convention from `src/solar/solar_position.rs:282-289` and `src/thermal/coupled_solver.rs:264-271` (Issue #1062).

## Coverage matrix (edge cases + invariants)

| Function | Property |
|----------|----------|
| `calculate_wind_infiltration_ach` | finite, non-negative, monotonic non-decreasing in `wind_speed` |
| `calculate_stack_infiltration_ach` | finite, non-negative, zero when `\|ΔT\| < 1e-6 K`, monotonic non-increasing in `height_diff` |
| `calculate_combined_infiltration_ach` | finite, non-negative, `combined ≥ max(wind, stack)` (ASHRAE combined-formula monotonicity bound) |
| `WeatherDependentVentilation::get_ach()` | zero-wind and zero-ΔT cases — graceful output (no NaN, no panic, no div-by-zero) |

## Monotonicity bound derivation

The bound `combined >= max(wind, stack)` is derived **algebraically from the source code** at `src/sim/ventilation.rs:108-109` (not from memory). The Python verification at `.agents/results/issue-1353-ventilation-monotonicity.py` proves:

```
combined  = max(wind_ach + stack_ach, 0.0)
          >= wind_ach + stack_ach               (clamp only truncates)
          >= max(wind_ach, stack_ach)           (both terms non-negative
                                                 for physical inputs)
```

Empirically verified across 100,000 random physical inputs in the Python script (0 violations).

## Acceptance criteria status

- [x] `cargo test --features ort --test ventilation_isolation` runs all 9 new proptest blocks to 10,000 cases with zero failures (13 tests total pass: 4 deterministic + 9 proptest)
- [x] At least one proptest case explicitly passes `wind_speed = 0.0` and asserts `get_ach()` returns a finite value >= `min_ach` — captured in `proptest_weather_dependent_ventilation_zero_wind`
- [x] At least one proptest case passes `T_in == T_out` (|ΔT| = 0 < 1e-6 K) and asserts stack component is 0.0 — captured in `proptest_stack_infiltration_zero_when_temperatures_approx_equal` AND `proptest_weather_dependent_ventilation_zero_delta_t`
- [x] Monotonicity assertions use `prop_assume!` only where the precondition is a single-variable guard; the multi-variable ordering cases (`wind_hi ≥ wind_lo`, `height_hi ≥ height_lo`) are constructed by adding a non-negative offset (`wind_extra`, `height_extra`) so the inequality holds by construction. This satisfies the issue's "filter preconditions rather than failing" guidance while avoiding proptest's 1024-rejection limit.
- [x] No new dependencies added beyond the existing `proptest 1.5` dev-dependency

## Verification

```
cargo build --release --features ort                # OK
cargo test  --features ort --test ventilation_isolation   # 13 passed (4 deterministic + 9 proptest)
cargo test  --features ort --lib sim::ventilation        # 20 passed
cargo clippy --lib --features ort -- -D warnings         # clean for changed code
```

## Out of scope (per issue)

- ACH formula tuning (no parameter changes)
- Reference CSV regeneration
- `hvac/modes.rs` proptest
- `WeatherDependentVentilation::get_ach()` body changes

## Linked issues

- #1062 (proptest convention source)
- #1278 (wind + temperature wired into `wind_benefit()`)
- #1279 (dynamic h_tr_is)