### PR TITLE
fix: resolve #1507 — explicit-body PR convention and closing-refs verifier

### DIFF
--- a/docs/orchestration/pr-body-conventions.md
+++ b/docs/orchestration/pr-body-conventions.md
@@ -1,0 +1,73 @@
+# PR Body Conventions for Wave Orchestration
+
+## The Problem
+
+GitHub's `gh pr create --fill` auto-fills the PR body from recent commit
+messages and PR activity. When the orchestrator's sub-agent template passes
+both `--fill` AND a body containing `Closes #N`, GitHub's
+`closingIssuesReferences` parser additionally pattern-matches every other
+issue number it can find in the title and commits — not just the explicit
+`Closes #N` mention.
+
+### Symptom (observed in PR #1487)
+
+> Commit message: "test: resolve #1425 — proptest FiveR1C steady_state_flux contract under query-only separation"
+> Auto-closed by GitHub: `[1415, 1425, 1438, 1441, 1444, 1461, 1462, 1465]`
+
+Seven of those were already closed by other PRs in the same wave; GitHub
+recorded `closingReferences` for them on this PR anyway, polluting the
+issue→PR linkage.
+
+### Same noise on PR #1486 (Perez dedup), PR #1482 (solar constant)
+
+The closing-references lists pull in 1461/1462/1465 (ThermalManifold /
+GaugeSolver Phase 1/2/3 issues) just because the PR body mentions
+`ARCHITECTURE.md` once.
+
+## The Fix
+
+**Use `--body`, never `--fill`.** The body must contain exactly one
+`Closes #N` line.
+
+```bash
+gh pr create --base main \
+  --title "fix: resolve #N — <title>" \
+  --body "$(cat <<'EOF'
+Closes #N
+
+<one-paragraph description>
+EOF
+)"
+```
+
+Rules:
+
+1. **One `Closes #N` line.** No other `#NNNN` references in body or title.
+2. **Single-paragraph description.** Avoid bullet lists — they sometimes
+   contain `#NNN` references that the parser picks up.
+3. **Title format:** `{fix|feat|docs|ci|test|refactor}: resolve #N — <title-slug>`.
+   The slug must not contain `#NNN`.
+
+## Verification
+
+Run immediately after `gh pr create`:
+
+```bash
+gh pr view <PR> --json closingIssuesReferences --jq '.closingIssuesReferences | length'
+# Expected: 1
+```
+
+If it returns more than 1:
+
+```bash
+gh pr edit <PR> --body "Closes #N\n\n<minimal description>"
+```
+
+And re-run the check.
+
+## History
+
+This convention was added as part of issue #1507 after the 2026-07-10/11
+wave orchestration polluted closing-references on PRs #1482, #1486, #1487.
+The corresponding skill update is at
+`~/.agents/skills/github-wave-orchestrator/REFERENCE.md` (lines 22–41).

--- a/scripts/check_pr_closing_refs.sh
+++ b/scripts/check_pr_closing_refs.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# scripts/check_pr_closing_refs.sh
+#
+# Verify a PR's `closingIssuesReferences` count matches the expected value.
+# Used by wave-orchestrator sub-agents after `gh pr create` to catch the
+# `--fill` auto-parse issue documented in docs/orchestration/pr-body-conventions.md.
+#
+# Usage:
+#   bash scripts/check_pr_closing_refs.sh <PR_NUMBER> <EXPECTED_COUNT>
+#
+# Exit codes:
+#   0 — count matches expected
+#   1 — count does not match (with diagnostic output)
+#   2 — usage error
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <pr_number> <expected_count>" >&2
+  exit 2
+fi
+
+PR_NUMBER="$1"
+EXPECTED="$2"
+
+# Get the count of closingIssuesReferences
+ACTUAL=$(gh pr view "$PR_NUMBER" --json closingIssuesReferences --jq '.closingIssuesReferences | length')
+
+# Also fetch the issue numbers for diagnostic output
+NUMBERS=$(gh pr view "$PR_NUMBER" --json closingIssuesReferences \
+  --jq '[.closingIssuesReferences[].number] | join(",")')
+
+if [[ "$ACTUAL" == "$EXPECTED" ]]; then
+  echo "OK PR #$PR_NUMBER closingIssuesReferences count = $ACTUAL (issues: ${NUMBERS:-(none)})"
+  exit 0
+else
+  echo "FAIL PR #$PR_NUMBER closingIssuesReferences count = $ACTUAL, expected $EXPECTED" >&2
+  echo "  referenced issues: ${NUMBERS:-(none)}" >&2
+  echo "  Fix: gh pr edit $PR_NUMBER --body \"Closes #<OWN>\"" >&2
+  exit 1
+fi


### PR DESCRIPTION
Closes #1507

Adds docs/orchestration/pr-body-conventions.md documenting why we use --body (not --fill) and how to keep closingIssuesReferences deterministic to one entry. Adds scripts/check_pr_closing_refs.sh to verify the count after gh pr create. The skill-side update at ~/.agents/skills/github-wave-orchestrator/REFERENCE.md (lines 22-41) was already applied by a prior session; this PR provides the in-repo conventions file that the skill file references.