### PR TITLE
fix: resolve #1413 — use canonical solar constant 1361 W/m² instead of 1367

### DIFF
--- a/src/solar/surface_irradiance.rs
+++ b/src/solar/surface_irradiance.rs
@@ -520,8 +520,7 @@ mod tests {
     fn test_extraterrestrial_irradiance_doy172() {
         // Issue #1413 acceptance: dni_extra(DOY 172) must match the canonical
         // formula 1361 × (1 + 0.033 × cos(2π·169/365)) to within 1e-9.
-        let expected =
-            1361.0 * (1.0 + 0.033 * (2.0 * std::f64::consts::PI * 169.0 / 365.0).cos());
+        let expected = 1361.0 * (1.0 + 0.033 * (2.0 * std::f64::consts::PI * 169.0 / 365.0).cos());
         let actual = extraterrestrial_irradiance(172);
         assert!(
             (actual - expected).abs() < 1e-9,

--- a/src/solar/surface_irradiance.rs
+++ b/src/solar/surface_irradiance.rs
@@ -15,7 +15,15 @@
 use crate::solar::solar_position::SolarPosition;
 
 /// Solar constant at the top of atmosphere (W/m²).
-const SOLAR_CONSTANT: f64 = 1367.0;
+///
+/// Canonical total solar irradiance (TSI) at mean Earth-Sun distance.
+/// **Value:** 1361.0 W/m² (ASHRAE 140-2022 Appendix C; Kopp & Lean 2011 / TSIS).
+///
+/// Previously this module used the older 1367 W/m² approximation, which caused
+/// a 0.44% drift in `dni_extra` and propagated into every Perez diffuse
+/// calculation through the `delta` parameter (Issue #1413). All other call sites
+/// (sky_radiation.rs, ashrae_140.rs, engine.rs) already use 1361.0.
+pub const SOLAR_CONSTANT: f64 = 1361.0;
 
 /// Surface orientation for irradiance calculations.
 ///
@@ -485,12 +493,39 @@ mod tests {
 
     #[test]
     fn test_extraterrestrial_irradiance() {
-        // At perihelion (DOY ~3): I₀ should be ~1422 W/m²
+        // At perihelion (DOY ~3): I₀ should be ~1406 W/m²
         let e_peri = extraterrestrial_irradiance(3);
         assert!(e_peri > 1400.0 && e_peri < 1440.0);
 
-        // At aphelion (DOY ~186): I₀ should be ~1315 W/m²
+        // At aphelion (DOY ~186): I₀ should be ~1316 W/m²
         let e_aph = extraterrestrial_irradiance(186);
         assert!(e_aph > 1300.0 && e_aph < 1340.0);
+    }
+
+    #[test]
+    fn test_solar_constant_matches_canonical() {
+        // Issue #1413: the leaf solar module's solar constant must equal the
+        // canonical ASHRAE 140-2022 value used everywhere else in the codebase.
+        assert_eq!(
+            SOLAR_CONSTANT,
+            crate::physics::constants::solar::ashrae_140::SOLAR_CONSTANT,
+            "SOLAR_CONSTANT in surface_irradiance ({}) must match \
+             ashrae_140::SOLAR_CONSTANT ({})",
+            SOLAR_CONSTANT,
+            crate::physics::constants::solar::ashrae_140::SOLAR_CONSTANT,
+        );
+    }
+
+    #[test]
+    fn test_extraterrestrial_irradiance_doy172() {
+        // Issue #1413 acceptance: dni_extra(DOY 172) must match the canonical
+        // formula 1361 × (1 + 0.033 × cos(2π·169/365)) to within 1e-9.
+        let expected =
+            1361.0 * (1.0 + 0.033 * (2.0 * std::f64::consts::PI * 169.0 / 365.0).cos());
+        let actual = extraterrestrial_irradiance(172);
+        assert!(
+            (actual - expected).abs() < 1e-9,
+            "dni_extra(DOY 172): expected {expected:.6}, got {actual:.6}"
+        );
     }
 }


### PR DESCRIPTION
- **fix(api): surface peak_heating/cooling loads in /v1/simulate response (#1450)**
- **fix(conduction): wire SolverManager.step_all into per-surface production path (#1451)**
- **perf: remove unused `t_sol_air` calculation from `step_physics_6r2c` (#1452)**
- **fix(validation): reconcile Case 900 reference drift between benchmark.rs and CSV (#1453)**
- **fix(validation): replace Case 960 multi-zone stub with real model execution (#1454)**
- **fix(deps): document RUSTSEC-2026-0192 (ttf-parser) as accepted-risk unmaintained (#1458) (#1459)**
- **fix(physics): resolve ASHRAE 140 Case 600 series failures (#1457) (#1460)**
- **fix(physics): resolve ASHRAE 140 Case 960 sunspace coupling (#1456) (#1466)**
- **test(ashrae140): add Case 970 reference + MultiZoneNetwork e2e validation (#1446) (#1467)**
- **feat(rest): add /v1/metrics, request tracing, structured logs (#1447) (#1468)**
- **docs: refresh KNOWN_ISSUES, deprecate ASHRAE140_RESULTS, add Case 970 (#1443) (#1469)**
- **docs(api): add REST API section to API_REFERENCE.md and verify OpenAPI drift (#1442) (#1470)**
- **fix(physics): wire full nonlinear Stefan-Boltzmann into MultiZone air-node step (#1445) (#1471)**
- **docs+test: track remaining ASHRAE 140 Case 600 failures (#1457) (#1472)**
- **feat: resolve #1461 — ThermalManifold data structure (#1474)**
- **feat: resolve #1462 — GaugeSolver shadow mode in physics_adapter.rs (#1473)**
- **feat(quantum): Phase 2b QUBO mapping for ThermalManifold tensors (#1464)**
- **Merge PR #1476: AI Phase 2a — Surrogate training targeting metric tensors (#1463)**
- **feat: resolve #1465 — GaugeSolver ASHRAE 140 Case 900 validation (#1477)**
- **fix: resolve #1413 — use canonical solar constant 1361 W/m² instead of 1367**
