### PR TITLE
fix(gauge): validate h_exterior unconditionally in effective_exterior_temperature

### DIFF
--- a/src/physics/gauge_solver.rs
+++ b/src/physics/gauge_solver.rs
@@ -132,9 +132,9 @@ impl GaugeSolver {
 
         let solar_irradiance_wm2 = gauge_connection[GAUGE_CONNECTION_SOLAR_INDEX];
         let outside_air_temp_c = gauge_connection[GAUGE_CONNECTION_OUTDOOR_TEMP_INDEX];
-        if solar_irradiance_wm2 != 0.0 && (h_exterior <= 0.0 || !h_exterior.is_finite()) {
+        if h_exterior <= 0.0 || !h_exterior.is_finite() {
             return Err(SolverError::InvalidConfig(
-                "h_exterior must be positive and finite when solar forcing is present".to_string(),
+                "h_exterior must be positive and finite".to_string(),
             ));
         }
 

--- a/src/sim/invariant_checker.rs
+++ b/src/sim/invariant_checker.rs
@@ -240,7 +240,9 @@ impl InvariantChecker {
         // (h_tr_em * (t_sol_air - T_mass_avg)). The InvariantChecker must mirror
         // this distinction exactly.
         let phi_m = match model.thermal_model_type {
-            ThermalModelType::NineRFourC => load_w * m_air_frac + remaining_sol * m_sol_frac + opaque_sol_w,
+            ThermalModelType::NineRFourC => {
+                load_w * m_air_frac + remaining_sol * m_sol_frac + opaque_sol_w
+            }
             _ => load_w * m_air_frac + remaining_sol * m_sol_frac,
         };
 
@@ -282,7 +284,8 @@ impl InvariantChecker {
                 // SolAirTemperature::for_roof(outdoor_temp, opaque_solar_ref[i], sky_temp)
                 // per zone (Issue #1527 fix).
                 let t_m_avg = 0.5 * (t_mass + t_mass_prev);
-                storage - (phi_m + h_tr_3 * (t_air - t_m_avg) + h_tr_em * (t_sol_air_zone - t_m_avg))
+                storage
+                    - (phi_m + h_tr_3 * (t_air - t_m_avg) + h_tr_em * (t_sol_air_zone - t_m_avg))
             }
         }
     }


### PR DESCRIPTION
Closes #1591
## Summary
Fixes #1591 — `effective_exterior_temperature()` now validates `h_exterior` unconditionally, not only when solar irradiance is non-zero.

## Changes
- Removed solar-conditional guard; `h_exterior` checked regardless of solar value
- Solar-specific branch logic preserved (division skipped when solar=0)

## Tests
`cargo test --lib gauge`: 11 passed