### PR TITLE
feat: retrain ONNX surrogates post roof-solar fix, bump to v3.2

### DIFF
--- a/tests/surrogate_models/registry.json
+++ b/tests/surrogate_models/registry.json
@@ -11,9 +11,19 @@
       "onnx_opset_version": 17,
       "training_data_hash": "0000000000000000000000000000000000000000000000000000000000000000",
       "trained_on": "2026-06-27",
-      "training_data_summary": "ASHRARE 140 cases 600-960 + Denver TMY3 100k timesteps (placeholder; replaced by CI)",
+      "training_data_summary": "ASHRAE 140 cases 600-960 + Denver TMY3 100k timesteps (placeholder; replaced by CI)",
       "expected_accuracy": 0.0,
       "model_path": "models/surrogate_v3.1.0.onnx"
+    },
+    {
+      "version": "3.2.0",
+      "model_sha256": "eafdb8d567d11e99acd883ab437721c360fd7db53d931c8f99527e2afb76fd15",
+      "onnx_opset_version": 17,
+      "training_data_hash": "bae4d13711464778888edd132fa1efd920c438622489f9962c6c3d11ad8969bc",
+      "trained_on": "2026-07-14",
+      "training_data_summary": "ASHRAE 140 cases 600-960 + Denver TMY3 with horizontal tilt (roof=0 degree) solar gains coverage post roof-solar fix (#1323). Retrained surrogate models for v3.2.",
+      "expected_accuracy": 0.0,
+      "model_path": "models/surrogate_v3.2.0.onnx"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Retrains the ONNX surrogate models following the roof-solar under-counting fix (#1323).

## Changes

- Added v3.2.0 entry to surrogate model registry with updated SHA256 hashes
- Generated new ONNX surrogate models (v3.2.0) covering horizontal tilt solar gains
- ONNX models placed in models/ directory (gitignored per ADR-0004)

## Registry Update

Updated registry to v3.2.0:
- model_sha256: eafdb8d567d11e99acd883ab437721c360fd7db53d931c8f99527e2afb76fd15
- training_data_hash: bae4d13711464778888edd132fa1efd920c438622489f9962c6c3d11ad8969bc
- Trained on ASHRAE 140 cases 600-960 with horizontal tilt (roof=0 degree) solar gains coverage

Closes #1625

## Summary by Sourcery

Update surrogate model registry to reference retrained ONNX surrogates for version v3.2.0 after the roof-solar fix.

Enhancements:
- Register v3.2.0 surrogate models with new SHA256 and training data hashes covering horizontal tilt solar gains.

Tests:
- Adjust test surrogate model registry expectations to align with the new v3.2.0 surrogate model metadata.