### PR TITLE
feat(#1348): extend multi-zone to N zones

### DIFF
--- a/.agents/results/issue-E5-n-zone-conservation.py
+++ b/.agents/results/issue-E5-n-zone-conservation.py
@@ -1,0 +1,200 @@
+"""
+Issue #1348 / batch_id E5 — N-zone inter-zone thermal coupling conservation.
+
+Verifies the algebraic identity
+
+    Σ_i Σ_j h_tr_ij · (T_j − T_i) = 0   when h_tr_ij = h_tr_ji
+
+for N = 3, 5, 10. The Rust `MultiZoneAirflowNetwork::net_inter_zone_q` and
+the `validate_n_zone_network_conservation` validator must reproduce this
+identity to machine precision (|Σ q_iz| < 1e-6 W, the Issue #1348 acceptance
+criterion). This script mirrors the Python verification in
+`.agents/results/issue-1281-python-verification.py` style: it builds the
+same symmetric random conductance matrices the Rust unit tests probe, and
+asserts conservation numerically.
+
+Usage:
+    python .agents/results/issue-E5-n-zone-conservation.py
+
+Exit code 0 ⇒ conservation holds. Exit code 1 ⇒ conservation violated.
+"""
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass
+class ConservationResult:
+    n: int
+    symmetric: bool
+    net_inter_zone_q_w: float
+    tolerance_w: float
+    energy_delta_j: float
+
+    @property
+    def passed(self) -> bool:
+        return abs(self.net_inter_zone_q_w) < self.tolerance_w
+
+
+def build_fully_connected(n: int, h: float) -> np.ndarray:
+    m = np.full((n, n), h, dtype=np.float64)
+    np.fill_diagonal(m, 0.0)
+    return m
+
+
+def build_ring(n: int, h: float) -> np.ndarray:
+    m = np.zeros((n, n), dtype=np.float64)
+    if n < 2:
+        return m
+    for i in range(n):
+        j_next = (i + 1) % n
+        m[i, j_next] = h
+        m[j_next, i] = h
+    return m
+
+
+def net_inter_zone_q(h_tr: np.ndarray, temps: np.ndarray) -> float:
+    """Σ_i q_iz[i] = Σ_i Σ_j h_tr_ij · (T_j − T_i)."""
+    n = h_tr.shape[0]
+    total = 0.0
+    for i in range(n):
+        for j in range(n):
+            total += h_tr[i, j] * (temps[j] - temps[i])
+    return float(total)
+
+
+def energy_delta_j(C: np.ndarray, T_old: np.ndarray, T_new: np.ndarray, q_ext: np.ndarray, dt: float) -> float:
+    """Total energy change during one implicit step, J.
+
+    For a closed system with q_ext = 0 and Σ q_iz = 0, ΔE must be 0 J.
+    """
+    e_old = float(np.sum(C * T_old))
+    e_new = float(np.sum(C * T_new))
+    e_added = float(np.sum(q_ext) * dt)
+    return e_new - e_old - e_added
+
+
+def backward_euler_step(C: np.ndarray, h_tr: np.ndarray, T_old: np.ndarray, q_ext: np.ndarray, dt: float) -> np.ndarray:
+    n = C.shape[0]
+    M = np.zeros((n, n), dtype=np.float64)
+    b = np.zeros(n, dtype=np.float64)
+    for i in range(n):
+        row_sum = float(np.sum(h_tr[i, :]))
+        M[i, i] = C[i] / dt + row_sum
+        b[i] = C[i] / dt * T_old[i] + q_ext[i]
+        for j in range(n):
+            if i != j:
+                M[i, j] = -h_tr[i, j]
+    return np.linalg.solve(M, b)
+
+
+def main() -> int:
+    print("Issue #1348 — N-zone inter-zone conservation verification")
+    print("=" * 60)
+    print()
+    print(f"{'N':>3} {'topology':<28} {'|Σ q_iz| [W]':>16} {'ΔE [J]':>14} {'pass':>6}")
+    print("-" * 70)
+
+    results: list[ConservationResult] = []
+    tolerance_w = 1e-6
+
+    # N=3 ring (matches the Rust `three_zone_symmetric_conductance_conserves_energy` test)
+    n = 3
+    h_tr = build_ring(n, 50.0)
+    T_old = np.array([20.0, 25.0, 15.0])
+    net = net_inter_zone_q(h_tr, T_old)
+    results.append(ConservationResult(
+        n=n, symmetric=True,
+        net_inter_zone_q_w=net,
+        tolerance_w=tolerance_w,
+        energy_delta_j=0.0,  # net_inter_zone_q algebraic; no step needed
+    ))
+
+    # N=5 fully connected (matches `five_zone_symmetric_conductance_conserves_energy`)
+    n = 5
+    h_tr = build_fully_connected(n, 30.0)
+    T_old = np.array([18.0, 20.0, 22.0, 24.0, 26.0])
+    C = np.full(n, 1.0e6)
+    q_ext = np.zeros(n)
+    dt = 3600.0
+    T_new = backward_euler_step(C, h_tr, T_old, q_ext, dt)
+    net = net_inter_zone_q(h_tr, T_new)
+    de = energy_delta_j(C, T_old, T_new, q_ext, dt)
+    results.append(ConservationResult(
+        n=n, symmetric=True,
+        net_inter_zone_q_w=net,
+        tolerance_w=tolerance_w,
+        energy_delta_j=de,
+    ))
+
+    # N=10 fully connected (matches `ten_zone_symmetric_conductance_conserves_energy`)
+    n = 10
+    h_tr = build_fully_connected(n, 10.0)
+    T_old = np.array([15.0 + i for i in range(n)], dtype=np.float64)
+    C = np.full(n, 1.0e6)
+    q_ext = np.zeros(n)
+    T_new = backward_euler_step(C, h_tr, T_old, q_ext, dt)
+    net = net_inter_zone_q(h_tr, T_new)
+    de = energy_delta_j(C, T_old, T_new, q_ext, dt)
+    results.append(ConservationResult(
+        n=n, symmetric=True,
+        net_inter_zone_q_w=net,
+        tolerance_w=tolerance_w,
+        energy_delta_j=de,
+    ))
+
+    # N=3 ASYMMETRIC: must fail — sanity check the algebraic identity really is asymmetric-sensitive
+    n = 3
+    h_tr = np.array([
+        [0.0, 5.0, 1.0],
+        [3.0, 0.0, 7.0],  # h_01 != h_10 → asymmetric
+        [2.0, 4.0, 0.0],
+    ])
+    T_old = np.array([25.0, 20.0, 15.0])
+    net = net_inter_zone_q(h_tr, T_old)
+    results.append(ConservationResult(
+        n=n, symmetric=False,
+        net_inter_zone_q_w=net,
+        tolerance_w=tolerance_w,
+        energy_delta_j=0.0,
+    ))
+
+    for r in results:
+        marker = "✅" if r.passed else ("❌" if r.symmetric else "⚠️")
+        topology = ("fully connected" if r.symmetric and r.n >= 5
+                    else "ring" if r.symmetric
+                    else "ASYMMETRIC ring")
+        print(f"{r.n:>3} {topology:<28} {abs(r.net_inter_zone_q_w):>16.3e} "
+              f"{r.energy_delta_j:>14.3e} {marker:>6}")
+
+    print()
+
+    symmetric_results = [r for r in results if r.symmetric]
+    failed = [r for r in symmetric_results if not r.passed]
+    if failed:
+        print(f"❌ {len(failed)} symmetric network(s) violated conservation:")
+        for r in failed:
+            print(f"   N={r.n}: |Σ q_iz| = {abs(r.net_inter_zone_q_w):.3e} W > {r.tolerance_w:.0e} W")
+        return 1
+
+    print(f"✅ All {len(symmetric_results)} symmetric N-zone networks conserve energy:")
+    for r in symmetric_results:
+        print(f"   N={r.n}: |Σ q_iz| = {abs(r.net_inter_zone_q_w):.3e} W  (< {r.tolerance_w:.0e} W)")
+
+    # Asymmetric case: confirm |Σ q_iz| > 1e-3 (proves the algebraic identity is asymmetric-sensitive)
+    asym = next(r for r in results if not r.symmetric)
+    if abs(asym.net_inter_zone_q_w) <= 1e-3:
+        print(f"❌ Asymmetric N=3 unexpectedly conserved energy: |Σ q_iz| = "
+              f"{abs(asym.net_inter_zone_q_w):.3e} W")
+        return 1
+    print(f"✅ Asymmetric N=3 correctly detected: |Σ q_iz| = "
+          f"{abs(asym.net_inter_zone_q_w):.3e} W  (no false PASS)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -398,3 +398,10 @@ harness = true
 name = "case_900_determinism"
 path = "tests/case_900_determinism.rs"
 harness = true
+
+# Issue #1348 — N-zone inter-zone thermal coupling network (E5).
+# `cargo test -p fluxion multi_zone_n_zone_network` runs this target.
+[[test]]
+name = "multi_zone_n_zone_network"
+path = "tests/multi_zone_n_zone_network.rs"
+harness = true

--- a/src/cli/multi_zone.rs
+++ b/src/cli/multi_zone.rs
@@ -76,6 +76,35 @@ pub struct ValidateCommand {
     /// Output format (json, csv, or text)
     #[arg(short, long, default_value = "text")]
     pub format: String,
+
+    /// Run N-zone inter-zone network conservation check (Issue #1348).
+    /// Solves the N-zone air-node balance for the configured conductance
+    /// matrix and asserts |Σ q_iz[i]| < --n-zone-tolerance W.
+    /// Implicitly activates when --zones >= 3 is also supplied, but the
+    /// explicit flag is provided for clarity in CI.
+    #[arg(long)]
+    pub n_zone_network: bool,
+
+    /// Number of zones for the N-zone network solve (Issue #1348). Used
+    /// together with `--n-zone-network` to instantiate an N-zone
+    /// `MultiZoneAirflowNetwork` and probe the conservation identity. Must
+    /// be ≥ 2 (N=2 reproduces the legacy Case 960 path; N≥3 exercises the
+    /// generalized N-zone solver).
+    #[arg(long, default_value_t = 3)]
+    pub n_zone_zones: usize,
+
+    /// Inter-zone conductance (W/K) for the N-zone network probe. Defaults
+    /// to a fully-connected symmetric ring at 50 W/K — sufficient to
+    /// exercise the conservation identity. For non-trivial adjacency
+    /// patterns, supply the same JSON matrix used by `--config`.
+    #[arg(long, default_value_t = 50.0)]
+    pub n_zone_conductance: f64,
+
+    /// Tolerance for the N-zone network conservation check (Watts).
+    /// Default = 1e-6 W (Issue #1348 acceptance criterion: machine
+    /// epsilon for the f64 LU solve).
+    #[arg(long, default_value_t = 1e-6)]
+    pub n_zone_tolerance: f64,
 }
 
 /// Multi-zone performance testing command
@@ -225,14 +254,27 @@ pub fn execute_simulate_command(command: &SimulateCommand) -> Result<(), anyhow:
         }
     }
 
