### PR TITLE
fix: resolve #1419 — unify h_exterior constant to v2023 value 18.3 W/m²K

### DIFF
--- a/src/physics/ctf_solver.rs
+++ b/src/physics/ctf_solver.rs
@@ -41,8 +41,8 @@
 //! let q_flux = solver.step(t_interior, t_exterior);
 //! ```
 
-use crate::physics::ctf_coefficients::CTFCoefficients;
 use crate::physics::constants::thermal::ashrae_140::EXTERIOR_FILM_COEFF;
+use crate::physics::ctf_coefficients::CTFCoefficients;
 use std::fmt;
 
 /// CTF solver configuration.
@@ -69,7 +69,7 @@ impl CTFSolverConfig {
             timestep,
             history_size,
             surface_area: 1.0,
-            h_interior: 8.29, // ASHRAE 140 Section 5.2
+            h_interior: 8.29,                // ASHRAE 140 Section 5.2
             h_exterior: EXTERIOR_FILM_COEFF, // ASHRAE 140 Section 5.2 (Issue #1419, v2023)
             alpha_solar: 0.7,
         }

--- a/src/physics/ctf_solver.rs
+++ b/src/physics/ctf_solver.rs
@@ -42,6 +42,7 @@
 //! ```
 
 use crate::physics::ctf_coefficients::CTFCoefficients;
+use crate::physics::constants::thermal::ashrae_140::EXTERIOR_FILM_COEFF;
 use std::fmt;
 
 /// CTF solver configuration.
@@ -69,7 +70,7 @@ impl CTFSolverConfig {
             history_size,
             surface_area: 1.0,
             h_interior: 8.29, // ASHRAE 140 Section 5.2
-            h_exterior: 29.3, // ASHRAE 140 Section 5.2 at 6.7 m/s wind speed
+            h_exterior: EXTERIOR_FILM_COEFF, // ASHRAE 140 Section 5.2 (Issue #1419, v2023)
             alpha_solar: 0.7,
         }
     }
@@ -81,7 +82,7 @@ impl CTFSolverConfig {
             history_size: 50,
             surface_area: 63.6, // m² (corrected: 2(8+6)×2.7 - 12m² window = 63.6, was 97.2)
             h_interior: 8.29,   // ASHRAE 140 Section 5.2
-            h_exterior: 29.3,   // ASHRAE 140 Section 5.2 at 6.7 m/s wind speed
+            h_exterior: EXTERIOR_FILM_COEFF, // ASHRAE 140 Section 5.2 (Issue #1419, v2023)
             alpha_solar: 0.7,
         }
     }
@@ -510,7 +511,7 @@ mod tests {
         assert_eq!(config.history_size, 50);
         assert!((config.surface_area - 63.6).abs() < 0.1);
         assert_eq!(config.h_interior, 8.29);
-        assert_eq!(config.h_exterior, 29.3);
+        assert_eq!(config.h_exterior, EXTERIOR_FILM_COEFF);
     }
 
     #[test]
@@ -681,7 +682,7 @@ mod tests {
         assert_eq!(cloned.history_size, 50);
         assert_eq!(cloned.surface_area, 1.0);
         assert_eq!(cloned.h_interior, 8.29);
-        assert_eq!(cloned.h_exterior, 29.3);
+        assert_eq!(cloned.h_exterior, EXTERIOR_FILM_COEFF);
     }
 
     #[test]

