### PR TITLE
⚡ Bolt: [performance improvement] Remove dead t_sol_air allocation in 6R2C loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -36,3 +36,6 @@
 ## 2026-06-25 - Avoid vector `clone` and chained math assignments inside physics hot loops
 **Learning:** Found that using chained VectorField calculations (`clone()`, `mul_assign()`, `add_assign()`, `zip_with()`) for mathematical formulas like `ts_num_act = h_tr_ms * mass_temp + h_tr_is * t_i_act + phi_st` produces significant memory allocation overhead inside highly iterated loop blocks like `physics_impl.rs`.
 **Action:** Replace `VectorField` chain arithmetic directly with a single pass scalar loop that pre-allocates an empty target vector using `Vec::with_capacity(num_zones)` and handles the computation directly for the buffer creation. This resulted in up to ~6.4% performance improvement in throughput.
+## 2026-07-09 - Removed dead t_sol_air allocation in step_physics_6r2c
+**Learning:** In hot loops like `step_physics_6r2c`, carefully audit for and remove dead code blocks calculating values only used by other model paths (e.g., `t_sol_air_data` intended for 5R1C) to eliminate unnecessary `Vec::with_capacity` heap allocations and floating-point operations.
+**Action:** Audit variables prefixed with underscores (`_`) inside hot loops that are artifacts from code reuse and clean them up.

--- a/src/sim/thermal_model_physics/physics_impl.rs
+++ b/src/sim/thermal_model_physics/physics_impl.rs
@@ -1517,24 +1517,6 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
             T::from(VectorField::new(t_s_data))
         };
 
-        // === FIX D1: Calculate sol-air temperature for exterior surface ===
-        // Per ISO 13790, exterior surface temperature is affected by solar radiation
-        // T_sol-air = T_outdoor + (α × I_sol / h_se)
-        // where α = solar absorptance (0.7), h_se = exterior surface coeff (25 W/m²K)
-        use crate::physics::constants::thermal::ashrae_140::v2023::{
-            EXTERIOR_FILM_COEFF_DEFAULT, SOLAR_ABSORPTANCE_DEFAULT,
-        };
-        let alpha = SOLAR_ABSORPTANCE_DEFAULT; // 0.7
-        let h_se = EXTERIOR_FILM_COEFF_DEFAULT; // 25.0 W/m²K
-        let mut t_sol_air_data = Vec::with_capacity(self.0.num_zones);
-        for &i_sol in solar_ref.iter().take(self.0.num_zones) {
-            let t_sol_air_zone = outdoor_temp + (alpha * i_sol / h_se);
-            t_sol_air_data.push(t_sol_air_zone);
-        }
-        // Note: t_sol_air is used by the 5R1C model path (for mass temperature update)
-        // It is NOT used by the 6R2C envelope mass path (which uses t_s instead)
-        let _t_sol_air = VectorField::new(t_sol_air_data);
-
         // === 6R2C: Update two mass nodes with implicit integration ===
         // Envelope mass: receives heat from exterior (sol-air), surface, and internal mass
         let old_env_mass_temperatures = self.0.envelope_mass_temperatures.clone();


### PR DESCRIPTION
💡 What: Removed a block of code calculating `t_sol_air` and `t_sol_air_data` inside `step_physics_6r2c`.
🎯 Why: The variable was prefixed with an underscore (`_t_sol_air`), explicitly indicating it was unused. The comments also confirmed it was only used in the 5R1C path, yet it was allocating a `Vec::with_capacity` and running floating-point ops every timestep in the 6R2C hot loop.
📊 Impact: Avoids unnecessary vector allocation and floating-point math every iteration in `step_physics_6r2c`.
🔬 Measurement: Verify tests and `engine_bench` benchmarks still pass, which they do.

---
*PR created automatically by Jules for task [5023142856758859877](https://jules.google.com/task/5023142856758859877) started by @anchapin*

## Summary by Sourcery

Remove unused sol-air temperature computation from the 6R2C physics hot loop to reduce per-step overhead and document the optimization guidance in the Bolt performance notes.

Enhancements:
- Eliminate dead code computing `t_sol_air` in the 6R2C path to avoid unnecessary allocations and floating-point work each timestep.

Documentation:
- Extend Bolt performance notes with guidance on auditing and removing dead allocations and unused calculations in physics hot loops.