-    // Configure inter-zone conductance
+    // Configure inter-zone conductance. The `inter_zone_conductance` matrix
+    // is N×N where element `[i][j]` is the per-pair conductance (W/K) from
+    // zone i to zone j. The existing `ThermalModel::h_tr_iz` field is a
+    // flat per-zone vector storing the row sum `Σ_j h_tr_ij` (the total
+    // conductance leaving zone i). The original CLI wiring set
+    // `h_tr_iz[i] = conductance[i][j]` in a nested loop — which only stored
+    // one element per row and was effectively a no-op for N > 2. Sum each
+    // row of the matrix and store it as the per-zone total; this matches the
+    // existing Case-960 physics-pipeline semantics
+    // (`ThermalModel::h_tr_iz[i]` = total W/K out of zone i) while still
+    // surfacing the full N×N matrix in the simulation JSON output.
     for i in 0..model.num_zones {
-        for j in 0..model.num_zones {
-            if i < config.inter_zone_conductance.len() && j < config.inter_zone_conductance[i].len()
-            {
-                model.h_tr_iz.as_mut_slice()[i] = config.inter_zone_conductance[i][j];
+        let mut row_sum = 0.0_f64;
+        if i < config.inter_zone_conductance.len() {
+            for j in 0..model.num_zones {
+                if j < config.inter_zone_conductance[i].len() {
+                    row_sum += config.inter_zone_conductance[i][j];
+                }
             }
         }
+        model.h_tr_iz.as_mut_slice()[i] = row_sum;
     }
 
     // Create surrogate manager
@@ -394,6 +436,13 @@ pub fn execute_validate_command(command: &ValidateCommand) -> Result<(), anyhow:
         run_case_960_validation(command).map_err(|e| anyhow::anyhow!(e))?;
     }
 
+    if command.n_zone_network || command.n_zone_zones >= 3 {
+        println!("Running N-zone inter-zone network conservation check...");
+        let n = command.n_zone_zones.max(2);
+        run_n_zone_network_validation(n, command.n_zone_conductance, command.n_zone_tolerance)
+            .map_err(|e| anyhow::anyhow!(e))?;
+    }
+
     Ok(())
 }
 
@@ -452,7 +501,101 @@ pub struct EnergyConservationSummary {
     pub zone_residuals_w: Vec<f64>,
 }
 
-/// Execute ASHRAE 140 Case 960 (sunspace + back-zone) validation.
+/// Run the N-zone inter-zone network conservation check (Issue #1348).
+///
+/// Builds a fully-connected symmetric `MultiZoneAirflowNetwork` of `n` zones
+/// with the supplied per-pair conductance, runs one backward-Euler step at
+/// a neutral 1 h timestep with `q_ext = 0` and zone temperatures taken from
+/// a deterministic ramp (10 °C → 10 + 2·(n-1) °C), and verifies that
+/// `|Σ q_iz[i]| < tolerance_w` per the Issue #1348 acceptance criterion.
+///
+/// Reports the per-zone `q_iz` vector and the net residual so the CLI
+/// surfaces the algebraic identity check at machine precision. The legacy
+/// Case 960 2-zone wiring (door opening = 1.5 W/K) is unaffected — this
+/// helper instantiates a separate `MultiZoneAirflowNetwork` alongside the
+/// existing `ThermalModel` Case-960 plumbing.
+pub fn run_n_zone_network_validation(
+    n: usize,
+    conductance: f64,
+    tolerance_w: f64,
+) -> Result<(), String> {
+    use crate::sim::multi_zone_network::{MultiZoneAirflowNetwork, ZoneState};
+    use crate::validation::energy_balance::{EnergyBalanceValidator, ValidationError};
+
+    if conductance < 0.0 {
+        return Err(format!("conductance {conductance} W/K must be non-negative"));
+    }
+
+    // Build the fully-connected symmetric conductance matrix.
+    let mut pairs: Vec<(usize, usize, f64)> = Vec::new();
+    for i in 0..n {
+        for j in 0..n {
+            if i != j {
+                pairs.push((i, j, conductance));
+            }
+        }
+    }
+    let network = MultiZoneAirflowNetwork::from_adjacency_pairs(n, &pairs);
+    let report = network.conservation_report();
+
+    // Build the zone states and run one backward-Euler step with q_ext = 0.
+    let mut zones: Vec<ZoneState> = (0..n)
+        .map(|i| ZoneState::new(10.0 + 2.0 * i as f64, 1.0e6))
+        .collect();
+    let q_ext = vec![0.0_f64; n];
+    let result = network
+        .solve_step(&mut zones, &q_ext, 3600.0)
+        .map_err(|e| format!("N-zone network solve failed: {e}"))?;
+
+    // Validate the algebraic identity.
+    let validator = EnergyBalanceValidator::default();
+    let validation = validator.validate_n_zone_network_conservation(&result.q_iz_w, tolerance_w);
+
+    let _status = match &validation {
+        Ok(()) => "PASS",
+        Err(_) => "FAIL",
+    };
+
+    println!("N-Zone Inter-Zone Network Conservation (Issue #1348)");
+    println!("================================================");
+    println!("Number of zones:           {n}");
+    println!("Per-pair conductance:      {conductance:.3} W/K (fully connected symmetric)");
+    println!("Conductance matrix shape:  {n}x{n} ({})", if report.symmetric { "symmetric" } else { "ASYMMETRIC" });
+    println!("Net Σ q_iz (probe):        {:.3e} W", report.net_inter_zone_q_w);
+    println!("Tolerance:                 {tolerance_w:.0e} W");
+    println!();
+    println!("Post-step per-zone q_iz (W):");
+    for (i, q) in result.q_iz_w.iter().enumerate() {
+        println!("  Zone {}: q_iz = {:+.4e} W", i, q);
+    }
+    println!();
+    match &validation {
+        Ok(()) => println!(
+            "✅ Status: PASS (|Σ q_iz| = {:.3e} W ≤ tolerance {:.0e} W)",
+            result.net_w.abs(),
+            tolerance_w
+        ),
+        Err(ValidationError::InterZoneConservationViolation {
+            net_inter_zone_q_w,
+            ..
+        }) => println!(
+            "❌ Status: FAIL (|Σ q_iz| = {:.3e} W > tolerance {:.0e} W)",
+            net_inter_zone_q_w.abs(),
+            tolerance_w
+        ),
+        Err(other) => println!("❌ Status: FAIL ({other})"),
+    }
+
+    if validation.is_err() {
+        return Err(format!(
+            "N-zone inter-zone conservation failed: |Σ q_iz| = {:.3e} W > {:.0e} W",
+            result.net_w.abs(),
+            tolerance_w
+        ));
+    }
+
+    Ok(())
+}
 ///
 /// Builds the multi-zone thermal model from the canonical CaseSpec, verifies that
 /// the inter-zone conductance is wired correctly per the MULTI-01 fix

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -16,6 +16,7 @@ pub mod invariant_checker;
 pub mod lighting;
 pub mod multi_node_hvac_runner;
 pub mod multi_node_thermal;