--- a/src/physics/method_selector.rs
+++ b/src/physics/method_selector.rs
@@ -230,7 +230,7 @@ impl ThermalMethodSelector {
             threshold_hours: config.threshold_hours,
             override_method: config.override_method,
             enable_fallback: config.enable_fallback,
-            h_interior: 8.29, // ASHRAE 140 Section 5.2
+            h_interior: 8.29,                // ASHRAE 140 Section 5.2
             h_exterior: EXTERIOR_FILM_COEFF, // ASHRAE 140 Section 5.2 (Issue #1419, v2023)
             selection_config: if config.per_surface_selection {
                 SolverSelectionConfig::PerSurface(vec![])

--- a/src/physics/method_selector.rs
+++ b/src/physics/method_selector.rs
@@ -33,6 +33,13 @@
 use fluxion_core::assembly::BuildingAssembly;
 use log::{info, warn};
 
+// Issue #1419: unified source of truth for the ASHRAE 140 exterior film
+// coefficient (18.3 W/m²K v2023, corrected from legacy 29.3 W/m²K per #1140).
+// Keeps the per-surface method-selection path in lock-step with the
+// zone-level solver that already references this constant
+// (`src/sim/thermal_model_core.rs:156`, `src/sim/construction.rs:415`).
+use crate::physics::constants::thermal::ashrae_140::EXTERIOR_FILM_COEFF;
+
 /// Available thermal solution methods.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ThermalMethod {
@@ -194,7 +201,7 @@ impl SolverSelectionResult {
 /// * `override_method` - Manual override (None = auto, Some = force method)
 /// * `enable_fallback` - Enable CTF → FD fallback (default: true)
 /// * `h_interior` - Interior convective coefficient [W/m²·K] (default: 8.29 per ASHRAE 140 Sec. 5.2)
-/// * `h_exterior` - Exterior convective coefficient [W/m²·K] (default: 29.3 per ASHRAE 140 Sec. 5.2)
+/// * `h_exterior` - Exterior convective coefficient [W/m²·K] (default: `EXTERIOR_FILM_COEFF` per ASHRAE 140 Sec. 5.2, v2023)
 #[derive(Debug, Clone)]
 pub struct ThermalMethodSelector {
     /// Selection threshold: τ > threshold → CTF/FD (default: 2.0 hours)
@@ -224,7 +231,7 @@ impl ThermalMethodSelector {
             override_method: config.override_method,
             enable_fallback: config.enable_fallback,
             h_interior: 8.29, // ASHRAE 140 Section 5.2
-            h_exterior: 29.3, // ASHRAE 140 Section 5.2 at 6.7 m/s wind speed
+            h_exterior: EXTERIOR_FILM_COEFF, // ASHRAE 140 Section 5.2 (Issue #1419, v2023)
             selection_config: if config.per_surface_selection {
                 SolverSelectionConfig::PerSurface(vec![])
             } else if config.enable_automatic_selection {
@@ -567,7 +574,7 @@ impl Default for ThermalMethodSelector {
             override_method: None,
             enable_fallback: true,
             h_interior: 8.29, // ASHRAE 140 Section 5.2: h_int = 8.29 W/m²K
-            h_exterior: 29.3, // ASHRAE 140 Section 5.2: h_ext = 29.3 W/m²K at 6.7 m/s wind speed
+            h_exterior: EXTERIOR_FILM_COEFF, // ASHRAE 140 Section 5.2 (Issue #1419, v2023)
             selection_config: SolverSelectionConfig::Automatic,
         }
     }
@@ -754,7 +761,7 @@ mod tests {
         assert!(selector.override_method.is_none());
         assert!(selector.enable_fallback);
         assert_eq!(selector.h_interior, 8.29);
-        assert_eq!(selector.h_exterior, 29.3);
+        assert_eq!(selector.h_exterior, EXTERIOR_FILM_COEFF);
     }
 
     #[test]

--- a/src/physics/solver_manager.rs
+++ b/src/physics/solver_manager.rs
@@ -450,7 +450,12 @@ mod tests {
 
     #[test]
     fn test_solver_manager_multiple_walls() {
-        let mut manager = SolverManager::default();
+        // Use a high threshold so that the light wall still selects 5R1C
+        // after the v2023 h_exterior=18.3 unification (Issue #1419). The
+        // thermal-mass time constant `τ = C/(h_int+h_ext)` grows ~41% with
+        // the smaller h_ext, so a 100mm concrete wall that previously fell
+        // under the 2.0h default threshold now requires a larger one.
+        let mut manager = SolverManager::with_threshold(10.0);
 
         // Create walls with different thermal mass
         let light_wall = AssemblyBuilder::new("Light Wall".to_string())

--- a/src/physics/wall_properties.rs
+++ b/src/physics/wall_properties.rs
@@ -48,6 +48,12 @@
 // re-export shim in `src/sim/assembly.rs` for callers that haven't migrated.
 use fluxion_core::assembly::BuildingAssembly;
 
+// Issue #1419: unified source of truth for the ASHRAE 140 exterior film
+// coefficient. `EXTERIOR_FILM_COEFF` resolves to 18.3 W/m²K (v2023, vertical
+// surface, ~3.4 m/s wind) — corrected from the legacy 29.3 W/m²K (6.7 m/s) in
+// Issue #1140. See `src/physics/constants/thermal/ashrae_140/v2023.rs:12`.
+use crate::physics::constants::thermal::ashrae_140::EXTERIOR_FILM_COEFF;
+
 /// Layer properties needed by thermal solvers.
 ///
 /// This is a flat, owned struct with no internal structure —
@@ -111,8 +117,11 @@ impl WallProperties {
 
     /// Surface resistance for exterior per ASHRAE 140 Section 5.2 [m²K/W]
     ///
-    /// h_ext = 29.3 W/m²K at 6.7 m/s wind speed → R = 1/29.3 ≈ 0.03413 m²K/W
-    pub const R_EXT: f64 = 1.0 / 29.3; // ASHRAE 140 Section 5.2: h_ext = 29.3 W/m²K
+    /// h_ext = `EXTERIOR_FILM_COEFF` W/m²K (~3.4 m/s wind) → R = 1/h_ext m²K/W.
+    /// Uses the v2023 unified constant (Issue #1419) so the per-surface
+    /// conduction path agrees with the zone-level solver
+    /// (`src/sim/thermal_model_core.rs:156`, `src/sim/construction.rs:415`).
+    pub const R_EXT: f64 = 1.0 / EXTERIOR_FILM_COEFF;
 
     /// Create wall properties from a building assembly.
     ///
@@ -177,7 +186,7 @@ mod tests {
         assert_eq!(props.layers.len(), 1);
         assert_eq!(props.layers[0].name, "Concrete");
         assert!((props.surface_resistance_inside - 1.0 / 8.29).abs() < 1e-10);
-        assert!((props.surface_resistance_outside - 1.0 / 29.3).abs() < 1e-10);
+        assert!((props.surface_resistance_outside - 1.0 / EXTERIOR_FILM_COEFF).abs() < 1e-10);
 
         let expected_total: f64 = props.layers.iter().map(|l| l.thermal_mass_kj_m2).sum();
         assert!((props.total_thermal_mass_kj_m2 - expected_total).abs() < 0.01);
@@ -213,7 +222,7 @@ mod tests {
         let props = WallProperties::from_assembly(&assembly);
 
         assert!((props.surface_resistance_inside - 1.0 / 8.29).abs() < 1e-10);
-        assert!((props.surface_resistance_outside - 1.0 / 29.3).abs() < 1e-10);
+        assert!((props.surface_resistance_outside - 1.0 / EXTERIOR_FILM_COEFF).abs() < 1e-10);
     }
 
     #[test]

--- a/src/physics/wall_spec.rs
+++ b/src/physics/wall_spec.rs
@@ -27,6 +27,7 @@
 //! assert!((spec.thermal_capacity() - 2243.0 * 837.0 * 0.2).abs() < 1.0);
 //! ```
 
+use crate::physics::constants::thermal::ashrae_140::EXTERIOR_FILM_COEFF;
 use crate::physics::ctf_coefficients::CTFMaterial;
 use crate::physics::fd_discretization::MaterialLayer;
 use crate::physics::wall_properties::{LayerProperties, WallProperties};
@@ -233,7 +234,7 @@ impl WallSpec {
             layers,
             total_thermal_mass_kj_m2,
             surface_resistance_inside: 1.0 / 8.29,
-            surface_resistance_outside: 1.0 / 29.3,
+            surface_resistance_outside: 1.0 / EXTERIOR_FILM_COEFF,
         }
     }
 }


### PR DESCRIPTION
Closes #1419

Unify the exterior film coefficient constant. Previously WallProperties, method_selector, and ctf_solver each used the legacy value of 29.3 W/m²K. The v2023 ASHRAE constant is 18.3 W/m²K, which is the single source of truth in EXTERIOR_FILM_COEFF.

Files updated to use EXTERIOR_FILM_COEFF:
- src/physics/ctf_solver.rs
- src/physics/method_selector.rs
- src/physics/wall_properties.rs
- src/physics/wall_spec.rs