### PR TITLE
refactor: resolve #1414 — deduplicate PerezSkyModel across leaf and sim modules

### DIFF
--- a/src/sim/sky_radiation.rs
+++ b/src/sim/sky_radiation.rs
@@ -424,158 +424,17 @@ pub fn sol_air_temperature_simple(
 /// - Perez, R., et al. (1990). "Modeling daylight availability and irradiance
 ///   components from direct and global irradiance." Solar Energy 44(5), 271-289.
 /// - ASHRAE Handbook - Fundamentals, Chapter 14: Climatic Design Information
-pub struct PerezSkyModel;
-
-impl PerezSkyModel {
-    #[allow(clippy::too_many_arguments)]
-    pub fn calculate_diffuse_tilted(
-        dhi: f64,
-        dni: f64,
-        dni_extra: f64,
-        airmass: f64,
-        zenith_deg: f64,
-        surface_tilt_deg: f64,
-        surface_azimuth_deg: f64,
-        solar_azimuth_deg: f64,
-    ) -> f64 {
-        if dhi <= 0.0 {
-            return 0.0;
-        }
-
-        let zenith_rad = zenith_deg.to_radians();
-        let surface_tilt = surface_tilt_deg.to_radians();
-        let _surface_azimuth = surface_azimuth_deg.to_radians();
-        let _solar_azimuth = solar_azimuth_deg.to_radians();
-
-        let kappa = 1.041;
-        let delta = dhi * airmass / dni_extra;
-
-        let epsilon = {
-            let z_cubed = zenith_rad.powi(3);
-            let numerator = (dhi + dni) / dhi + kappa * z_cubed;
-            let denominator = 1.0 + kappa * z_cubed;
-            numerator / denominator
-        };
-
-        let ebin = Self::classify_sky_clearness(epsilon);
-        let (f1c, f2c) = Self::get_perez_coefficients(ebin);
-        let f1 = (f1c[0] + f1c[1] * delta + f1c[2] * zenith_rad).max(0.0);
-        let f2 = f2c[0] + f2c[1] * delta + f2c[2] * zenith_rad;
-
-        let cos_incidence = Self::calculate_cos_incidence(
-            surface_tilt_deg,
-            surface_azimuth_deg,
-            zenith_deg,
-            solar_azimuth_deg,
-        );
-
-        let a = cos_incidence.max(0.0);
-        let b = zenith_rad.cos().max((85.0f64).to_radians().cos());
-
-        let term1 = 0.5 * (1.0 - f1) * (1.0 + surface_tilt.cos());
-        let term2 = f1 * a / b;
-        let term3 = f2 * surface_tilt.sin();
-
-        (dhi * (term1 + term2 + term3)).max(0.0)
-    }
-
-    fn classify_sky_clearness(epsilon: f64) -> usize {
-        let bounds = [0.0, 1.065, 1.23, 1.5, 1.95, 2.8, 4.5, 6.2];
-        let mut ebin = 7;
-        for (i, &bound) in bounds.iter().enumerate() {
-            if epsilon <= bound {
-                ebin = i;
-                break;
-            }
-        }
-        ebin
-    }
-
-    fn get_perez_coefficients(ebin: usize) -> ([f64; 3], [f64; 3]) {
-        // Perez sky model coefficients (F1 and F2) from Perez et al. 1990
-        // Table 3: "Coefficients for the calculation of F1 and F2 from ε and Δ"
-        //
-        // Sky clearness bins (ε):
-        //   Bin 1: 1.000-1.065 (overcast)
-        //   Bin 2: 1.065-1.230
-        //   Bin 3: 1.230-1.500
-        //   Bin 4: 1.500-1.950
-        //   Bin 5: 1.950-2.800
-        //   Bin 6: 2.800-4.500
-        //   Bin 7: 4.500-6.200
-        //   Bin 8: >6.200 (clear sky)
-        //
-        // F1 = F1C[0] + F1C[1] * Δ + F1C[2] * θz (circumsolar brightness)
-        // F2 = F2C[0] + F2C[1] * Δ + F2C[2] * θz (horizon brightness)
-        //
-        // Reference: Perez, R., et al. (1990). "Modeling daylight availability and
-        // irradiance components from direct and global irradiance." Solar Energy 44(5),
-        // 271-289. Table 3.
-
-        const F1C: [[f64; 3]; 8] = [
-            [-0.008317, 0.587728, -0.062064], // Bin 1: overcast
-            [0.129967, 0.682595, -0.151375],  // Bin 2
-            [0.329676, 0.486861, -0.221272],  // Bin 3
-            [0.568205, 0.187452, -0.295250],  // Bin 4
-            [0.873018, -0.393289, -0.369150], // Bin 5
-            [1.321297, -1.176777, -0.393994], // Bin 6
-            [0.999852, -1.634380, -0.291495], // Bin 7
-            [0.553776, 0.631414, -0.209172],  // Bin 8: clear sky
-        ];
-
-        // F2 coefficients: Note that F2 is typically small (0.00-0.06) for most
-        // sky conditions. The horizon brightness term is only significant for
-        // clear skies with low zenith angles.
-        //
-        // IMPORTANT: Original implementation had F2 = 0.091 + 0.77*Δ for clear sky,
-        // which is TOO HIGH. Correct values from Perez 1990 Table 3 show F2 should
-        // be much smaller. The second coefficient (Δ multiplier) should be ~0.06,
-        // not 0.77.
-        const F2C: [[f64; 3]; 8] = [
-            [0.091000, 0.060000, 0.000000],  // Bin 1: overcast
-            [0.055000, 0.060000, 0.000000],  // Bin 2
-            [0.025000, 0.060000, 0.000000],  // Bin 3
-            [-0.015000, 0.060000, 0.000000], // Bin 4
-            [-0.065000, 0.060000, 0.000000], // Bin 5
-            [-0.115000, 0.060000, 0.000000], // Bin 6
-            [-0.165000, 0.060000, 0.000000], // Bin 7
-            [-0.215000, 0.060000, 0.000000], // Bin 8: clear sky
-        ];
-
-        let ebin_clamped = ebin.min(7);
-        (F1C[ebin_clamped], F2C[ebin_clamped])
-    }
-
-    fn calculate_cos_incidence(
-        surface_tilt_deg: f64,
-        surface_azimuth_deg: f64,
-        zenith_deg: f64,
-        solar_azimuth_deg: f64,
-    ) -> f64 {
-        let tilt = surface_tilt_deg.to_radians();
-        let surface_az = surface_azimuth_deg.to_radians();
-        let zenith = zenith_deg.to_radians();
-        let solar_az = solar_azimuth_deg.to_radians();
-
-        let cos_incidence = tilt.sin() * surface_az.sin() * zenith.cos() * solar_az.sin()
-            + tilt.sin() * surface_az.cos() * zenith.cos() * solar_az.cos()
-            + tilt.cos() * zenith.sin();
-
-        cos_incidence.clamp(-1.0, 1.0)
-    }
-}
-
-pub fn extraterrestrial_irradiance(day_of_year: usize) -> f64 {
-    let day_rad = 2.0 * std::f64::consts::PI * (day_of_year as f64 - 3.0) / 365.0;
-    SOLAR_CONSTANT * (1.0 + 0.033 * day_rad.cos())
-}
-
-pub fn relative_airmass(zenith_deg: f64) -> f64 {
-    let zenith_rad = zenith_deg.to_radians();
-    let cos_zenith = zenith_rad.cos();
-    let term = 96.07995 - zenith_deg;
-    1.0 / (cos_zenith + 0.50572 * term.powf(-1.6364))
-}
+///
+/// # Source of truth (Issue #1414)
+///
+/// `PerezSkyModel`, `extraterrestrial_irradiance`, and `relative_airmass` are
+/// **defined once** in `crate::solar::surface_irradiance` and re-exported here
+/// so existing `sim::sky_radiation::` call sites continue to work without
+/// parallel physics code paths. Future corrections (e.g. ASHRAE 140-2023
+/// coefficient updates) need to touch only the leaf module.
+pub use crate::solar::surface_irradiance::{
+    extraterrestrial_irradiance, relative_airmass, PerezSkyModel,
+};
 
 /// Calculate clearness index (kt) from GHI.
 ///

--- a/src/solar/mod.rs
+++ b/src/solar/mod.rs
@@ -19,5 +19,6 @@ pub mod surface_irradiance;
 // Re-export primary types and functions for convenient access
 pub use solar_position::{calculate_day_of_year, calculate_solar_position, SolarPosition};
 pub use surface_irradiance::{
-    calculate_surface_irradiance, orientation_to_angles, SurfaceIrradiance,
+    calculate_surface_irradiance, extraterrestrial_irradiance, orientation_to_angles,
+    relative_airmass, PerezSkyModel, SurfaceIrradiance,
 };

--- a/src/solar/surface_irradiance.rs
+++ b/src/solar/surface_irradiance.rs
@@ -223,12 +223,15 @@ pub fn calculate_surface_irradiance(
 // ============================================================================
 
 /// Perez sky model for diffuse irradiance on tilted surfaces.
-struct PerezSkyModel;
+///
+/// Single source of truth — see `sim::sky_radiation` re-exports.
+/// Issue #1414: dedup target.
+pub struct PerezSkyModel;
 
 impl PerezSkyModel {
     /// Calculate diffuse irradiance on a tilted surface.
     #[allow(clippy::too_many_arguments)]
-    fn calculate_diffuse_tilted(
+    pub fn calculate_diffuse_tilted(
         dhi: f64,
         dni: f64,
         dni_extra: f64,
@@ -277,7 +280,7 @@ impl PerezSkyModel {
         (dhi * (term1 + term2 + term3)).max(0.0)
     }
 
-    fn classify_sky_clearness(epsilon: f64) -> usize {
+    pub(crate) fn classify_sky_clearness(epsilon: f64) -> usize {
         let bounds = [0.0, 1.065, 1.23, 1.5, 1.95, 2.8, 4.5, 6.2];
         let mut ebin = 7;
         for (i, &bound) in bounds.iter().enumerate() {
@@ -290,7 +293,7 @@ impl PerezSkyModel {
     }
 
     /// Perez model F1 and F2 coefficients from Table 3 of Perez et al. (1990).
-    fn get_perez_coefficients(ebin: usize) -> ([f64; 3], [f64; 3]) {
+    pub(crate) fn get_perez_coefficients(ebin: usize) -> ([f64; 3], [f64; 3]) {
         const F1C: [[f64; 3]; 8] = [
             [-0.008317, 0.587728, -0.062064],
             [0.129967, 0.682595, -0.151375],
@@ -316,7 +319,7 @@ impl PerezSkyModel {
         (F1C[ebin_clamped], F2C[ebin_clamped])
     }
 
-    fn calculate_cos_incidence(
+    pub(crate) fn calculate_cos_incidence(
         surface_tilt_deg: f64,
         surface_azimuth_deg: f64,
         zenith_deg: f64,
@@ -341,7 +344,10 @@ impl PerezSkyModel {
 /// I₀ = G_sc × (1 + 0.033 × cos(360° × (n-3)/365))
 ///
 /// Reference: ASHRAE Fundamentals, Chapter 14, Eq. 3.
-fn extraterrestrial_irradiance(day_of_year: usize) -> f64 {
+///
+/// Single source of truth — see `sim::sky_radiation` re-exports.
+/// Issue #1414: dedup target.
+pub fn extraterrestrial_irradiance(day_of_year: usize) -> f64 {
     let day_rad = 2.0 * std::f64::consts::PI * (day_of_year as f64 - 3.0) / 365.0;
     SOLAR_CONSTANT * (1.0 + 0.033 * day_rad.cos())
 }
@@ -351,7 +357,10 @@ fn extraterrestrial_irradiance(day_of_year: usize) -> f64 {
 /// AM = 1 / [cos(θ_z) + 0.50572 × (96.07995 - θ_z)^(-1.6364)]
 ///
 /// Valid for zenith angles up to ~90°.
-fn relative_airmass(zenith_deg: f64) -> f64 {
+///
+/// Single source of truth — see `sim::sky_radiation` re-exports.
+/// Issue #1414: dedup target.
+pub fn relative_airmass(zenith_deg: f64) -> f64 {
     let zenith_rad = zenith_deg.to_radians();
     let cos_zenith = zenith_rad.cos();
     let term = 96.07995 - zenith_deg;

--- a/tests/perez_model_parity.rs
+++ b/tests/perez_model_parity.rs
@@ -63,11 +63,7 @@ fn test_leaf_and_sim_perez_identical() {
             surface_azimuth_deg,
             solar_azimuth_deg,
         );
-        assert_bit_identical(
-            &format!("diffuse_tilted[{i}]"),
-            leaf_diffuse,
-            sim_diffuse,
-        );
+        assert_bit_identical(&format!("diffuse_tilted[{i}]"), leaf_diffuse, sim_diffuse);
 
         // extraterrestrial_irradiance varies only by day_of_year.
         let day_of_year: usize = rng.gen_range(1..=365);

--- a/tests/perez_model_parity.rs
+++ b/tests/perez_model_parity.rs
@@ -1,0 +1,116 @@
+//! Parity test for the PerezSkyModel dedup (Issue #1414).
+//!
+//! `PerezSkyModel`, `extraterrestrial_irradiance`, and `relative_airmass` are
+//! defined exactly once in `fluxion::solar::surface_irradiance` (the leaf
+//! module). `fluxion::sim::sky_radiation` re-exports them so callers depending
+//! on either path observe bit-identical results.
+//!
+//! This test asserts the leaf path (`fluxion::solar::*`) and the sim path
+//! (`fluxion::sim::sky_radiation::*`) agree for 50 deterministic random
+//! samples within `f64::EPSILON * 1e3`. Because both paths now resolve to the
+//! same function items via `pub use`, they should match exactly — we use a
+//! generous epsilon (1e3 ulps) only as an explicit allow-list for any future
+//! platform-specific floating-point variance.
+
+use fluxion::sim::sky_radiation as sim_path;
+use fluxion::solar::surface_irradiance as leaf_path;
+use rand::{rngs::StdRng, Rng, SeedableRng};
+
+const SAMPLES: usize = 50;
+const SEED: u64 = 0x1414_DEAD_BEEF;
+
+fn assert_bit_identical(name: &str, a: f64, b: f64) {
+    assert!(
+        (a - b).abs() <= f64::EPSILON * 1e3,
+        "{name} parity drift: leaf={a} sim={b} delta={} (tol={})",
+        (a - b).abs(),
+        f64::EPSILON * 1e3,
+    );
+}
+
+#[test]
+fn test_leaf_and_sim_perez_identical() {
+    let mut rng = StdRng::seed_from_u64(SEED);
+
+    // 50 deterministic random (DNI, DHI, zenith, tilt, az) tuples.
+    for i in 0..SAMPLES {
+        let dhi: f64 = rng.gen_range(0.0..500.0);
+        let dni: f64 = rng.gen_range(0.0..900.0);
+        let dni_extra: f64 = rng.gen_range(1300.0..1400.0);
+        let airmass: f64 = rng.gen_range(1.0..10.0);
+        let zenith_deg: f64 = rng.gen_range(0.0..85.0);
+        let surface_tilt_deg: f64 = rng.gen_range(0.0..90.0);
+        let surface_azimuth_deg: f64 = rng.gen_range(0.0..360.0);
+        let solar_azimuth_deg: f64 = rng.gen_range(0.0..360.0);
+
+        let leaf_diffuse = leaf_path::PerezSkyModel::calculate_diffuse_tilted(
+            dhi,
+            dni,
+            dni_extra,
+            airmass,
+            zenith_deg,
+            surface_tilt_deg,
+            surface_azimuth_deg,
+            solar_azimuth_deg,
+        );
+        let sim_diffuse = sim_path::PerezSkyModel::calculate_diffuse_tilted(
+            dhi,
+            dni,
+            dni_extra,
+            airmass,
+            zenith_deg,
+            surface_tilt_deg,
+            surface_azimuth_deg,
+            solar_azimuth_deg,
+        );
+        assert_bit_identical(
+            &format!("diffuse_tilted[{i}]"),
+            leaf_diffuse,
+            sim_diffuse,
+        );
+
+        // extraterrestrial_irradiance varies only by day_of_year.
+        let day_of_year: usize = rng.gen_range(1..=365);
+        assert_bit_identical(
+            &format!("extraterrestrial_irradiance[{i}]"),
+            leaf_path::extraterrestrial_irradiance(day_of_year),
+            sim_path::extraterrestrial_irradiance(day_of_year),
+        );
+
+        assert_bit_identical(
+            &format!("relative_airmass[{i}]"),
+            leaf_path::relative_airmass(zenith_deg),
+            sim_path::relative_airmass(zenith_deg),
+        );
+    }
+}
+
+/// Belt-and-braces: every re-export must resolve to the exact same function
+/// address as the leaf definition. If a future contributor reintroduces a
+/// local copy in `sim::sky_radiation`, this test trips immediately rather
+/// than relying on coincidental numerical agreement.
+#[test]
+fn test_re_exports_point_at_single_definition() {
+    let leaf_perez: fn(f64, f64, f64, f64, f64, f64, f64, f64) -> f64 =
+        leaf_path::PerezSkyModel::calculate_diffuse_tilted;
+    let sim_perez: fn(f64, f64, f64, f64, f64, f64, f64, f64) -> f64 =
+        sim_path::PerezSkyModel::calculate_diffuse_tilted;
+    assert_eq!(
+        leaf_perez as usize, sim_perez as usize,
+        "PerezSkyModel::calculate_diffuse_tilted re-export diverged from leaf"
+    );
+
+    let leaf_eti: fn(usize) -> f64 = leaf_path::extraterrestrial_irradiance;
+    let sim_eti: fn(usize) -> f64 = sim_path::extraterrestrial_irradiance;
+    assert_eq!(
+        leaf_eti as usize, sim_eti as usize,
+        "extraterrestrial_irradiance re-export diverged from leaf"
+    );
+
+    let leaf_am: fn(f64) -> f64 = leaf_path::relative_airmass;
+    let sim_am: fn(f64) -> f64 = sim_path::relative_airmass;
+    assert_eq!(
+        leaf_am as usize, sim_am as usize,
+        "relative_airmass re-export diverged from leaf"
+    );
+}


### PR DESCRIPTION
- **fix(api): surface peak_heating/cooling loads in /v1/simulate response (#1450)**
- **fix(conduction): wire SolverManager.step_all into per-surface production path (#1451)**
- **perf: remove unused `t_sol_air` calculation from `step_physics_6r2c` (#1452)**
- **fix(validation): reconcile Case 900 reference drift between benchmark.rs and CSV (#1453)**
- **fix(validation): replace Case 960 multi-zone stub with real model execution (#1454)**
- **fix(deps): document RUSTSEC-2026-0192 (ttf-parser) as accepted-risk unmaintained (#1458) (#1459)**
- **fix(physics): resolve ASHRAE 140 Case 600 series failures (#1457) (#1460)**
- **fix(physics): resolve ASHRAE 140 Case 960 sunspace coupling (#1456) (#1466)**
- **test(ashrae140): add Case 970 reference + MultiZoneNetwork e2e validation (#1446) (#1467)**
- **feat(rest): add /v1/metrics, request tracing, structured logs (#1447) (#1468)**
- **docs: refresh KNOWN_ISSUES, deprecate ASHRAE140_RESULTS, add Case 970 (#1443) (#1469)**
- **docs(api): add REST API section to API_REFERENCE.md and verify OpenAPI drift (#1442) (#1470)**
- **fix(physics): wire full nonlinear Stefan-Boltzmann into MultiZone air-node step (#1445) (#1471)**
- **docs+test: track remaining ASHRAE 140 Case 600 failures (#1457) (#1472)**
- **feat: resolve #1461 — ThermalManifold data structure (#1474)**
- **feat: resolve #1462 — GaugeSolver shadow mode in physics_adapter.rs (#1473)**
- **feat(quantum): Phase 2b QUBO mapping for ThermalManifold tensors (#1464)**
- **Merge PR #1476: AI Phase 2a — Surrogate training targeting metric tensors (#1463)**
- **feat: resolve #1465 — GaugeSolver ASHRAE 140 Case 900 validation (#1477)**
- **fix: resolve #1444 — Hottel view factor reciprocity under asymmetric geometry (#1479)**
- **perf: resolve #1438 — adaptive wait_ms + multi-worker scheduler (#1480)**
- **refactor: resolve #1441 — move Orientation (and ASHRAE-140 leaf types) to fluxion-core (#1478)**
- **fix: resolve #1415 — reject 9999 missing-data sentinel in EPW parser (#1483)**
- **refactor: resolve #1414 — deduplicate PerezSkyModel across leaf and sim modules**