+pub mod multi_zone_network;
 pub mod occupancy;
 pub mod per_surface_conduction;
 pub mod profiles;

--- a/src/sim/multi_zone_network.rs
+++ b/src/sim/multi_zone_network.rs
@@ -1,0 +1,681 @@
+//! N-zone airflow / thermal coupling network (Issue #1348).
+//!
+//! Generalizes the Case 960 two-zone pair into an arbitrary N-zone network.
+//! The conductance matrix `h_tr_iz: DMatrix<f64>` of shape (N, N) stores the
+//! per-pair inter-zone conductance `h_tr_iz[i, j]` (W/K) from zone `i` to
+//! zone `j`. The diagonal is conventionally zero (no self-coupling).
+//!
+//! ## Sign convention
+//! `q_iz[i] = Σ_j h_tr_iz[i, j] · (T[j] − T[i])` is the net heat flow INTO
+//! zone `i` from all other zones. Positive `q_iz[i]` means zone `i` is gaining
+//! heat from its neighbours.
+//!
+//! ## Energy conservation
+//! For a SYMMETRIC conductance matrix (`h_tr_iz[i, j] = h_tr_iz[j, i]`),
+//! the sum of all inter-zone transfers is identically zero — the algebraic
+//! identity
+//!
+//! ```text
+//! Σ_i q_iz[i] = Σ_i Σ_j h_tr_ij · (T_j − T_i)
+//!             = Σ_{i<j} (h_tr_ij − h_tr_ji) · (T_j − T_i)
+//!             = 0   when h_tr_ij = h_tr_ji.
+//! ```
+//!
+//! The backward-Euler step computes the post-step temperatures first, then
+//! derives `q_iz` from those — so the identity holds for the matrix `M`
+//! solve to within machine epsilon for the LU decomposition.
+//!
+//! ## Scope
+//! This module handles the **air-node** inter-zone coupling only. Per-zone
+//! surface conduction, thermal mass, solar gain, ventilation, and HVAC live
+//! in the per-zone thermal models. The N-zone network here is the "glue"
+//! that couples N otherwise-independent zones by their inter-zone heat flow.
+//! Pressure-driven airflow / CONTAM-style multi-zone air flow is explicitly
+//! **out of scope** per Issue #1348.
+
+use nalgebra::{DMatrix, DVector};
+
+/// Conservation diagnostic emitted by
+/// [`MultiZoneAirflowNetwork::conservation_report`]. Used by the CLI / report
+/// generators to surface the algebraic identity check
+/// `Σ q_iz[i] ≈ 0 W` (Issue #1348 acceptance criterion).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct MultiZoneNetworkReport {
+    /// Number of zones in the network.
+    pub n_zones: usize,
+    /// Whether the conductance matrix is symmetric within 1e-12.
+    pub symmetric: bool,
+    /// `Σ q_iz[i]` (W) for the probed temperature vector. For a symmetric
+    /// matrix this is O(1e-13) — at machine precision for the f64 LU solve.
+    pub net_inter_zone_q_w: f64,
+    /// Acceptance tolerance (W). The Issue #1348 criterion is 1e-6 W.
+    pub tolerance_w: f64,
+}
+
+/// Error type for N-zone network solve failures.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MultiZoneNetworkError {
+    /// The conductance matrix dimensions don't match the number of zones.
+    DimensionMismatch {
+        /// Number of zones supplied.
+        n_zones: usize,
+        /// Rows in the conductance matrix.
+        matrix_rows: usize,
+        /// Columns in the conductance matrix.
+        matrix_cols: usize,
+    },
+    /// The zone slice length doesn't match the matrix dimension.
+    ZoneCountMismatch {
+        /// Number of zones supplied.
+        n_zones: usize,
+        /// Length of the zone-state slice.
+        zone_slice_len: usize,
+    },
+    /// The system matrix is singular (LU decomposition failed).
+    SingularSystem,
+    /// A zone has non-positive thermal capacity.
+    InvalidHeatCapacity {
+        /// Zone index with invalid capacity.
+        zone: usize,
+        /// Observed capacity (J/K).
+        capacity: f64,
+    },
+    /// Timestep is non-positive.
+    InvalidTimestep(f64),
+}
+
+impl std::fmt::Display for MultiZoneNetworkError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DimensionMismatch { n_zones, matrix_rows, matrix_cols } => write!(
+                f,
+                "conductance matrix is {matrix_rows}x{matrix_cols} but expected {n_zones}x{n_zones}",
+            ),
+            Self::ZoneCountMismatch { n_zones, zone_slice_len } => write!(
+                f,
+                "zone slice length {zone_slice_len} does not match matrix size {n_zones}",
+            ),
+            Self::SingularSystem => write!(f, "system matrix is singular"),
+            Self::InvalidHeatCapacity { zone, capacity } => write!(
+                f,
+                "zone {zone} has non-positive heat capacity {capacity} J/K",
+            ),
+            Self::InvalidTimestep(dt) => write!(f, "timestep {dt} must be > 0"),
+        }
+    }
+}
+
+impl std::error::Error for MultiZoneNetworkError {}
+
+/// Per-zone state consumed by `MultiZoneAirflowNetwork::solve_step`.
+///
+/// The full `ThermalModel` carries far more state (surface heat fluxes,
+/// thermal mass, HVAC equipment, etc.); for the N-zone inter-zone solve the
+/// only quantities that matter are the air-node temperature and the air-node
+/// heat capacity. The zone temperature is read AND mutated by `solve_step` so
+/// the caller doesn't need to thread `T_old` and `T_new` through two separate
+/// buffers.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ZoneState {
+    /// Air-node temperature [°C]. Read at the start of the step, written at
+    /// the end of the step.
+    pub temperature: f64,
+    /// Air-node thermal capacity C_air = ρ·cp·V_zone [J/K]. Must be > 0.
+    pub heat_capacity: f64,
+}
+
+impl ZoneState {
+    /// Build a zone state with the given temperature and heat capacity.
+    pub fn new(temperature: f64, heat_capacity: f64) -> Self {
+        Self { temperature, heat_capacity }
+    }
+}
+
+/// Per-zone inter-zone heat transfer result.
+#[derive(Debug, Clone, PartialEq)]
+pub struct InterZoneResult {
+    /// `q_iz[i]` = net heat flow INTO zone `i` from all other zones [W].
+    /// Sign convention: positive = heat gained by zone `i`.
+    pub q_iz_w: Vec<f64>,
+    /// Net system inter-zone transfer `Σ q_iz[i]` [W]. For a symmetric
+    /// conductance matrix and any set of temperatures, this must be ≤ 1e-6 W
+    /// in absolute value (Issue #1348 acceptance criterion).
+    pub net_w: f64,
+    /// Post-step zone temperatures [°C].
+    pub temperatures_after: Vec<f64>,
+}
+
+/// N-zone inter-zone airflow / thermal coupling network.
+///
+/// Wraps the symmetric N×N conductance matrix `h_tr_iz` and provides a
+/// backward-Euler implicit step that solves the air-node heat balance for
+/// all zones simultaneously. The solve conserves energy to within machine
+/// precision for symmetric `h_tr_iz` (see module docs).
+#[derive(Debug, Clone)]
+pub struct MultiZoneAirflowNetwork {
+    h_tr_iz: DMatrix<f64>,
+}
+
+impl MultiZoneAirflowNetwork {
+    /// Build a network from a square conductance matrix. The matrix is
+    /// copied; subsequent mutations to `h_tr_iz` by the caller do not affect
+    /// this network.
+    ///
+    /// # Errors
+    /// Returns `DimensionMismatch` if `h_tr_iz` is not square, or
+    /// `InvalidHeatCapacity` later at `solve_step` time.
+    pub fn from_matrix(h_tr_iz: DMatrix<f64>) -> Self {
+        debug_assert!(
+            h_tr_iz.nrows() == h_tr_iz.ncols(),
+            "MultiZoneAirflowNetwork::from_matrix: matrix must be square ({}x{})",
+            h_tr_iz.nrows(),
+            h_tr_iz.ncols()
+        );
+        Self { h_tr_iz }
+    }
+
+    /// Build a network from an adjacency list of `(i, j, h_tr_ij)` triples
+    /// (W/K). Both `h_tr_ij` and `h_tr_ji` are stored — pass them explicitly
+    /// for asymmetric conductances. Missing pairs are treated as zero
+    /// conductance.
+    ///
+    /// # Errors
+    /// Returns `DimensionMismatch` if `n` doesn't match later, or panics on
+    /// out-of-range indices.
+    pub fn from_adjacency_pairs(n: usize, pairs: &[(usize, usize, f64)]) -> Self {
+        let mut m = DMatrix::<f64>::zeros(n, n);
+        for &(i, j, h) in pairs {
+            assert!(i < n && j < n, "pair ({i}, {j}) out of range for {n}x{n}");
+            m[(i, j)] = h;
+        }
+        Self::from_matrix(m)
+    }
+
+    /// Number of zones in this network.
+    pub fn num_zones(&self) -> usize {
+        self.h_tr_iz.nrows()
+    }
+
+    /// Borrow the underlying conductance matrix.
+    pub fn conductance_matrix(&self) -> &DMatrix<f64> {
+        &self.h_tr_iz
+    }
+
+    /// Per-zone outgoing conductance sum `Σ_j h_tr_iz[i, j]` (W/K). This is
+    /// the value stored in `model.h_tr_iz[i]` (flat per-zone total) for
+    /// backward-compatible integration with the existing Case-960
+    /// `ThermalModel` air-node solver, which uses the flat per-zone total
+    /// rather than the full N×N matrix.
+    pub fn per_zone_conductance(&self) -> Vec<f64> {
+        let n = self.h_tr_iz.nrows();
+        (0..n).map(|i| (0..n).map(|j| self.h_tr_iz[(i, j)]).sum()).collect()
+    }
+
+    /// Compute the net inter-zone transfer `Σ q_iz[i]` (W) for the supplied
+    /// temperature vector without running a step. Useful for the energy
+    /// conservation check and for diagnostic output.
+    ///
+    /// For a symmetric conductance matrix and any temperature vector this
+    /// returns 0.0 to machine precision (algebraic identity).
+    pub fn net_inter_zone_q(&self, temps: &[f64]) -> f64 {
+        let n = self.h_tr_iz.nrows();
+        debug_assert_eq!(temps.len(), n);
+        let mut net = 0.0_f64;
+        for i in 0..n {
+            for j in 0..n {
+                net += self.h_tr_iz[(i, j)] * (temps[j] - temps[i]);
+            }
+        }
+        net
+    }
+
+    /// Run one backward-Euler step on the air-node heat balance.
+    ///
+    /// For each zone `i`, the air-node balance is
+    ///
+    /// ```text
+    /// C_i/dt · (T_new_i − T_old_i) = q_ext_i + Σ_j h_tr_ij · (T_new_j − T_new_i)
+    /// ```
+    ///
+    /// Rearranging yields the linear system `M · T_new = b` with
+    ///
+    /// ```text
+    /// M_ii = C_i/dt + Σ_j h_tr_ij
+    /// M_ij = −h_tr_ij       (i ≠ j)
+    /// b_i  = C_i/dt · T_old_i + q_ext_i
+    /// ```
+    ///
+    /// The post-step temperatures `T_new` are obtained by an LU solve
+    /// (`nalgebra::DMatrix::lu`). Per-zone inter-zone transfer is then
+    /// `q_iz[i] = Σ_j h_tr_ij · (T_new_j − T_new_i)`, written back into the
+    /// zone's `temperature` field. `q_ext` defaults to zero (no external
+    /// HVAC / solar / conduction at the air node — those live in the per-zone
+    /// thermal model and would be added to `q_ext` by the integration layer).
+    ///
+    /// # Errors
+    /// - `ZoneCountMismatch` if `zones.len() != num_zones()`.
+    /// - `InvalidHeatCapacity` if any zone has `heat_capacity ≤ 0`.
+    /// - `InvalidTimestep` if `dt ≤ 0`.
+    /// - `SingularSystem` if the LU decomposition cannot solve the system
+    ///   (mathematically impossible for a positive-definite `h_tr_iz` and
+    ///   positive `C`, but flagged defensively for malformed input).
+    pub fn solve_step(
+        &self,
+        zones: &mut [ZoneState],
+        q_ext: &[f64],
+        dt: f64,
+    ) -> Result<InterZoneResult, MultiZoneNetworkError> {
+        let n = self.num_zones();
+        if zones.len() != n {
+            return Err(MultiZoneNetworkError::ZoneCountMismatch {
+                n_zones: n,
+                zone_slice_len: zones.len(),
+            });
+        }
+        if q_ext.len() != n {
+            return Err(MultiZoneNetworkError::ZoneCountMismatch {
+                n_zones: n,
+                zone_slice_len: q_ext.len(),
+            });
+        }
+        if dt <= 0.0 || !dt.is_finite() {
+            return Err(MultiZoneNetworkError::InvalidTimestep(dt));
+        }
+        for (i, z) in zones.iter().enumerate() {
+            if z.heat_capacity <= 0.0 {
+                return Err(MultiZoneNetworkError::InvalidHeatCapacity {
+                    zone: i,
+                    capacity: z.heat_capacity,
+                },
+                );
+            }
+        }
+
+        // Build the backward-Euler system: M_ii = C_i/dt + Σ_j h_tr_ij,
+        // M_ij = -h_tr_ij for i != j.
+        let mut m = DMatrix::<f64>::zeros(n, n);
+        let mut b = DVector::<f64>::zeros(n);
+        let t_old: Vec<f64> = zones.iter().map(|z| z.temperature).collect();
+        for i in 0..n {
+            let row_sum: f64 = (0..n).map(|j| self.h_tr_iz[(i, j)]).sum();
+            m[(i, i)] = zones[i].heat_capacity / dt + row_sum;
+            b[i] = zones[i].heat_capacity / dt * t_old[i] + q_ext[i];
+            for j in 0..n {
+                if i != j {
+                    m[(i, j)] = -self.h_tr_iz[(i, j)];
+                }
+            }
+        }
+
+        let lu = m.clone().lu();
+        let t_new = lu
+            .solve(&b)
+            .ok_or(MultiZoneNetworkError::SingularSystem)?;
+
+        // Compute q_iz from the post-step temperatures.
+        let mut q_iz = vec![0.0_f64; n];
+        let mut net = 0.0_f64;
+        for i in 0..n {
+            let mut qi = 0.0_f64;
+            for j in 0..n {
+                qi += self.h_tr_iz[(i, j)] * (t_new[j] - t_new[i]);
+            }
+            q_iz[i] = qi;
+            net += qi;
+            zones[i].temperature = t_new[i];
+        }
+
+        Ok(InterZoneResult {
+            q_iz_w: q_iz,
+            net_w: net,
+            temperatures_after: t_old.into_iter().zip(t_new.iter()).map(|(_, &tn)| tn).collect(),
+        })
+    }
+
+    /// Generate a `MultiZoneNetworkReport` summarizing the conservation
+    /// check across a sequence of (symmetric) conductance configurations.
+    /// Used by the validation CLI to emit machine-readable output.
+    pub fn conservation_report(&self) -> MultiZoneNetworkReport {
+        // The algebraic identity is exact; numerical LU noise gives O(1e-13)
+        // for symmetric matrices. We probe with a fixed random temperature
+        // vector so the report is reproducible.
+        let n = self.num_zones();
+        // Deterministic temperature ramp 10..30.
+        let temps: Vec<f64> = (0..n).map(|i| 10.0 + 2.0 * i as f64).collect();
+        let net = self.net_inter_zone_q(&temps);
+        let symmetric = is_symmetric(&self.h_tr_iz, 1e-12);
+        MultiZoneNetworkReport {
+            n_zones: n,
+            symmetric,
+            net_inter_zone_q_w: net,
+            tolerance_w: 1e-6,
+        }
+    }
+}
+
+/// Returns `true` if `m` is symmetric within `tol`.
+fn is_symmetric(m: &DMatrix<f64>, tol: f64) -> bool {
+    if m.nrows() != m.ncols() {
+        return false;
+    }
+    for i in 0..m.nrows() {
+        for j in (i + 1)..m.ncols() {
+            if (m[(i, j)] - m[(j, i)]).abs() > tol {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: build a symmetric ring conductance matrix where each zone is
+    /// coupled only to its neighbour (`h` W/K). For a ring of N zones, the
+    /// matrix has `h` on the two off-diagonals per row, 0 elsewhere.
+    fn ring_conductance(n: usize, h: f64) -> DMatrix<f64> {
+        let mut m = DMatrix::<f64>::zeros(n, n);
+        if n < 2 {
+            return m;
+        }
+        for i in 0..n {
+            let j_next = (i + 1) % n;
+            m[(i, j_next)] = h;
+            m[(j_next, i)] = h;
+        }
+        m
+    }
+
+    /// Helper: build a fully-connected symmetric conductance matrix where
+    /// every zone pair has conductance `h` W/K.
+    fn fully_connected_conductance(n: usize, h: f64) -> DMatrix<f64> {
+        let mut m = DMatrix::<f64>::zeros(n, n);
+        for i in 0..n {
+            for j in 0..n {
+                if i != j {
+                    m[(i, j)] = h;
+                }
+            }
+        }
+        m
+    }
+
+    /// Acceptance criterion #1 (Issue #1348):
+    /// N=3 symmetric 3×3 conductance matrix, sum of all inter-zone transfers
+    /// equals 0 W within 1e-6 W tolerance (machine precision for f64 sum).
+    #[test]
+    fn three_zone_symmetric_conductance_conserves_energy() {
+        let h = ring_conductance(3, 50.0);
+        let net = MultiZoneAirflowNetwork::from_matrix(h.clone())
+            .net_inter_zone_q(&[20.0, 25.0, 15.0]);
+        assert!(
+            net.abs() < 1e-6,
+            "N=3 symmetric network must conserve energy; got |Σ q_iz| = {net:.3e} W"
+        );
+    }
+
+    /// Acceptance criterion #2 (Issue #1348):
+    /// Same identity at N=5 round-trip (backward-Euler solve and report).
+    #[test]
+    fn five_zone_symmetric_conductance_conserves_energy() {
+        let h = fully_connected_conductance(5, 30.0);
+        let mut zones: Vec<ZoneState> = (0..5)
+            .map(|i| ZoneState::new(18.0 + 2.0 * i as f64, 1.0e6))
+            .collect();
+        let q_ext = vec![0.0; 5];
+        let dt = 3600.0;
+        let net = MultiZoneAirflowNetwork::from_matrix(h)
+            .solve_step(&mut zones, &q_ext, dt)
+            .expect("5-zone solve")
+            .net_w;
+        assert!(
+            net.abs() < 1e-6,
+            "N=5 symmetric network must conserve energy; got |Σ q_iz| = {net:.3e} W"
+        );
+    }
+
+    /// Acceptance criterion #2 (Issue #1348): N=10 round-trip.
+    #[test]
+    fn ten_zone_symmetric_conductance_conserves_energy() {
+        let h = fully_connected_conductance(10, 10.0);
+        let mut zones: Vec<ZoneState> = (0..10)
+            .map(|i| ZoneState::new(15.0 + i as f64, 1.0e6))
+            .collect();
+        let q_ext = vec![0.0; 10];
+        let dt = 3600.0;
+        let net = MultiZoneAirflowNetwork::from_matrix(h)
+            .solve_step(&mut zones, &q_ext, dt)
+            .expect("10-zone solve")
+            .net_w;
+        assert!(
+            net.abs() < 1e-6,
+            "N=10 symmetric network must conserve energy; got |Σ q_iz| = {net:.3e} W"
+        );
+    }
+
+    /// Backward-compatibility: Case 960 two-zone (door opening = 1.5 W/K).
+    /// The existing `inter_zone_tolerance = 1.0 W` in `EnergyBalanceValidator`
+    /// must continue to pass (i.e. the 2-zone pair produces a meaningful,
+    /// non-pathological q_iz).
+    #[test]
+    fn two_zone_case960_backward_compatible() {
+        let h = DMatrix::from_row_slice(2, 2, &[0.0, 1.5, 1.5, 0.0]);
+        let mut zones = vec![
+            ZoneState::new(20.0, 2.0e6),  // Living (back-zone)
+            ZoneState::new(8.0, 5.0e5),   // Sunspace
+        ];
+        let q_ext = vec![0.0, 0.0];
+        let result = MultiZoneAirflowNetwork::from_matrix(h)
+            .solve_step(&mut zones, &q_ext, 3600.0)
+            .expect("2-zone solve");
+
+        // Zone 0 (living, warmer) loses heat; zone 1 (sunspace, cooler) gains.
+        // Sign: q_iz[0] = h · (T_1 − T_0) < 0; q_iz[1] = h · (T_0 − T_1) > 0.
+        assert!(
+            result.q_iz_w[0] < 0.0,
+            "warm zone must lose heat: q_iz[0] = {}",
+            result.q_iz_w[0]
+        );
+        assert!(
+            result.q_iz_w[1] > 0.0,
+            "cool zone must gain heat: q_iz[1] = {}",
+            result.q_iz_w[1]
+        );
+        assert!(
+            (result.q_iz_w[0] + result.q_iz_w[1]).abs() < 1.0,
+            "Case 960 inter-zone transfer must be within the legacy 1.0 W tolerance; \
+             got |q_iz[0] + q_iz[1]| = {} W",
+            (result.q_iz_w[0] + result.q_iz_w[1]).abs()
+        );
+        assert_eq!(result.net_w, 0.0);
+    }
+
+    /// Acceptance criterion #1 (Issue #1348): performance budget — 3-zone
+    /// network solves in < 1 ms on a single core (interactive CLI budget).
+    #[test]
+    fn three_zone_solves_under_one_millisecond() {
+        let h = fully_connected_conductance(3, 50.0);
+        let mut zones = vec![
+            ZoneState::new(22.0, 1.0e6),
+            ZoneState::new(20.0, 1.0e6),
+            ZoneState::new(18.0, 1.0e6),
+        ];
+        let q_ext = vec![0.0; 3];
+        let network = MultiZoneAirflowNetwork::from_matrix(h);
+
+        // Warm up once.
+        let _ = network.solve_step(&mut zones, &q_ext, 3600.0).unwrap();
+
+        // Measure 1000 solves; report per-solve average.
+        let iters = 1000_usize;
+        let start = std::time::Instant::now();
+        for _ in 0..iters {
+            let _ = network.solve_step(&mut zones, &q_ext, 3600.0).unwrap();
+        }
+        let elapsed = start.elapsed();
+        let per_step_us = elapsed.as_micros() as f64 / iters as f64;
+        assert!(
+            per_step_us < 1000.0,
+            "N=3 must solve in < 1 ms; got {per_step_us:.1} µs/solve"
+        );
+    }
+
+    /// Dimension-mismatch error is surfaced when the zone count doesn't
+    /// match the matrix size.
+    #[test]
+    fn solve_step_rejects_zone_count_mismatch() {
+        let h = fully_connected_conductance(3, 50.0);
+        let mut zones = vec![ZoneState::new(20.0, 1.0e6); 2]; // wrong length
+        let q_ext = vec![0.0; 3]; // matches matrix
+        let result = MultiZoneAirflowNetwork::from_matrix(h)
+            .solve_step(&mut zones, &q_ext, 3600.0);
+        assert!(matches!(
+            result,
+            Err(MultiZoneNetworkError::ZoneCountMismatch { .. })
+        ));
+    }
+
+    /// Non-positive timestep is rejected.
+    #[test]
+    fn solve_step_rejects_zero_timestep() {
+        let h = fully_connected_conductance(2, 50.0);
+        let mut zones = vec![ZoneState::new(20.0, 1.0e6); 2];
+        let q_ext = vec![0.0; 2];
+        let result = MultiZoneAirflowNetwork::from_matrix(h)
+            .solve_step(&mut zones, &q_ext, 0.0);
+        assert!(matches!(
+            result,
+            Err(MultiZoneNetworkError::InvalidTimestep(_))
+        ));
+    }
+
+    /// Non-positive heat capacity is rejected.
+    #[test]
+    fn solve_step_rejects_nonpositive_heat_capacity() {
+        let h = fully_connected_conductance(2, 50.0);
+        let mut zones = vec![ZoneState::new(20.0, 0.0), ZoneState::new(20.0, 1.0)];
+        let q_ext = vec![0.0; 2];
+        let result = MultiZoneAirflowNetwork::from_matrix(h)
+            .solve_step(&mut zones, &q_ext, 3600.0);
+        assert!(matches!(
+            result,
+            Err(MultiZoneNetworkError::InvalidHeatCapacity { .. })
+        ));
+    }
+
+    /// Asymmetric conductance violates conservation (sanity check that the
+    /// `|Σ q_iz| < 1e-6 W` acceptance criterion really is testing
+    /// symmetry, not numerical noise).
+    #[test]
+    fn asymmetric_conductance_breaks_conservation() {
+        let m = DMatrix::from_row_slice(3, 3, &[
+            0.0, 5.0, 1.0,
+            3.0, 0.0, 7.0, // h_10 != h_01 — asymmetric
+            2.0, 4.0, 0.0,
+        ]);
+        let net = MultiZoneAirflowNetwork::from_matrix(m)
+            .net_inter_zone_q(&[25.0, 20.0, 15.0]);
+        assert!(
+            net.abs() > 1e-3,
+            "asymmetric network should NOT conserve energy; got |Σ q_iz| = {net:.3e} W"
+        );
+    }
+
+    /// `from_adjacency_pairs` constructs the same matrix as `from_matrix` for
+    /// a fully-connected symmetric configuration.
+    #[test]
+    fn from_adjacency_pairs_matches_from_matrix() {
+        let n = 4_usize;
+        let pairs: Vec<(usize, usize, f64)> = (0..n)
+            .flat_map(|i| (0..n).filter_map(move |j| if i != j { Some((i, j, 12.5)) } else { None }))
+            .collect();
+        let from_pairs = MultiZoneAirflowNetwork::from_adjacency_pairs(n, &pairs);
+        let from_matrix =
+            MultiZoneAirflowNetwork::from_matrix(fully_connected_conductance(n, 12.5));
+        assert_eq!(
+            from_pairs.conductance_matrix(),
+            from_matrix.conductance_matrix()
+        );
+    }
+
+    /// `per_zone_conductance` returns the row sums of the N×N matrix — the
+    /// backward-compatible flat vector for the existing `model.h_tr_iz`
+    /// field used by the Case 960 physics pipeline.
+    #[test]
+    fn per_zone_conductance_is_row_sum_of_matrix() {
+        let m = DMatrix::from_row_slice(3, 3, &[
+            0.0, 5.0, 1.0,
+            5.0, 0.0, 7.0,
+            1.0, 7.0, 0.0,
+        ]);
+        let row_sums = MultiZoneAirflowNetwork::from_matrix(m).per_zone_conductance();
+        assert_eq!(row_sums, vec![6.0, 12.0, 8.0]);
+    }
+
+    /// `solve_step` mutates zone temperatures in place to the post-step
+    /// values — caller doesn't have to thread a separate output buffer.
+    /// Uses a smaller heat capacity so a single 1 h step produces a
+    /// detectable ΔT (otherwise 1 MJ/K vs 50 W/K over 1 h moves ~0.005 K,
+    /// which trips floating-point equality on the floor-direction check).
+    #[test]
+    fn solve_step_mutates_zone_temperatures_in_place() {
+        let h = fully_connected_conductance(2, 50.0);
+        let mut zones = vec![ZoneState::new(20.0, 1.0e4), ZoneState::new(15.0, 1.0e4)];
+        let t_before: Vec<f64> = zones.iter().map(|z| z.temperature).collect();
+        let result = MultiZoneAirflowNetwork::from_matrix(h)
+            .solve_step(&mut zones, &[0.0, 0.0], 3600.0)
+            .expect("2-zone solve");
+        assert_eq!(zones.len(), 2);
+        // Energy conservation (C_0 = C_1) ⇒ |ΔT_0| = |ΔT_1|, and zone 0
+        // (warmer) cools while zone 1 (cooler) warms.
+        assert!(
+            zones[0].temperature < t_before[0],
+            "warmer zone 0 should cool: {} -> {}",
+            t_before[0],
+            zones[0].temperature
+        );
+        assert!(
+            zones[1].temperature > t_before[1],
+            "cooler zone 1 should warm: {} -> {}",
+            t_before[1],
+            zones[1].temperature
+        );
+        // The post-step temperatures must match what `solve_step` reported.
+        assert_eq!(zones[0].temperature, result.temperatures_after[0]);
+        assert_eq!(zones[1].temperature, result.temperatures_after[1]);
+        // The post-step temperatures must be between the two initial values
+        // (no overshoot in a backward-Euler solve of a stable system).
+        assert!(zones[0].temperature >= t_before[1]);
+        assert!(zones[1].temperature <= t_before[0]);
+    }
+
+    /// `conservation_report` flags an asymmetric matrix as non-symmetric
+    /// and emits the (non-zero) `net_inter_zone_q_w` value.
+    #[test]
+    fn conservation_report_flags_asymmetry() {
+        let m = DMatrix::from_row_slice(2, 2, &[0.0, 5.0, 3.0, 0.0]);
+        let report = MultiZoneAirflowNetwork::from_matrix(m).conservation_report();
+        assert_eq!(report.n_zones, 2);
+        assert!(!report.symmetric);
+        assert!(report.net_inter_zone_q_w.abs() > 1e-3);
+    }
+
+    /// `conservation_report` flags a symmetric matrix as symmetric and
+    /// emits a net residual ≤ 1e-6 W (the machine-precision floor for the
+    /// identity check).
+    #[test]
+    fn conservation_report_flags_symmetric() {
+        let h = fully_connected_conductance(4, 25.0);
+        let report = MultiZoneAirflowNetwork::from_matrix(h).conservation_report();
+        assert_eq!(report.n_zones, 4);
+        assert!(report.symmetric);
+        assert!(
+            report.net_inter_zone_q_w.abs() < 1e-6,
+            "symmetric matrix must report net ≈ 0; got {} W",
+            report.net_inter_zone_q_w.abs()
+        );
+        assert_eq!(report.tolerance_w, 1e-6);
+    }
+}

--- a/src/validation/energy_balance.rs
+++ b/src/validation/energy_balance.rs
@@ -32,6 +32,16 @@ pub enum ValidationError {
         expected_heat_flow: f64,
         actual_heat_flow: f64,
     },
+    /// N-zone inter-zone conservation violation (Issue #1348).
+    /// For a symmetric conductance matrix the algebraic identity
+    /// `Σ_i q_iz[i] = 0 W` must hold within machine precision. If the
+    /// validator reports a non-trivial residual, the matrix is asymmetric
+    /// or the network solve lost energy.
+    InterZoneConservationViolation {
+        net_inter_zone_q_w: f64,
+        zone_residuals_w: Vec<f64>,
+        tolerance_w: f64,
+    },
     /// Per-zone residual breakdown from the strict multi-zone invariant check.
     /// `residual_w` is the total system residual in Watts
     /// (signed: heat_in - heat_out - dE/dt, consistent with `InvariantChecker`).
@@ -72,6 +82,21 @@ impl std::fmt::Display for ValidationError {
                 "Inter-zone imbalance between zone {} and {}: expected {:.2} W, got {:.2} W",
                 zone_from, zone_to, expected_heat_flow, actual_heat_flow
             ),
+            ValidationError::InterZoneConservationViolation {
+                net_inter_zone_q_w,
+                zone_residuals_w,
+                tolerance_w,
+            } => {
+                writeln!(
+                    f,
+                    "N-zone inter-zone conservation violation: Σ q_iz = {:.3e} W (tolerance {:.0e} W)",
+                    net_inter_zone_q_w, tolerance_w
+                )?;
+                for (i, z) in zone_residuals_w.iter().enumerate() {
+                    writeln!(f, "  Zone {} q_iz: {:.3e} W", i, z)?;
+                }
+                Ok(())
+            }
             ValidationError::MultiZoneConservationViolation {
                 residual_w,
                 zone_residuals_w,
@@ -461,6 +486,45 @@ impl EnergyBalanceValidator {
 
         report_text
     }
+
+    /// Validate N-zone inter-zone heat transfer conservation (Issue #1348).
+    ///
+    /// For a SYMMETRIC conductance matrix `h_tr_iz`, the algebraic identity
+    /// `Σ_i Σ_j h_tr_ij · (T_j − T_i) = 0` holds to machine precision for any
+    /// temperature vector. This validator checks that the supplied
+    /// `q_iz_per_zone_w` vector sums to within `tolerance_w` of zero — the
+    /// Issue #1348 acceptance criterion.
+    ///
+    /// Use the tolerance you'd apply for the actual application: the strict
+    /// Issue #1348 budget is `1e-6` W (machine epsilon for the f64 LU solve
+    /// in `MultiZoneAirflowNetwork::solve_step`). The legacy Case 960 2-zone
+    /// tolerance is `1.0` W (see `inter_zone_tolerance` in the validator
+    /// default) and applies to a different quantity (per-pair imbalance),
+    /// so it's preserved unchanged.
+    ///
+    /// # Arguments
+    /// * `q_iz_per_zone_w` - Per-zone inter-zone heat transfer vector [W]
+    /// * `tolerance_w` - Acceptable |Σ q_iz[i]| in Watts
+    ///
+    /// # Returns
+    /// `Ok(())` if `|Σ q_iz[i]| ≤ tolerance_w`. Otherwise
+    /// [`ValidationError::InterZoneConservationViolation`] (Issue #1348) with
+    /// the signed sum, the per-zone breakdown, and the tolerance.
+    pub fn validate_n_zone_network_conservation(
+        &self,
+        q_iz_per_zone_w: &[f64],
+        tolerance_w: f64,
+    ) -> Result<(), ValidationError> {
+        let net_w: f64 = q_iz_per_zone_w.iter().sum();
+        if net_w.abs() > tolerance_w {
+            return Err(ValidationError::InterZoneConservationViolation {
+                net_inter_zone_q_w: net_w,
+                zone_residuals_w: q_iz_per_zone_w.to_vec(),
+                tolerance_w,
+            });
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -624,5 +688,45 @@ mod tests {
             "Hand-balanced 2-zone stub must pass; got {:?}",
             result
         );
+    }
+
+    /// Issue #1348 acceptance criterion: for a symmetric N-zone network the
+    /// validator must accept |Σ q_iz[i]| < 1e-6 W. Construct the per-zone
+    /// vector analytically: with symmetric h_tr_ij = h_tr_ji, the
+    /// algebraic identity guarantees Σ q_iz = 0 exactly; we synthesise a
+    /// numerically-zero residual by adding q_iz[i] and −q_iz[i] in pairs.
+    #[test]
+    fn n_zone_network_conservation_passes_for_symmetric_matrix() {
+        let q_iz = vec![12.5_f64, -7.3_f64, -5.2_f64]; // sums to 0 exactly
+        let validator = EnergyBalanceValidator::new(1.0, 1.0);
+        assert!(
+            validator
+                .validate_n_zone_network_conservation(&q_iz, 1e-6)
+                .is_ok(),
+            "Σ q_iz = 0 must pass with tolerance 1e-6 W"
+        );
+    }
+
+    /// Issue #1348 acceptance criterion: an asymmetric residual that
+    /// exceeds the 1e-6 W tolerance must surface as
+    /// `InterZoneConservationViolation` carrying the signed sum and
+    /// per-zone breakdown.
+    #[test]
+    fn n_zone_network_conservation_rejects_asymmetric_residual() {
+        let q_iz = vec![10.0_f64, -5.0_f64, 0.0_f64]; // sums to 5 W (asymmetric)
+        let validator = EnergyBalanceValidator::new(1.0, 1.0);
+        let result = validator.validate_n_zone_network_conservation(&q_iz, 1e-6);
+        match result {
+            Err(ValidationError::InterZoneConservationViolation {
+                net_inter_zone_q_w,
+                zone_residuals_w,
+                tolerance_w,
+            }) => {
+                assert!((net_inter_zone_q_w - 5.0).abs() < 1e-12);
+                assert_eq!(zone_residuals_w, vec![10.0, -5.0, 0.0]);
+                assert!((tolerance_w - 1e-6).abs() < 1e-12);
+            }
+            other => panic!("expected InterZoneConservationViolation, got {:?}", other),
+        }
     }
 }

--- a/tests/multi_zone_n_zone_network.rs
+++ b/tests/multi_zone_n_zone_network.rs
@@ -1,0 +1,269 @@
+//! Integration test for the N-zone inter-zone thermal coupling network.
+//!
+//! Acceptance criteria (Issue #1348):
+//!   1. N-zone network solves 3 zones in <1 ms on a single core.
+//!   2. Energy conservation: |Σ inter-zone transfers| < 1e-6 W for N=3, 5, 10.
+//!   3. `MultiZoneConfig::zones` accepts ≥3 zones without panic and produces
+//!      non-zero inter-zone transfer when zones differ in temperature.
+//!   4. Regression: Case 960 two-zone wiring still passes
+//!      `inter_zone_tolerance = 1.0 W`.
+//!   5. `cargo test -p fluxion multi_zone_n_zone_network` passes including
+//!      the 3-zone and 5-zone round-trip.
+//!
+//! These tests call the public `fluxion::sim::multi_zone_network` API and
+//! the `fluxion::cli::multi_zone::MultiZoneConfig` wiring path directly so
+//! the issue's acceptance criterion #5 (`cargo test -p fluxion
+//! multi_zone_n_zone_network`) is satisfied.
+
+use fluxion::cli::multi_zone::MultiZoneConfig;
+use fluxion::sim::multi_zone_network::{MultiZoneAirflowNetwork, ZoneState};
+use fluxion::validation::energy_balance::EnergyBalanceValidator;
+use std::time::Instant;
+
+/// Issue #1348 acceptance criterion #2: 3-zone symmetric network
+/// must conserve energy to within 1e-6 W (machine precision).
+#[test]
+fn multi_zone_n_zone_network_3_zone_conservation() {
+    let n = 3_usize;
+    let mut pairs: Vec<(usize, usize, f64)> = Vec::new();
+    for i in 0..n {
+        for j in 0..n {
+            if i != j {
+                pairs.push((i, j, 50.0));
+            }
+        }
+    }
+    let network = MultiZoneAirflowNetwork::from_adjacency_pairs(n, &pairs);
+    let mut zones = vec![
+        ZoneState::new(20.0, 1.0e6),
+        ZoneState::new(25.0, 1.0e6),
+        ZoneState::new(15.0, 1.0e6),
+    ];
+    let q_ext = vec![0.0; n];
+    let result = network
+        .solve_step(&mut zones, &q_ext, 3600.0)
+        .expect("3-zone solve");
+
+    assert!(
+        result.net_w.abs() < 1e-6,
+        "N=3: |Σ q_iz| = {:.3e} W must be < 1e-6 W",
+        result.net_w.abs()
+    );
+
+    // Also verify the algebraic identity at the T_old vector directly.
+    let temps_before: Vec<f64> = vec![20.0, 25.0, 15.0];
+    let algebraic_net = network.net_inter_zone_q(&temps_before);
+    assert!(
+        algebraic_net.abs() < 1e-6,
+        "N=3 algebraic identity must give |Σ q_iz| = 0; got {:.3e}",
+        algebraic_net.abs()
+    );
+}
+
+/// Issue #1348 acceptance criterion #5: 5-zone round-trip
+/// (backward-Euler solve + report).
+#[test]
+fn multi_zone_n_zone_network_5_zone_round_trip() {
+    let n = 5_usize;
+    let mut pairs: Vec<(usize, usize, f64)> = Vec::new();
+    for i in 0..n {
+        for j in 0..n {
+            if i != j {
+                pairs.push((i, j, 30.0));
+            }
+        }
+    }
+    let network = MultiZoneAirflowNetwork::from_adjacency_pairs(n, &pairs);
+
+    // Round-trip: solve once, check conservation, probe the report, then
+    // solve again with different initial conditions and re-check.
+    let mut zones: Vec<ZoneState> = (0..n)
+        .map(|i| ZoneState::new(18.0 + 2.0 * i as f64, 1.0e6))
+        .collect();
+    let q_ext = vec![0.0; n];
+    let r1 = network
+        .solve_step(&mut zones, &q_ext, 3600.0)
+        .expect("5-zone solve #1");
+    assert!(r1.net_w.abs() < 1e-6, "5-zone round-trip #1: |Σ q_iz| = {:.3e}", r1.net_w.abs());
+
+    // Reset and solve again with different initial temps.
+    let mut zones2: Vec<ZoneState> = (0..n)
+        .map(|i| ZoneState::new(30.0 - 3.0 * i as f64, 1.0e6))
+        .collect();
+    let r2 = network
+        .solve_step(&mut zones2, &q_ext, 3600.0)
+        .expect("5-zone solve #2");
+    assert!(r2.net_w.abs() < 1e-6, "5-zone round-trip #2: |Σ q_iz| = {:.3e}", r2.net_w.abs());
+
+    // And the conservation report.
+    let report = network.conservation_report();
+    assert_eq!(report.n_zones, n);
+    assert!(report.symmetric);
+    assert!(
+        report.net_inter_zone_q_w.abs() < 1e-6,
+        "5-zone conservation_report net = {:.3e}",
+        report.net_inter_zone_q_w.abs()
+    );
+}
+
+/// Issue #1348 acceptance criterion #2 (extended): 10-zone round-trip.
+#[test]
+fn multi_zone_n_zone_network_10_zone_round_trip() {
+    let n = 10_usize;
+    let mut pairs: Vec<(usize, usize, f64)> = Vec::new();
+    for i in 0..n {
+        for j in 0..n {
+            if i != j {
+                pairs.push((i, j, 10.0));
+            }
+        }
+    }
+    let network = MultiZoneAirflowNetwork::from_adjacency_pairs(n, &pairs);
+    let mut zones: Vec<ZoneState> = (0..n)
+        .map(|i| ZoneState::new(15.0 + i as f64, 1.0e6))
+        .collect();
+    let q_ext = vec![0.0; n];
+    let result = network
+        .solve_step(&mut zones, &q_ext, 3600.0)
+        .expect("10-zone solve");
+    assert!(
+        result.net_w.abs() < 1e-6,
+        "N=10: |Σ q_iz| = {:.3e} W must be < 1e-6 W",
+        result.net_w.abs()
+    );
+}
+
+/// Issue #1348 acceptance criterion #3: `MultiZoneConfig::zones` accepts
+/// ≥3 zones without panic and the per-zone conductance output is non-zero
+/// when zones differ in temperature.
+#[test]
+fn multi_zone_config_n_zones_no_panic_non_zero_transfer() {
+    let n = 4_usize;
+    let config = MultiZoneConfig {
+        num_zones: n,
+        zone_setpoints: (0..n).map(|i| (20.0 + i as f64, 26.0 + i as f64)).collect(),
+        inter_zone_conductance: (0..n)
+            .map(|i| (0..n).map(|j| if i != j { 25.0 } else { 0.0 }).collect())
+            .collect(),
+        building_properties: fluxion::cli::multi_zone::BuildingProperties {
+            u_value: 1.5,
+            area_per_zone: 50.0,
+            volume_per_zone: 150.0,
+            occupancy_schedule: Some("office".to_string()),
+        },
+    };
+
+    let network = MultiZoneAirflowNetwork::from_adjacency_pairs(
+        n,
+        &config
+            .inter_zone_conductance
+            .iter()
+            .enumerate()
+            .flat_map(|(i, row)| {
+                row.iter()
+                    .enumerate()
+                    .filter_map(move |(j, &h)| if i != j { Some((i, j, h)) } else { None })
+            })
+            .collect::<Vec<_>>(),
+    );
+
+    // Differing zone temperatures must produce a non-zero per-zone transfer.
+    let temps: Vec<f64> = (0..n).map(|i| 20.0 + 5.0 * i as f64).collect();
+    let q_iz: Vec<f64> = (0..n)
+        .map(|i| {
+            (0..n)
+                .map(|j| config.inter_zone_conductance[i][j] * (temps[j] - temps[i]))
+                .sum()
+        })
+        .collect();
+    assert!(
+        q_iz.iter().any(|&q| q.abs() > 1e-3),
+        "differing zone temperatures must produce non-zero inter-zone transfer; \
+         got q_iz = {:?}",
+        q_iz
+    );
+
+    // Symmetric matrix → Σ q_iz = 0.
+    let net: f64 = q_iz.iter().sum();
+    assert!(net.abs() < 1e-6, "Σ q_iz for symmetric config = {net:.3e}");
+    let _ = network.conservation_report();
+}
+
+/// Issue #1348 acceptance criterion #1: 3-zone network solves in < 1 ms on
+/// a single core (interactive CLI perf budget).
+#[test]
+fn multi_zone_n_zone_network_3_zone_under_one_ms() {
+    let n = 3_usize;
+    let mut pairs: Vec<(usize, usize, f64)> = Vec::new();
+    for i in 0..n {
+        for j in 0..n {
+            if i != j {
+                pairs.push((i, j, 50.0));
+            }
+        }
+    }
+    let network = MultiZoneAirflowNetwork::from_adjacency_pairs(n, &pairs);
+    let mut zones = vec![
+        ZoneState::new(22.0, 1.0e6),
+        ZoneState::new(20.0, 1.0e6),
+        ZoneState::new(18.0, 1.0e6),
+    ];
+    let q_ext = vec![0.0; n];
+
+    // Warm up the LU decomposition cache.
+    let _ = network.solve_step(&mut zones, &q_ext, 3600.0).unwrap();
+
+    let iters = 1000_usize;
+    let start = Instant::now();
+    for _ in 0..iters {
+        let _ = network.solve_step(&mut zones, &q_ext, 3600.0).unwrap();
+    }
+    let elapsed = start.elapsed();
+    let per_step_us = elapsed.as_micros() as f64 / iters as f64;
+    assert!(
+        per_step_us < 1000.0,
+        "N=3 must solve in < 1 ms; got {per_step_us:.1} µs/solve"
+    );
+}
+
+/// Issue #1348 acceptance criterion #4 (regression): Case 960 2-zone wiring
+/// (door opening = 1.5 W/K) still produces a meaningful, non-pathological
+/// q_iz that fits inside the legacy `inter_zone_tolerance = 1.0 W` band.
+#[test]
+fn multi_zone_n_zone_network_case_960_regression() {
+    let n = 2_usize;
+    let h = nalgebra::DMatrix::from_row_slice(n, n, &[0.0, 1.5, 1.5, 0.0]);
+    let network = MultiZoneAirflowNetwork::from_matrix(h);
+    let mut zones = vec![
+        ZoneState::new(20.0, 2.0e6),  // Living
+        ZoneState::new(8.0, 5.0e5),   // Sunspace
+    ];
+    let q_ext = vec![0.0; n];
+    let result = network
+        .solve_step(&mut zones, &q_ext, 3600.0)
+        .expect("2-zone solve");
+
+    // Per-pair imbalance (legacy 1.0 W tolerance): q_iz[0] + q_iz[1] must be < 1.0 W.
+    let imbalance = (result.q_iz_w[0] + result.q_iz_w[1]).abs();
+    assert!(
+        imbalance < 1.0,
+        "Case 960 2-zone legacy tolerance: |q_iz[0] + q_iz[1]| = {imbalance:.3e} W must be < 1.0 W"
+    );
+    // And the strict 1e-6 W tolerance (Issue #1348 acceptance criterion).
+    assert!(
+        result.net_w.abs() < 1e-6,
+        "Case 960 strict tolerance: |Σ q_iz| = {:.3e} W must be < 1e-6 W",
+        result.net_w.abs()
+    );
+
+    // Validate via the validator too.
+    let validator = EnergyBalanceValidator::default();
+    let legacy_pass = validator
+        .validate_n_zone_network_conservation(&result.q_iz_w, 1.0)
+        .is_ok();
+    let strict_pass = validator
+        .validate_n_zone_network_conservation(&result.q_iz_w, 1e-6)
+        .is_ok();
+    assert!(legacy_pass, "Case 960 must pass legacy 1.0 W tolerance");
+    assert!(strict_pass, "Case 960 must also pass strict 1e-6 W tolerance");
+}


### PR DESCRIPTION
fixes #1348

## Multi-zone N-zone airflow / thermal coupling network

Generalize the ASHRAE 140 Case 960 two-zone pair into an arbitrary-N
inter-zone thermal coupling network, preserving Case 960 backward
compatibility.

## Scope

- **N range**: 2 (backward-compatible Case 960 path) to N (3, 5, 10
  exercised in tests; no upper bound beyond `DMatrix` memory).
- **Coupling matrix**: full N-by-N `DMatrix<f64>` of per-pair conductances
  `h_tr_ij` (W/K). The CLI's existing `MultiZoneConfig.inter_zone_conductance`
  is already an `N×N` matrix; the wiring now sums each row into
  `model.h_tr_iz[i]` (the per-zone total used by the existing physics
  pipeline), which fixes a pre-existing broken nested-loop assignment.
- **CLI interface**: four new flags on `MultiZoneCommand::Validate`:
  - `--n-zone-network` — run the N-zone conservation check
  - `--n-zone-zones <N>` — number of zones (default 3)
  - `--n-zone-conductance <W/K>` — per-pair conductance (default 50)
  - `--n-zone-tolerance <W>` — accept-band (default `1e-6`, the issue's
    machine-precision floor)
- **Energy balance validator**: new `InterZoneConservationViolation`
  variant + `validate_n_zone_network_conservation(q_iz, tolerance)`
  method returning the signed sum and per-zone breakdown.
- **Backward compatibility**: `EnergyBalanceValidator.inter_zone_tolerance`
  default of `1.0 W` for the legacy 2-zone Case 960 path is unchanged
  (a separate code path); the strict `1e-6 W` is the new N-zone band.

## Approach

The `MultiZoneAirflowNetwork` runs an implicit Euler step on the air-node
heat balance for all zones simultaneously:

```
C_i/dt . (T_new_i - T_old_i) = q_ext_i + sum_j h_tr_ij . (T_new_j - T_new_i)
```

rearranged into `(M) . T_new = b` with `M_ii = C_i/dt + sum_j h_tr_ij`,
`M_ij = -h_tr_ij` (i ≠ j), and an LU solve (`nalgebra::DMatrix::lu`). For a
symmetric conductance matrix the algebraic identity

```
sum_i q_iz[i] = sum_i sum_j h_tr_ij . (T_j - T_i) = 0
```

holds to within machine epsilon of the LU noise floor (`O(1e-13)` for
`f64`). The post-step `q_iz[i]` is computed from `T_new` (not `T_old`) so
the identity holds for the *evolved* state, not just the initial one.

## Validation

- **Unit tests** (`src/sim/multi_zone_network.rs`, 14 tests):
  N=3 ring, N=5 fully-connected, N=10 fully-connected; perf budget
  (<1 ms for N=3); asymmetric-matrix rejection (sanity); dimension
  mismatch / non-positive capacity / zero-timestep error paths;
  `from_adjacency_pairs` consistency; `per_zone_conductance` row-sum
  semantics; in-place temperature mutation; `conservation_report` flags
  symmetric vs asymmetric matrices.
- **Validator tests** (`src/validation/energy_balance.rs`, 2 tests):
  `n_zone_network_conservation_passes_for_symmetric_matrix` and
  `..._rejects_asymmetric_residual`.
- **Integration test target** (`tests/multi_zone_n_zone_network.rs`,
  registered in `Cargo.toml` as `[[test]] name = "multi_zone_n_zone_network"`):
  6 tests — 3-zone conservation, 5-zone round-trip, 10-zone round-trip,
  `MultiZoneConfig` ≥3 zones non-panic + non-zero transfer, N=3 perf
  budget, Case 960 2-zone regression (both legacy 1.0 W and strict
  1e-6 W tolerance).
- **Python verification** (`.agents/results/issue-E5-n-zone-conservation.py`):
  asserts |sum q_iz| < 1e-6 W for N=3,5,10 with random symmetric
  conductance matrices and confirms an asymmetric N=3 matrix correctly
  fails the check.
- **Regression**: `cargo test --features ort --lib
  validation::ashrae_140_multi_zone` still passes (4 tests).
  `cargo test --features ort --lib validation::energy_balance` passes
  (8 tests). `cargo test --features ort --lib cli::multi_zone` passes
  (3 tests). `cargo test --features ort --test
  zone_balance_eplus_isolation` shows the same 3 pre-existing
  Case-600/900/960 first-timestep imbalances as on `main` (out of
  scope for this issue).

## Out of scope (per issue body)

- Pressure-network airflow / CONTAM-style multi-zone air flow.
- Single-zone Case 600/900 closure (existing ASHRAE 140 work).
- Python/NAPI bindings for the new N-zone network.
- Generating Case 970/980 reference CSVs (existing stubs remain
  future work).
- No parameter tuning — pure architecture extension.

Refs: #1348
