### PR TITLE
fix: wire performance regression gate as required PR check

### DIFF
--- a/.github/workflows/ashrae_validation.yml
+++ b/.github/workflows/ashrae_validation.yml
@@ -83,6 +83,14 @@ on:
     workflows: ["Cross-Platform Determinism CI"]
     types: [completed]
 
+  # Issue #1618: mirror the Performance Dashboard conclusion into this
+  # workflow as a single non-matrix "Fluxion Performance Gate" check
+  # that branch protection can reference. The listener only fires for the
+  # same SHA on the same branch.
+  workflow_run:
+    workflows: ["Performance Dashboard"]
+    types: [completed]
+
 concurrency:
   group: ashrae-ci-gate-${{ github.ref }}
   cancel-in-progress: true
@@ -863,4 +871,88 @@ jobs:
         if: github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'cancelled' || github.event.workflow_run.conclusion == 'timed_out'
         run: |
           echo "::error::Determinism gate hard fail — see upstream run ${{ github.event.workflow_run.html_url }}"
+          exit 1
+
+  # =====================================================================
+  # Issue #1618 — Cross-workflow performance regression gate listener
+  # =====================================================================
+  # This job fires after the `Performance Dashboard` workflow completes
+  # for the same SHA. It exists so branch protection can name a single,
+  # non-matrix required check (`Fluxion Performance Gate`) and the PR can
+  # be blocked at the gate if a performance regression is detected.
+  #
+  # The listener is intentionally minimal: it does NOT re-run benchmarks —
+  # it just observes the upstream `conclusion` and surfaces a clear PR
+  # comment + branch-protection check name.
+  # =====================================================================
+  fluxion-performance-gate:
+    name: "Fluxion Performance Gate (Issue #1618)"
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    permissions:
+      contents: read
+      checks: read
+      pull-requests: write
+      actions: read
+    steps:
+      - name: Verify upstream conclusion and post PR comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPSTREAM_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          UPSTREAM_RUN_ID: ${{ github.event.workflow_run.id }}
+          UPSTREAM_RUN_URL: ${{ github.event.workflow_run.html_url }}
+          UPSTREAM_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          UPSTREAM_HEAD_REF: ${{ github.event.workflow_run.head_branch }}
+          UPSTREAM_NAME: ${{ github.event.workflow_run.name }}
+        run: |
+          set -euo pipefail
+          echo "Upstream workflow: ${UPSTREAM_NAME}"
+          echo "Upstream run ID:   ${UPSTREAM_RUN_ID}"
+          echo "Upstream head SHA: ${UPSTREAM_HEAD_SHA}"
+          echo "Upstream head ref: ${UPSTREAM_HEAD_REF}"
+          echo "Upstream conclusion: ${UPSTREAM_CONCLUSION}"
+
+          PR_NUMBER="$(gh pr list --state open --head "${UPSTREAM_HEAD_REF}" --json number --jq '.[0].number // empty' || true)"
+
+          case "${UPSTREAM_CONCLUSION}" in
+            success)
+              echo "::notice::Performance gate PASSED — upstream workflow succeeded."
+              exit 0
+              ;;
+            failure|cancelled|timed_out)
+              echo "::error::Performance gate FAILED — upstream workflow concluded '${UPSTREAM_CONCLUSION}'."
+              echo "::error::See upstream run: ${UPSTREAM_RUN_URL}"
+              if [ -n "${PR_NUMBER:-}" ]; then
+                COMMENT_FILE="$(mktemp -t performance-gate-comment.XXXXXX.md)"
+                cat > "${COMMENT_FILE}" << 'COMMENTEOF'
+## Performance Regression Detected ⚠️
+
+The **Fluxion Performance Gate** has failed. Upstream benchmarks show a performance regression exceeding the 10% threshold.
+
+### Action Required
+Please investigate the performance regression and either:
+- Fix the regression before merging, OR
+- Establish a new baseline on `main` if the regression is intentional
+
+### Details
+See the upstream Performance Dashboard run for detailed benchmark results.
+COMMENTEOF
+                gh pr comment "${PR_NUMBER}" --body-file "${COMMENT_FILE}" \
+                  || echo "::warning::Failed to post PR comment for PR #${PR_NUMBER}"
+                rm -f "${COMMENT_FILE}"
+              else
+                echo "::warning::No open PR found for ref ${UPSTREAM_HEAD_REF}; skipping PR comment."
+              fi
+              exit 1
+              ;;
+            *)
+              echo "::notice::Upstream performance workflow concluded '${UPSTREAM_CONCLUSION}' — not blocking the gate."
+              exit 0
+              ;;
+          esac
+
+      - name: Hard fail on upstream non-success
+        if: github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'cancelled' || github.event.workflow_run.conclusion == 'timed_out'
+        run: |
+          echo "::error::Performance gate hard fail — see upstream run ${{ github.event.workflow_run.html_url }}"
           exit 1

--- a/release_gates.yaml
+++ b/release_gates.yaml
@@ -205,6 +205,14 @@ ci:
     # determinism failure to slip through with a green `validate` job.
     - "Fluxion Determinism Gate (Issue #1351)"
 
+    # Issue #1618: performance regression gate wired as a required check.
+    # The listener job is defined in `.github/workflows/ashrae_validation.yml`
+    # under the `fluxion-performance-gate` id and is triggered by the
+    # `Performance Dashboard` workflow_run completion. It exits non-zero on
+    # `failure` / `cancelled` / `timed_out` upstream conclusions and posts
+    # a PR comment linking the upstream run URL.
+    - "Fluxion Performance Gate (Issue #1618)"
+
   # Job-to-workflow map (informational; branch-protection reads job
   # names directly). Used by `scripts/release_gate_checker.py` to verify
   # the required_checks list is in sync with the workflows directory.
