### PR TITLE
fix: resolve #1628 — expose zone energy tracking and peak load metrics to Python bindings

### DIFF
--- a/src/python/bindings.rs
+++ b/src/python/bindings.rs
@@ -212,7 +212,10 @@ impl PyMultiZoneThermalModel {
     /// - "cooling_mw": Peak cooling power in MW
     /// - "heating_timestep": Timestep index when peak heating occurred
     /// - "cooling_timestep": Timestep index when peak cooling occurred
-    pub fn get_zone_peaks(&self, zone_identifier: &Bound<'_, PyAny>) -> PyResult<HashMap<String, PyObject>> {
+    pub fn get_zone_peaks(
+        &self,
+        zone_identifier: &Bound<'_, PyAny>,
+    ) -> PyResult<HashMap<String, PyObject>> {
         let zone_idx = if let Ok(idx) = zone_identifier.extract::<usize>() {
             idx
         } else if let Ok(name) = zone_identifier.extract::<String>() {
@@ -259,10 +262,22 @@ impl PyMultiZoneThermalModel {
 
         Python::with_gil(|py| {
             let mut result = HashMap::new();
-            result.insert("heating_mw".to_string(), (heating_kw[zone_idx] / 1000.0).to_object(py));
-            result.insert("cooling_mw".to_string(), (cooling_kw[zone_idx] / 1000.0).to_object(py));
-            result.insert("heating_timestep".to_string(), heating_timesteps[zone_idx].to_object(py));
-            result.insert("cooling_timestep".to_string(), cooling_timesteps[zone_idx].to_object(py));
+            result.insert(
+                "heating_mw".to_string(),
+                (heating_kw[zone_idx] / 1000.0).to_object(py),
+            );
+            result.insert(
+                "cooling_mw".to_string(),
+                (cooling_kw[zone_idx] / 1000.0).to_object(py),
+            );
+            result.insert(
+                "heating_timestep".to_string(),
+                heating_timesteps[zone_idx].to_object(py),
+            );
+            result.insert(
+                "cooling_timestep".to_string(),
+                cooling_timesteps[zone_idx].to_object(py),
+            );
             Ok(result)
         })
     }

--- a/src/python/bindings.rs
+++ b/src/python/bindings.rs
@@ -201,6 +201,72 @@ impl PyMultiZoneThermalModel {
         Ok(result)
     }
 
+    /// Get peak load metrics for a specific zone (Issue #1628)
+    ///
+    /// Accepts a zone identifier as either:
+    /// - An integer index (e.g., 0, 1, 2)
+    /// - A string zone name (e.g., "Zone1", "Zone 1", "zone_1")
+    ///
+    /// Returns a dictionary with:
+    /// - "heating_mw": Peak heating power in MW
+    /// - "cooling_mw": Peak cooling power in MW
+    /// - "heating_timestep": Timestep index when peak heating occurred
+    /// - "cooling_timestep": Timestep index when peak cooling occurred
+    pub fn get_zone_peaks(&self, zone_identifier: &Bound<'_, PyAny>) -> PyResult<HashMap<String, PyObject>> {
+        let zone_idx = if let Ok(idx) = zone_identifier.extract::<usize>() {
+            idx
+        } else if let Ok(name) = zone_identifier.extract::<String>() {
+            let normalized = name.trim().to_lowercase();
+            if let Some(stripped) = normalized.strip_prefix("zone") {
+                let num_str = stripped.trim().replace('_', "-").replace(' ', "-");
+                if let Ok(num) = num_str.parse::<usize>() {
+                    if num == 0 {
+                        return Err(pyo3::exceptions::PyValueError::new_err(
+                            "Zone indices are 0-based. Use 0 for Zone 1.",
+                        ));
+                    }
+                    num - 1
+                } else {
+                    return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                        "Invalid zone name {:?}. Expected format: Zone1, Zone 1, or integer index.",
+                        name
+                    )));
+                }
+            } else {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "Invalid zone identifier {:?}. Expected format: Zone1, Zone 1, or integer index.",
+                    name
+                )));
+            }
+        } else {
+            return Err(pyo3::exceptions::PyTypeError::new_err(
+                "Zone identifier must be an integer index or string like Zone1",
+            ));
+        };
+
+        if zone_idx >= self.inner.num_zones {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "Zone index {} out of range (0-{})",
+                zone_idx,
+                self.inner.num_zones - 1
+            )));
+        }
+
+        let heating_kw = self.inner.get_zone_peak_heating_kw();
+        let cooling_kw = self.inner.get_zone_peak_cooling_kw();
+        let heating_timesteps = self.inner.get_zone_peak_heating_timestep();
+        let cooling_timesteps = self.inner.get_zone_peak_cooling_timestep();
+
+        Python::with_gil(|py| {
+            let mut result = HashMap::new();
+            result.insert("heating_mw".to_string(), (heating_kw[zone_idx] / 1000.0).to_object(py));
+            result.insert("cooling_mw".to_string(), (cooling_kw[zone_idx] / 1000.0).to_object(py));
+            result.insert("heating_timestep".to_string(), heating_timesteps[zone_idx].to_object(py));
+            result.insert("cooling_timestep".to_string(), cooling_timesteps[zone_idx].to_object(py));
+            Ok(result)
+        })
+    }
+
     /// Export zone temperatures as Python dictionary
     pub fn export_zone_temperatures(&self) -> PyResult<Py<PyDict>> {
         Python::with_gil(|py| {

--- a/src/sim/thermal_model_core.rs
+++ b/src/sim/thermal_model_core.rs
@@ -2649,6 +2649,9 @@ impl ThermalModel<VectorField> {
             // Per-zone peak power tracking (Issue #1289)
             zone_peak_heating_kw: VectorField::from_scalar(0.0, num_zones),
             zone_peak_cooling_kw: VectorField::from_scalar(0.0, num_zones),
+            // Issue #1628: per-zone peak timestep tracking
+            zone_peak_heating_timestep: vec![0usize; num_zones],
+            zone_peak_cooling_timestep: vec![0usize; num_zones],
 
             // Separate heating and cooling energy tracking (Plan 03-08d: Diagnostic)
             annual_heating_energy: 0.0, // Cumulative heating energy in kWh
@@ -2857,6 +2860,16 @@ impl ThermalModel<VectorField> {
     /// Get per-zone peak cooling power in kW (Issue #1289)
     pub fn get_zone_peak_cooling_kw(&self) -> Vec<f64> {
         self.0.zone_peak_cooling_kw.as_slice().to_vec()
+    }
+
+    /// Get per-zone peak heating timestep index (Issue #1628)
+    pub fn get_zone_peak_heating_timestep(&self) -> Vec<usize> {
+        self.0.zone_peak_heating_timestep.clone()
+    }
+
+    /// Get per-zone peak cooling timestep index (Issue #1628)
+    pub fn get_zone_peak_cooling_timestep(&self) -> Vec<usize> {
+        self.0.zone_peak_cooling_timestep.clone()
     }
 }
 

--- a/src/sim/thermal_model_data.rs
+++ b/src/sim/thermal_model_data.rs
@@ -184,6 +184,10 @@ pub struct ThermalModelData<T: ContinuousTensor<f64> + Clone> {
     pub zone_peak_heating_kw: T,
     /// Issue #1289 — per-zone peak cooling power in kW
     pub zone_peak_cooling_kw: T,
+    /// Issue #1628 — timestep index when peak heating occurred for each zone
+    pub zone_peak_heating_timestep: Vec<usize>,
+    /// Issue #1628 — timestep index when peak cooling occurred for each zone
+    pub zone_peak_cooling_timestep: Vec<usize>,
     pub annual_heating_energy: f64,
     pub annual_cooling_energy: f64,
     pub annual_electrical_energy: f64,
@@ -358,6 +362,8 @@ impl<T: ContinuousTensor<f64> + Clone> Clone for ThermalModelData<T> {
             peak_power_cooling: self.peak_power_cooling,
             zone_peak_heating_kw: self.zone_peak_heating_kw.clone(),
             zone_peak_cooling_kw: self.zone_peak_cooling_kw.clone(),
+            zone_peak_heating_timestep: self.zone_peak_heating_timestep.clone(),
+            zone_peak_cooling_timestep: self.zone_peak_cooling_timestep.clone(),
             annual_heating_energy: self.annual_heating_energy,
             annual_cooling_energy: self.annual_cooling_energy,
             annual_electrical_energy: self.annual_electrical_energy,

--- a/src/sim/thermal_model_physics/physics_impl.rs
+++ b/src/sim/thermal_model_physics/physics_impl.rs
@@ -917,17 +917,20 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
                 hvac_output_sum += val;
 
                 // Issue #1289: Track per-zone peaks
+                // Issue #1628: Also track timestep when peak occurred
                 if val > 0.0 {
                     // Heating mode for this zone
                     let val_kw = val / 1000.0;
                     if val_kw > self.0.zone_peak_heating_kw.as_mut()[i] {
                         self.0.zone_peak_heating_kw.as_mut()[i] = val_kw;
+                        self.0.zone_peak_heating_timestep[i] = timestep;
                     }
                 } else if val < 0.0 {
                     // Cooling mode for this zone
                     let val_kw = -val / 1000.0;
                     if val_kw > self.0.zone_peak_cooling_kw.as_mut()[i] {
                         self.0.zone_peak_cooling_kw.as_mut()[i] = val_kw;
+                        self.0.zone_peak_cooling_timestep[i] = timestep;
                     }
                 }
             }
@@ -972,15 +975,18 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
                 hvac_power_watts_sum += val;
 
                 // Issue #1289: Track per-zone peaks
+                // Issue #1628: Also track timestep when peak occurred
                 if val > 0.0 {
                     let val_kw = val / 1000.0;
                     if val_kw > self.0.zone_peak_heating_kw.as_mut()[i] {
                         self.0.zone_peak_heating_kw.as_mut()[i] = val_kw;
+                        self.0.zone_peak_heating_timestep[i] = timestep;
                     }
                 } else if val < 0.0 {
                     let val_kw = -val / 1000.0;
                     if val_kw > self.0.zone_peak_cooling_kw.as_mut()[i] {
                         self.0.zone_peak_cooling_kw.as_mut()[i] = val_kw;
+                        self.0.zone_peak_cooling_timestep[i] = timestep;
                     }
                 }
             }
@@ -1673,16 +1679,20 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
             if val > 0.0 {
                 heating_sum += val;
                 // Issue #1289: Track per-zone peaks
+                // Issue #1628: Also track timestep when peak occurred
                 let val_kw = val / 1000.0;
                 if val_kw > self.0.zone_peak_heating_kw.as_mut()[i] {
                     self.0.zone_peak_heating_kw.as_mut()[i] = val_kw;
+                    self.0.zone_peak_heating_timestep[i] = timestep;
                 }
             } else {
                 cooling_sum += -val;
                 // Issue #1289: Track per-zone peaks
+                // Issue #1628: Also track timestep when peak occurred
                 let val_kw = -val / 1000.0;
                 if val_kw > self.0.zone_peak_cooling_kw.as_mut()[i] {
                     self.0.zone_peak_cooling_kw.as_mut()[i] = val_kw;
+                    self.0.zone_peak_cooling_timestep[i] = timestep;
                 }
             }
         }
@@ -3250,16 +3260,20 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
                 if val > 0.0 {
                     heating_sum += val;
                     // Issue #1289: Track per-zone peaks
+                    // Issue #1628: Also track timestep when peak occurred
                     let val_kw = val / 1000.0;
                     if val_kw > self.0.zone_peak_heating_kw.as_mut()[i] {
                         self.0.zone_peak_heating_kw.as_mut()[i] = val_kw;
+                        self.0.zone_peak_heating_timestep[i] = timestep;
                     }
                 } else if val < 0.0 {
                     cooling_sum += -val;
                     // Issue #1289: Track per-zone peaks
+                    // Issue #1628: Also track timestep when peak occurred
                     let val_kw = -val / 1000.0;
                     if val_kw > self.0.zone_peak_cooling_kw.as_mut()[i] {
                         self.0.zone_peak_cooling_kw.as_mut()[i] = val_kw;
+                        self.0.zone_peak_cooling_timestep[i] = timestep;
                     }
                 }
             }


### PR DESCRIPTION
Closes #1628

Added PyO3 getter method get_zone_peaks() to expose per-zone peak heating/cooling load metrics with timestep indices to Python bindings.