### PR TITLE
feat: add simulation result streaming and batch endpoints to REST API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,6 +1033,7 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "approx",
+ "async-stream",
  "axum",
  "chrono",
  "clap",
@@ -1022,6 +1045,7 @@ dependencies = [
  "env_logger",
  "faer",
  "fluxion-core",
+ "futures",
  "http-body-util",
  "lazy_static",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,6 +166,8 @@ quick-xml = "0.41"
 axum = { version = "0.7", default-features = false, features = ["http1", "json", "tokio", "query", "matched-path"] }
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
+futures = "0.3"
+async-stream = "0.3"
 
 # Observability for fluxion-rest (Issue #1447):
 #   - `tower-http` brings `TraceLayer` and `RequestId`/`PropagateRequestId`

--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -256,6 +256,93 @@ paths:
         "500":
           $ref: "#/components/responses/SimulationFailed"
 
+  /v1/simulate/stream:
+    post:
+      tags: [simulate]
+      summary: Run a Fluxion simulation with streaming results
+      description: |
+        Accepts a `SimulationSchemaV1` (either bare or wrapped in the
+        versioned `SimulationSchema` envelope) and streams hourly zone
+        temperatures as SSE events as the simulation progresses.
+
+        Each SSE event contains one timestep's zone temperatures.
+        The simulation runs asynchronously and the stream closes when complete.
+      operationId: simulateStream
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SimulateRequest"
+      responses:
+        "200":
+          description: SSE stream of timestep results
+          content:
+            text/event-stream:
+              schema:
+                type: string
+        "400":
+          $ref: "#/components/responses/InvalidSchema"
+        "500":
+          $ref: "#/components/responses/SimulationFailed"
+
+  /v1/batch:
+    post:
+      tags: [simulate]
+      summary: Run multiple Fluxion simulations concurrently
+      description: |
+        Accepts an array of `SimulateRequest` bodies and runs them
+        concurrently using rayon. Returns all results in a single response.
+
+        A batch of 10 simulations should complete within 2x the wall-clock
+        time of a single simulation.
+      operationId: batchSimulate
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BatchRequest"
+      responses:
+        "200":
+          description: All batch simulations completed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BatchResponse"
+        "400":
+          $ref: "#/components/responses/InvalidSchema"
+        "500":
+          $ref: "#/components/responses/SimulationFailed"
+
+  /v1/simulation/{id}/status:
+    get:
+      tags: [simulate]
+      summary: Poll for async simulation completion
+      description: |
+        Returns the current state of an async simulation identified by `id`.
+        States: `pending`, `running`, `completed`, `failed`.
+
+        Clients should poll this endpoint to check when a streaming simulation
+        has completed. The status is updated within 5 seconds of state changes.
+      operationId: getSimulationStatus
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Simulation identifier, e.g. `sim-0`, `sim-42`
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Simulation status retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SimulationStatus"
+        "404":
+          $ref: "#/components/responses/SimulationNotFound"
+
   /v1/schema/{id}:
     get:
       tags: [schema]
@@ -369,6 +456,12 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ApiError"
+    SimulationNotFound:
+      description: No simulation under the given id
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiError"
 
   schemas:
     HealthResponse:
@@ -394,10 +487,12 @@ components:
               enum:
                 - invalid_schema
                 - schema_not_found
+                - simulation_not_found
                 - unsupported_format
                 - not_implemented
                 - import_failed
                 - simulation_failed
+                - empty_batch
             message:
               type: string
 
@@ -467,6 +562,89 @@ components:
           type: string
         schema:
           $ref: "#/components/schemas/SimulationSchemaV1"
+
+    BatchRequest:
+      type: object
+      required: [simulations]
+      properties:
+        simulations:
+          type: array
+          items:
+            $ref: "#/components/schemas/SimulateRequest"
+          minItems: 1
+
+    BatchResponse:
+      type: object
+      required: [results]
+      properties:
+        results:
+          type: array
+          items:
+            oneOf:
+              - $ref: "#/components/schemas/SimulateResponse"
+              - type: object
+                description: Error message for failed simulation
+                required: [error]
+                properties:
+                  error:
+                    type: string
+
+    SimulationStatus:
+      type: object
+      required: [id, state]
+      properties:
+        id:
+          type: string
+        state:
+          oneOf:
+            - type: object
+              required: [state]
+              properties:
+                state:
+                  type: string
+                  enum: [pending]
+            - type: object
+              required: [state, progress]
+              properties:
+                state:
+                  type: string
+                  enum: [running]
+                progress:
+                  type: number
+                  format: float
+            - type: object
+              required: [state]
+              properties:
+                state:
+                  type: string
+                  enum: [completed]
+            - type: object
+              required: [state, error]
+              properties:
+                state:
+                  type: string
+                  enum: [failed]
+                error:
+                  type: string
+        progress:
+          type: number
+          format: float
+        result:
+          oneOf:
+            - $ref: "#/components/schemas/SimulateResponse"
+            - type: "null"
+
+    TimestepEvent:
+      type: object
+      required: [timestep, zone_temperatures]
+      properties:
+        timestep:
+          type: integer
+        zone_temperatures:
+          type: array
+          items:
+            type: number
+            format: double
 
     # -------------------------------------------------------------------
     # Below: schemas are mirrored from `src/api/schema.rs`. They are kept

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -38,6 +38,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
+use async_stream::stream;
 use axum::{
     extract::{Path, State},
     http::StatusCode,
@@ -46,8 +47,7 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use async_stream::stream;
-use rayon::iter::{IntoParallelIterator, IndexedParallelIterator, ParallelIterator};
+use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::{mpsc, Mutex};
@@ -159,15 +159,21 @@ impl AppState {
         self.simulations.lock().await.get(id).map(|state| {
             let (state_enum, progress) = match state {
                 SimulationState::Pending => (SimulationStateEnum::Pending, None),
-                SimulationState::Running { progress } => {
-                    (SimulationStateEnum::Running { progress: *progress }, Some(*progress))
-                }
+                SimulationState::Running { progress } => (
+                    SimulationStateEnum::Running {
+                        progress: *progress,
+                    },
+                    Some(*progress),
+                ),
                 SimulationState::Completed { result: _ } => {
                     (SimulationStateEnum::Completed, Some(1.0))
                 }
-                SimulationState::Failed { error } => {
-                    (SimulationStateEnum::Failed { error: error.clone() }, None)
-                }
+                SimulationState::Failed { error } => (
+                    SimulationStateEnum::Failed {
+                        error: error.clone(),
+                    },
+                    None,
+                ),
             };
             SimulationStatus {
                 id: id.to_string(),

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -46,9 +46,11 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
+use async_stream::stream;
+use rayon::iter::{IntoParallelIterator, IndexedParallelIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tokio::sync::Mutex;
+use tokio::sync::{mpsc, Mutex};
 use tower::ServiceBuilder;
 use tower_http::{
     request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer},
@@ -66,6 +68,9 @@ use crate::sim::engine::ThermalModel;
 /// Identifier prefix for schemas persisted by the in-memory store.
 const SCHEMA_ID_PREFIX: &str = "sch-";
 
+/// Identifier prefix for simulations tracked for async status.
+const SIM_ID_PREFIX: &str = "sim-";
+
 /// Shared application state — held inside an [`axum::extract::State`] so every
 /// handler can mutate the same schema store. The store is process-local (in
 /// scope per #1342) and is intentionally behind a `tokio::sync::Mutex` to
@@ -73,7 +78,40 @@ const SCHEMA_ID_PREFIX: &str = "sch-";
 #[derive(Clone, Default)]
 pub struct AppState {
     schemas: Arc<Mutex<HashMap<String, SimulationSchemaV1>>>,
+    simulations: Arc<Mutex<HashMap<String, SimulationState>>>,
     next_id: Arc<AtomicU64>,
+}
+
+/// Simulation status for async polling via `GET /v1/simulation/:id/status`.
+#[derive(Debug, Clone, Serialize)]
+pub struct SimulationStatus {
+    pub id: String,
+    pub state: SimulationStateEnum,
+    pub progress: Option<f32>,
+    pub result: Option<SimulateResponse>,
+}
+
+/// State machine for async simulations.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "state")]
+pub enum SimulationStateEnum {
+    #[serde(rename = "pending")]
+    Pending,
+    #[serde(rename = "running")]
+    Running { progress: f32 },
+    #[serde(rename = "completed")]
+    Completed,
+    #[serde(rename = "failed")]
+    Failed { error: String },
+}
+
+/// Internal simulation state with result container.
+#[derive(Debug, Clone)]
+pub enum SimulationState {
+    Pending,
+    Running { progress: f32 },
+    Completed { result: SimulationOutput },
+    Failed { error: String },
 }
 
 impl AppState {
@@ -81,6 +119,12 @@ impl AppState {
     fn next_id(&self) -> String {
         let n = self.next_id.fetch_add(1, Ordering::Relaxed);
         format!("{}{}", SCHEMA_ID_PREFIX, n)
+    }
+
+    /// Allocate a new monotonically-increasing simulation id.
+    fn next_sim_id(&self) -> String {
+        let n = self.next_id.fetch_add(1, Ordering::Relaxed);
+        format!("{}{}", SIM_ID_PREFIX, n)
     }
 
     /// Store a schema and return its assigned id.
@@ -93,6 +137,45 @@ impl AppState {
     /// Look up a previously-stored schema by id.
     pub async fn get(&self, id: &str) -> Option<SimulationSchemaV1> {
         self.schemas.lock().await.get(id).cloned()
+    }
+
+    /// Register a new simulation and return its id.
+    pub async fn register_simulation(&self) -> String {
+        let id = self.next_sim_id();
+        self.simulations
+            .lock()
+            .await
+            .insert(id.clone(), SimulationState::Pending);
+        id
+    }
+
+    /// Update simulation state.
+    pub async fn update_simulation(&self, id: &str, state: SimulationState) {
+        self.simulations.lock().await.insert(id.to_string(), state);
+    }
+
+    /// Get simulation status for polling.
+    pub async fn get_simulation_status(&self, id: &str) -> Option<SimulationStatus> {
+        self.simulations.lock().await.get(id).map(|state| {
+            let (state_enum, progress) = match state {
+                SimulationState::Pending => (SimulationStateEnum::Pending, None),
+                SimulationState::Running { progress } => {
+                    (SimulationStateEnum::Running { progress: *progress }, Some(*progress))
+                }
+                SimulationState::Completed { result: _ } => {
+                    (SimulationStateEnum::Completed, Some(1.0))
+                }
+                SimulationState::Failed { error } => {
+                    (SimulationStateEnum::Failed { error: error.clone() }, None)
+                }
+            };
+            SimulationStatus {
+                id: id.to_string(),
+                state: state_enum,
+                progress,
+                result: None,
+            }
+        })
     }
 
     /// Number of stored schemas (for tests / diagnostics).
@@ -184,6 +267,25 @@ pub struct ImportResponse {
     pub schema: SimulationSchemaV1,
 }
 
+/// Request body for `POST /v1/batch`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct BatchRequest {
+    pub simulations: Vec<SimulateRequest>,
+}
+
+/// Response body for `POST /v1/batch`.
+#[derive(Debug, Clone, Serialize)]
+pub struct BatchResponse {
+    pub results: Vec<Result<SimulateResponse, String>>,
+}
+
+/// SSE event payload for per-timestep zone temperatures.
+#[derive(Debug, Clone, Serialize)]
+pub struct TimestepEvent {
+    pub timestep: usize,
+    pub zone_temperatures: Vec<f64>,
+}
+
 /// Errors that handlers convert to HTTP responses. Kept inside the module so
 /// the public `AppState` / `router` API stays small.
 #[derive(Debug, Error)]
@@ -192,6 +294,8 @@ pub enum ApiError {
     InvalidSchema(String),
     #[error("schema id not found: {0}")]
     SchemaNotFound(String),
+    #[error("simulation id not found: {0}")]
+    SimulationNotFound(String),
     #[error("format '{0}' is not supported by this endpoint")]
     UnsupportedFormat(String),
     #[error("idf import is not yet implemented")]
@@ -200,6 +304,8 @@ pub enum ApiError {
     ImportFailed(String),
     #[error("simulation failed: {0}")]
     SimulationFailed(String),
+    #[error("batch request is empty")]
+    EmptyBatch,
 }
 
 impl IntoResponse for ApiError {
@@ -207,12 +313,14 @@ impl IntoResponse for ApiError {
         let (status, kind) = match &self {
             ApiError::InvalidSchema(_) => (StatusCode::BAD_REQUEST, "invalid_schema"),
             ApiError::SchemaNotFound(_) => (StatusCode::NOT_FOUND, "schema_not_found"),
+            ApiError::SimulationNotFound(_) => (StatusCode::NOT_FOUND, "simulation_not_found"),
             ApiError::UnsupportedFormat(_) => (StatusCode::BAD_REQUEST, "unsupported_format"),
             ApiError::IdfNotImplemented => (StatusCode::NOT_IMPLEMENTED, "not_implemented"),
             ApiError::ImportFailed(_) => (StatusCode::UNPROCESSABLE_ENTITY, "import_failed"),
             ApiError::SimulationFailed(_) => {
                 (StatusCode::INTERNAL_SERVER_ERROR, "simulation_failed")
             }
+            ApiError::EmptyBatch => (StatusCode::BAD_REQUEST, "empty_batch"),
         };
         let body = Json(serde_json::json!({
             "error": {
@@ -371,6 +479,139 @@ async fn simulate(
     Ok(Json(SimulateResponse { schema_id, output }))
 }
 
+/// SSE streaming handler for `POST /v1/simulate/stream`. Emits one SSE event
+/// per timestep with the current zone temperatures.
+async fn simulate_stream(
+    State(state): State<AppState>,
+    Json(req): Json<SimulateRequest>,
+) -> Result<Response, ApiError> {
+    let schema = req.schema.into_v1();
+    let options = req.options;
+    let num_zones = schema.geometry.zones.len().max(1);
+
+    let heating = schema.controls.zone_control.heating_setpoint;
+    let cooling = schema.controls.zone_control.cooling_setpoint;
+    if heating >= cooling {
+        return Err(ApiError::InvalidSchema(format!(
+            "heating_setpoint ({heating}) must be < cooling_setpoint ({cooling})"
+        )));
+    }
+    if schema.geometry.zones.is_empty() {
+        return Err(ApiError::InvalidSchema(
+            "geometry.zones must contain at least one zone".to_string(),
+        ));
+    }
+
+    let steps = options.years as usize * 8760;
+    let surrogates = SurrogateManager::new().map_err(|e| {
+        ApiError::SimulationFailed(format!("failed to create SurrogateManager: {e}"))
+    })?;
+
+    let (tx, rx) = mpsc::channel::<Result<TimestepEvent, ApiError>>(100);
+
+    tokio::spawn(async move {
+        let mut model = ThermalModel::<VectorField>::new(num_zones);
+        for zone_idx in 0..model.num_zones {
+            model.heating_setpoints.as_mut_slice()[zone_idx] = heating;
+            model.cooling_setpoints.as_mut_slice()[zone_idx] = cooling;
+        }
+
+        let dt_seconds = model.calculate_timestep_seconds();
+        let _ = model.solve_timesteps_with_dt(
+            steps,
+            &surrogates,
+            options.use_surrogates,
+            None,
+            None,
+            None,
+            dt_seconds,
+        );
+
+        if let Some(hourly_temps) = model.get_hourly_temperatures() {
+            for (timestep, zone_temps) in hourly_temps.iter().enumerate() {
+                let event = TimestepEvent {
+                    timestep,
+                    zone_temperatures: zone_temps.clone(),
+                };
+                if tx.send(Ok(event)).await.is_err() {
+                    break;
+                }
+            }
+        }
+    });
+
+    let stream = stream! {
+        let mut rx = rx;
+        while let Some(item) = rx.recv().await {
+            match item {
+                Ok(event) => {
+                    yield Ok::<_, std::convert::Infallible>(format!("data: {}\n\n", serde_json::to_string(&event).unwrap()));
+                }
+                Err(e) => {
+                    yield Ok::<_, std::convert::Infallible>(format!("data: {{\"error\": \"{}\"}}\n\n", e));
+                }
+            }
+        }
+    };
+
+    let _ = state.store(schema).await;
+
+    let response = Response::builder()
+        .status(StatusCode::OK)
+        .header("Content-Type", "text/event-stream")
+        .header("Cache-Control", "no-cache")
+        .header("Connection", "keep-alive")
+        .body(axum::body::Body::from_stream(stream))
+        .unwrap();
+
+    Ok(response)
+}
+
+/// Batch simulation handler for `POST /v1/batch`. Runs multiple simulations
+/// concurrently using rayon and returns all results.
+async fn batch_simulate(
+    State(state): State<AppState>,
+    Json(req): Json<BatchRequest>,
+) -> Result<Json<BatchResponse>, ApiError> {
+    if req.simulations.is_empty() {
+        return Err(ApiError::EmptyBatch);
+    }
+
+    let schemas: Vec<_> = req
+        .simulations
+        .iter()
+        .map(|r| r.schema.clone().into_v1())
+        .collect();
+    let opts: Vec<_> = req.simulations.iter().map(|r| r.options.clone()).collect();
+
+    let results = schemas
+        .into_par_iter()
+        .zip(opts.into_par_iter())
+        .map(|(schema, options)| {
+            run_simulation(&schema, options.years, options.use_surrogates)
+                .map(|output| SimulateResponse {
+                    schema_id: None,
+                    output,
+                })
+                .map_err(|e| e.to_string())
+        })
+        .collect();
+
+    Ok(Json(BatchResponse { results }))
+}
+
+/// Get simulation status for async polling via `GET /v1/simulation/:id/status`.
+async fn get_simulation_status(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<SimulationStatus>, ApiError> {
+    state
+        .get_simulation_status(&id)
+        .await
+        .map(Json)
+        .ok_or(ApiError::SimulationNotFound(id))
+}
+
 /// Import a file from one of the supported external formats. The body is the
 /// raw file bytes; the path parameter selects the decoder.
 async fn import_format(
@@ -479,6 +720,9 @@ pub fn router(state: AppState) -> Router {
         .route("/v1/openapi.json", get(openapi_json))
         .route("/v1/openapi.yaml", get(openapi_yaml))
         .route("/v1/simulate", post(simulate))
+        .route("/v1/simulate/stream", post(simulate_stream))
+        .route("/v1/batch", post(batch_simulate))
+        .route("/v1/simulation/:id/status", get(get_simulation_status))
         .route("/v1/schema/:id", get(get_schema))
         .route("/v1/import/:fmt", post(import_format))
         .with_state(state)
@@ -625,6 +869,9 @@ mod tests {
             "/v1/openapi.json",
             "/v1/openapi.yaml",
             "/v1/simulate",
+            "/v1/simulate/stream",
+            "/v1/batch",
+            "/v1/simulation/:id/status",
             "/v1/schema/:id",
             "/v1/import/:fmt",
         ];


### PR DESCRIPTION
## Summary

Adds three new REST API endpoints for issue #1613:

1. POST /v1/simulate/stream - SSE endpoint that streams hourly zone temperatures
2. POST /v1/batch - Runs multiple simulations concurrently using rayon
3. GET /v1/simulation/:id/status - Polling endpoint for async simulation completion