@@ -223,3 +231,12 @@ ci:
       issue: 1351
       depends_on: 1297
       triggered_by: "workflow_run on Cross-Platform Determinism CI completion"
+
+    - job: "Fluxion Performance Gate (Issue #1618)"
+      # The listener job is defined in `ashrae_validation.yml`; it
+      # observes completion of the upstream workflow named below.
+      workflow: ".github/workflows/ashrae_validation.yml"
+      observes_workflow: "Performance Dashboard"
+      observes_workflow_file: ".github/workflows/performance_dashboard.yml"
+      issue: 1618
+      triggered_by: "workflow_run on Performance Dashboard completion"

--- a/scripts/performance_gate.py
+++ b/scripts/performance_gate.py
@@ -11,6 +11,7 @@ import json
 import os
 import sys
 import re
+import argparse
 from pathlib import Path
 from typing import Dict, List, Tuple
 
@@ -55,7 +56,7 @@ def get_main_branch_baseline() -> Dict[str, float]:
         with open(BASELINE_FILE) as f:
             main_baseline = json.load(f)
     finally:
-        run_command(["git", "checkout", "-")
+        run_command(["git", "checkout", "-"])
         run_command(["git", "stash", "pop"])
 
     return main_baseline
@@ -127,13 +128,21 @@ def save_baseline(benchmarks: Dict[str, float]):
 
 
 def main():
+    parser = argparse.ArgumentParser(description="Fluxion Performance Gate")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Run benchmark check against baseline and exit with appropriate code"
+    )
+    args = parser.parse_args()
+
     print("=== Performance Gate ===")
     print(f"Threshold: {BENCHMARK_THRESHOLD*100}% max regression")
 
     branch = get_git_branch()
     is_main = branch == "main"
 
-    if is_main:
+    if is_main and not args.check:
         print("Running on main branch — saving baseline")
         benchmarks = run_benchmarks()
         if benchmarks:
@@ -144,7 +153,11 @@ def main():
             sys.exit(1)
         sys.exit(0)
 
-    print(f"Running on branch '{branch}' — checking against baseline")
+    if args.check:
+        print(f"Running in check mode — comparing against baseline")
+    else:
+        print(f"Running on branch '{branch}' — checking against baseline")
+
     baseline = get_main_branch_baseline()
     if not baseline:
         print("No baseline found — run on main first to establish baseline")

--- a/src/sim/invariant_checker.rs
+++ b/src/sim/invariant_checker.rs
@@ -240,7 +240,9 @@ impl InvariantChecker {
         // (h_tr_em * (t_sol_air - T_mass_avg)). The InvariantChecker must mirror
         // this distinction exactly.
         let phi_m = match model.thermal_model_type {
-            ThermalModelType::NineRFourC => load_w * m_air_frac + remaining_sol * m_sol_frac + opaque_sol_w,
+            ThermalModelType::NineRFourC => {
+                load_w * m_air_frac + remaining_sol * m_sol_frac + opaque_sol_w
+            }
             _ => load_w * m_air_frac + remaining_sol * m_sol_frac,
         };
 
@@ -282,7 +284,8 @@ impl InvariantChecker {
                 // SolAirTemperature::for_roof(outdoor_temp, opaque_solar_ref[i], sky_temp)
                 // per zone (Issue #1527 fix).
                 let t_m_avg = 0.5 * (t_mass + t_mass_prev);
-                storage - (phi_m + h_tr_3 * (t_air - t_m_avg) + h_tr_em * (t_sol_air_zone - t_m_avg))
+                storage
+                    - (phi_m + h_tr_3 * (t_air - t_m_avg) + h_tr_em * (t_sol_air_zone - t_m_avg))
             }
         }
     }
@@ -407,10 +410,8 @@ impl InvariantChecker {
         let opaque_solar_ref = model.opaque_solar_gains.as_ref();
 
         let mut t_sol_air_vec = Vec::with_capacity(n);
-        for i in 0..n {
-            // opaque_solar_ref[i] is the effective opaque irradiance (W/m²)
-            // on exterior surfaces for the zone, set by distribute_opaque_solar_gains.
-            let t_sol_air_i = sol_air.for_roof(outdoor_temp, opaque_solar_ref[i], sky_temp);
+        for op_ref in opaque_solar_ref.iter().take(n) {
+            let t_sol_air_i = sol_air.for_roof(outdoor_temp, *op_ref, sky_temp);
             t_sol_air_vec.push(t_sol_air_i);
         }
         t_sol_air_vec


### PR DESCRIPTION
## Summary
Wires the performance regression gate as a required PR merge check (issue #1618).

### Changes
- **ashrae_validation.yml**: Added `workflow_run` listener for `Performance Dashboard` and `fluxion-performance-gate` job that mirrors the determinism_gate pattern (#1351)
- **release_gates.yaml**: Added `Fluxion Performance Gate (Issue #1618)` to `ci.required_checks` and `workflow_index`
- **scripts/performance_gate.py**: Added `--check` flag for CLI verification

### Acceptance Criteria
1. release_gates.yaml contains 'Fluxion Performance Gate'
2. ashrae_validation workflow_run listener triggers on performance_dashboard.yml completion
3. scripts/performance_gate.py exits non-zero on >10% regression
4. Gate enforced as branch-protection required check

Closes #1618
