### PR TITLE
fix #1606: add GaugeSolver diurnal parity test vs FiveR1C baseline

### DIFF
--- a/.agents/results/issue-1465-diurnal-parity.py
+++ b/.agents/results/issue-1465-diurnal-parity.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""
+Python verification script for issue #1606 — GaugeSolver diurnal parity vs FiveR1CSolver baseline.
+
+This script simulates both solvers through a 24-hour synthetic Case 900 diurnal
+forcing and verifies the acceptance criteria:
+
+1. GaugeSolver flux within ±10% of FiveR1C at every hour
+2. Both solvers peak at hour 12, trough at hour 4-5
+3. Nighttime negative, daytime positive response (bipolar)
+4. Amplitude ≥80 W/m²
+
+Physics notes:
+- GaugeSolver: steady-state flux q = (T_eff - T_int) / R_wall where
+  T_eff = T_outdoor + solar / h_ext. No thermal mass evolution.
+- FiveR1C: lumped-capacitance model with thermal mass that evolves toward
+  T_eff over time (τ ≈ 25.6 h for Case 900 200mm concrete).
+  On first step, seeds T_mass = (T_int + T_eff) / 2 (steady-state).
+  Subsequent steps: transient response with thermal lag.
+
+The ±10% criterion is only achievable if BOTH solvers use the same
+steady-state effective-temperature approach. FiveR1C's transient thermal-mass
+evolution causes it to lag behind the effective temperature, resulting in
+large discrepancies during the diurnal cycle.
+
+Run: python3 .agents/results/issue-1465-diurnal-parity.py
+"""
+
+import math
+import sys
+
+# Case 900 parameters (matching tests/gauge_validation_case_900.rs)
+SOLAR_PEAK_W_M2 = 800.0
+T_OUTDOOR_AVG_C = 15.0
+T_OUTDOOR_AMP_C = 10.0
+T_INDOOR_HVAC_SETPOINT_C = 20.0
+H_EXT = 18.3  # W/m²K per ASHRAE 140 v2023
+DT_SECONDS = 3600.0
+
+# Wall: 200 mm HW concrete
+THICKNESS_M = 0.200
+K_W_MK = 0.51
+RHO_KG_M3 = 1400.0
+CP_J_KGK = 840.0
+R_WALL = THICKNESS_M / K_W_MK  # 0.392 m²K/W
+C_WALL = RHO_KG_M3 * CP_J_KGK * THICKNESS_M  # 235200 J/m²K
+
+
+def outdoor_temperature_at(hour: int) -> float:
+    h = hour % 24
+    return T_OUTDOOR_AVG_C + T_OUTDOOR_AMP_C * math.cos((h - 15.0) / 24.0 * 2.0 * math.pi)
+
+
+def solar_irradiance_at(hour: int) -> float:
+    h = hour % 24
+    if 6.0 <= h <= 18.0:
+        return SOLAR_PEAK_W_M2 * math.sin((h - 6.0) / 12.0 * math.pi)
+    return 0.0
+
+
+def effective_temperature(hour: int) -> float:
+    return outdoor_temperature_at(hour) + solar_irradiance_at(hour) / H_EXT
+
+
+def simulate_gauge_solver() -> list[float]:
+    """Steady-state flux at each hour: q = (T_eff - T_int) / R_wall"""
+    fluxes = []
+    for hour in range(24):
+        t_eff = effective_temperature(hour)
+        q = (t_eff - T_INDOOR_HVAC_SETPOINT_C) / R_WALL
+        fluxes.append(q)
+    return fluxes
+
+
+def simulate_fiver1c() -> list[float]:
+    """FiveR1C lumped-capacitance: evolves T_mass toward T_eff each hour."""
+    t_mass = T_INDOOR_HVAC_SETPOINT_C  # initial
+    pre_step = True
+    fluxes = []
+
+    for hour in range(24):
+        t_eff = effective_temperature(hour)
+        q_ss = (t_eff - T_INDOOR_HVAC_SETPOINT_C) / R_WALL
+
+        if pre_step:
+            # Steady-state seed on first step
+            t_mass = (T_INDOOR_HVAC_SETPOINT_C + t_eff) / 2.0
+            q = q_ss
+            pre_step = False
+        else:
+            # Transient: Q_ext = (T_eff - T_mass) / R_wall
+            q_ext = (t_eff - t_mass) / R_WALL
+            dT_mass = q_ext / C_WALL * DT_SECONDS
+            t_mass += dT_mass
+            q = (t_mass - T_INDOOR_HVAC_SETPOINT_C) / R_WALL
+
+        fluxes.append(q)
+
+    return fluxes
+
+
+def main() -> int:
+    print("=" * 80)
+    print("Issue #1606 — GaugeSolver vs FiveR1C Diurnal Parity Verification")
+    print("=" * 80)
+    print()
+    print("Case 900 envelope: 200mm HW concrete, R_wall = {:.4f} m²K/W".format(R_WALL))
+    print("Thermal capacity: {:.0f} kJ/m²K, τ = {:.1f} h".format(
+        C_WALL / 1000.0, C_WALL * R_WALL / 3600.0))
+    print()
+
+    gauge_fluxes = simulate_gauge_solver()
+    fiver1c_fluxes = simulate_fiver1c()
+
+    print("Hour | T_out | Solar | T_eff  | Gauge  | 5R1C   | Diff%")
+    print("-" * 72)
+    all_pass = True
+    for hour in range(24):
+        t_out = outdoor_temperature_at(hour)
+        solar = solar_irradiance_at(hour)
+        t_eff = effective_temperature(hour)
+        q_gauge = gauge_fluxes[hour]
+        q_5r1c = fiver1c_fluxes[hour]
+        diff_pct = abs(q_gauge - q_5r1c) / abs(q_5r1c) * 100 if abs(q_5r1c) > 1e-9 else 0.0
+        flag = "✗" if diff_pct > 10.0 else " "
+        print(f"{hour:4d} | {t_out:5.2f} | {solar:6.1f} | {t_eff:6.2f} | {q_gauge:7.2f} | {q_5r1c:7.2f} | {diff_pct:5.1f}% {flag}")
+
+    print()
+    print("=" * 80)
+    print("AC1: Per-hour ±10% agreement")
+    print("=" * 80)
+    failures = []
+    for hour in range(24):
+        q_gauge = gauge_fluxes[hour]
+        q_5r1c = fiver1c_fluxes[hour]
+        diff_pct = abs(q_gauge - q_5r1c) / abs(q_5r1c) * 100 if abs(q_5r1c) > 1e-9 else abs(q_gauge) * 100
+        if diff_pct > 10.0:
+            failures.append((hour, q_gauge, q_5r1c, diff_pct))
+
+    if failures:
+        print("FAILED — {} hours exceed ±10%:".format(len(failures)))
+        for hour, qg, q5, diff in failures[:5]:
+            print("  Hour {:2d}: Gauge={:8.2f} 5R1C={:8.2f} Diff={:.1f}%".format(
+                hour, qg, q5, diff))
+        if len(failures) > 5:
+            print("  ... and {} more".format(len(failures) - 5))
+        all_pass = False
+    else:
+        print("PASS — all 24 hours within ±10%")
+
+    print()
+    print("=" * 80)
+    print("AC2: Peak at hour 12, trough at hour 4-5")
+    print("=" * 80)
+    gauge_peak = gauge_fluxes.index(max(gauge_fluxes))
+    r1c_peak = fiver1c_fluxes.index(max(fiver1c_fluxes))
+    gauge_trough = gauge_fluxes.index(min(gauge_fluxes))
+    r1c_trough = fiver1c_fluxes.index(min(fiver1c_fluxes))
+
+    peak_ok = (gauge_peak == 12 and r1c_peak == 12)
+    trough_ok = (4 <= gauge_trough <= 5) and (4 <= r1c_trough <= 5)
+    print("GaugeSolver peak: hour {:2d} (expected 12) {}".format(gauge_peak, "✓" if gauge_peak == 12 else "✗"))
+    print("FiveR1C peak:     hour {:2d} (expected 12) {}".format(r1c_peak, "✓" if r1c_peak == 12 else "✗"))
+    print("GaugeSolver trough: hour {:2d} (expected 4-5) {}".format(gauge_trough, "✓" if 4 <= gauge_trough <= 5 else "✗"))
+    print("FiveR1C trough:     hour {:2d} (expected 4-5) {}".format(r1c_trough, "✓" if 4 <= r1c_trough <= 5 else "✗"))
+    if not peak_ok or not trough_ok:
+        all_pass = False
+
+    print()
+    print("=" * 80)
+    print("AC3: Bipolar response")
+    print("=" * 80)
+    max_flux = max(gauge_fluxes)
+    min_flux = min(gauge_fluxes)
+    bipolar = max_flux > 10.0 and min_flux < -10.0
+    print("Max flux: {:.2f} W/m² (expected > 10)".format(max_flux))
+    print("Min flux: {:.2f} W/m² (expected < -10)")
+    print("Bipolar: {}".format("PASS" if bipolar else "FAIL"))
+    if not bipolar:
+        all_pass = False
+
+    print()
+    print("=" * 80)
+    print("AC4: Amplitude ≥80 W/m²")
+    print("=" * 80)
+    amplitude = max_flux - min_flux
+    amp_ok = amplitude >= 80.0
+    print("Amplitude: {:.2f} W/m² (expected ≥80)".format(amplitude))
+    print("Result: {}".format("PASS" if amp_ok else "FAIL"))
+    if not amp_ok:
+        all_pass = False
+
+    print()
+    print("=" * 80)
+    print("SUMMARY: {}".format("ALL PASS" if all_pass else "SOME FAILURES"))
+    print("=" * 80)
+    print()
+    print("Physics note: The large discrepancy between GaugeSolver (steady-state)")
+    print("and FiveR1C (transient with thermal mass) is expected. The thermal mass")
+    print("time constant τ ≈ 25.6 h means FiveR1C's T_mass evolves slowly toward")
+    print("T_eff, while GaugeSolver responds instantly. This causes FiveR1C flux")
+    print("to lag significantly behind the effective temperature drive.")
+
+    return 0 if all_pass else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/gauge_validation_case_900.rs
+++ b/tests/gauge_validation_case_900.rs
@@ -695,10 +695,14 @@ fn test_case_900_gauge_fiver1c_diurnal_parity() {
 
     // Both solvers share the same wall and initial conditions.
     let mut gauge_solver = GaugeSolver::default();
-    gauge_solver.initialize(&wall).expect("GaugeSolver::initialize");
+    gauge_solver
+        .initialize(&wall)
+        .expect("GaugeSolver::initialize");
 
     let mut fiver1c_solver = FiveR1CSolver::new();
-    fiver1c_solver.initialize(&wall).expect("FiveR1C::initialize");
+    fiver1c_solver
+        .initialize(&wall)
+        .expect("FiveR1C::initialize");
 
     let t_int = Temperature::from_value(T_INDOOR_HVAC_SETPOINT_C);
     let h_ext = HeatTransferCoefficient::from_value(CASE_900_H_EXT);

--- a/tests/gauge_validation_case_900.rs
+++ b/tests/gauge_validation_case_900.rs
@@ -662,7 +662,175 @@ fn test_case_900_zone_count_envelope_matches_geometry_tensor() {
 }
 
 // =============================================================================
-// Test 8: CSV reference parity — read the synthetic diurnal CSV and verify
+// Test 8: GaugeSolver vs FiveR1C diurnal parity — 24h synthetic Case 900
+// =============================================================================
+
+/// Run both `GaugeSolver` and `FiveR1CSolver` through the same 24-hour
+/// synthetic Case 900 diurnal forcing and verify per-hour flux agreement.
+///
+/// **Why this test exists** (issue #1606): the existing steady-state zero-solar
+/// parity test (Test 5) only validates the no-solar case. The diurnal cycle
+/// with solar is the primary Case 900 scenario and where the discrete-node
+/// solar-injection pathology was observed. This test ensures both solvers
+/// produce physically consistent flux through a full day-night cycle.
+///
+/// **Methodology**: both solvers receive the same effective exterior temperature
+/// computed as `T_eff = outdoor_temperature + solar_irradiance / h_ext` where
+/// `h_ext = 18.3 W/m²K` per ASHRAE 140 v2023. The `FiveR1CSolver` receives
+/// this as `T_exterior` via its standard `step()` interface; the `GaugeSolver`
+/// receives it via `step_with_boundary_conditions` with the raw solar and
+/// outdoor values (which internally computes the same effective temperature).
+///
+/// Both use the same `case_900_wall()` geometry (`R_wall = 0.392 m²K/W`) and
+/// the same interior setpoint `T_int = 20 °C`.  `DT_SECONDS = 3600.0` (1 h).
+///
+/// Acceptance criteria (issue #1606):
+/// 1. GaugeSolver flux within ±10% of FiveR1C at every hour.
+/// 2. Both solvers peak at hour 12, trough at hour 4-5.
+/// 3. Nighttime negative, daytime positive response (bipolar).
+/// 4. Amplitude ≥80 W/m².
+#[test]
+fn test_case_900_gauge_fiver1c_diurnal_parity() {
+    let wall = case_900_wall();
+
+    // Both solvers share the same wall and initial conditions.
+    let mut gauge_solver = GaugeSolver::default();
+    gauge_solver.initialize(&wall).expect("GaugeSolver::initialize");
+
+    let mut fiver1c_solver = FiveR1CSolver::new();
+    fiver1c_solver.initialize(&wall).expect("FiveR1C::initialize");
+
+    let t_int = Temperature::from_value(T_INDOOR_HVAC_SETPOINT_C);
+    let h_ext = HeatTransferCoefficient::from_value(CASE_900_H_EXT);
+    let h_int = HeatTransferCoefficient::from_value(CASE_900_H_INT);
+
+    let mut gauge_fluxes: Vec<f64> = Vec::with_capacity(24);
+    let mut fiver1c_fluxes: Vec<f64> = Vec::with_capacity(24);
+
+    for hour in 0..24 {
+        let t_outdoor = outdoor_temperature_at(hour);
+        let solar = solar_irradiance_at(hour);
+
+        // Effective exterior temperature = T_outdoor + solar / h_ext
+        // This is the sol-air translation; both solvers use the same T_eff.
+        let t_eff = t_outdoor + solar / CASE_900_H_EXT;
+
+        // GaugeSolver: step with boundary conditions (solar-aware path).
+        let gauge_flux = gauge_solver
+            .step_with_boundary_conditions(
+                Time::from_value(DT_SECONDS),
+                t_int,
+                h_ext,
+                GaugeBoundaryConditions::new(solar, t_outdoor),
+            )
+            .expect("GaugeSolver step")
+            .to_value();
+        gauge_fluxes.push(gauge_flux);
+
+        // FiveR1C: step with effective exterior temperature.
+        // FiveR1C does not have a solar-irradiance parameter; the
+        // effective-temperature approach makes the comparison physically
+        // equivalent to the GaugeSolver boundary-condition translation.
+        let fiver1c_flux = fiver1c_solver
+            .step(
+                Time::from_value(DT_SECONDS),
+                t_int,
+                Temperature::from_value(t_eff),
+                h_int,
+                h_ext,
+            )
+            .expect("FiveR1C step")
+            .to_value();
+        fiver1c_fluxes.push(fiver1c_flux);
+    }
+
+    // ---- AC1: per-hour ±10% agreement ----
+    for hour in 0..24 {
+        let q_gauge = gauge_fluxes[hour];
+        let q_5r1c = fiver1c_fluxes[hour];
+        let drift_pct = if q_5r1c.abs() > 1e-9 {
+            ((q_gauge - q_5r1c) / q_5r1c * 100.0).abs()
+        } else {
+            (q_gauge - q_5r1c).abs() * 100.0
+        };
+        assert!(
+            drift_pct < 10.0,
+            "Hour {hour}: GaugeSolver flux ({q_gauge:.4} W/m²) differs from \
+             FiveR1C ({q_5r1c:.4} W/m²) by {drift_pct:.2}% — exceeds ±10% bound",
+        );
+    }
+
+    // ---- AC2: peak at hour 12, trough at hour 4-5 ----
+    let gauge_peak_hour = gauge_fluxes
+        .iter()
+        .enumerate()
+        .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
+        .map(|(i, _)| i)
+        .expect("non-empty fluxes");
+    let r1c_peak_hour = fiver1c_fluxes
+        .iter()
+        .enumerate()
+        .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
+        .map(|(i, _)| i)
+        .expect("non-empty fluxes");
+    assert_eq!(
+        gauge_peak_hour, 12,
+        "GaugeSolver peak should be at hour 12, got hour {gauge_peak_hour}"
+    );
+    assert_eq!(
+        r1c_peak_hour, 12,
+        "FiveR1C peak should be at hour 12, got hour {r1c_peak_hour}"
+    );
+
+    let gauge_trough_hour = gauge_fluxes
+        .iter()
+        .enumerate()
+        .min_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
+        .map(|(i, _)| i)
+        .expect("non-empty fluxes");
+    let r1c_trough_hour = fiver1c_fluxes
+        .iter()
+        .enumerate()
+        .min_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
+        .map(|(i, _)| i)
+        .expect("non-empty fluxes");
+    assert!(
+        (4..=5).contains(&gauge_trough_hour),
+        "GaugeSolver trough should be at hour 4 or 5, got hour {gauge_trough_hour}"
+    );
+    assert!(
+        (4..=5).contains(&r1c_trough_hour),
+        "FiveR1C trough should be at hour 4 or 5, got hour {r1c_trough_hour}"
+    );
+
+    // ---- AC3: bipolar response (nighttime negative, daytime positive) ----
+    let max_flux = *gauge_fluxes
+        .iter()
+        .max_by(|a, b| a.partial_cmp(b).unwrap())
+        .expect("non-empty");
+    let min_flux = *gauge_fluxes
+        .iter()
+        .min_by(|a, b| a.partial_cmp(b).unwrap())
+        .expect("non-empty");
+    assert!(
+        max_flux > 10.0,
+        "Expected positive daytime peak flux, got {max_flux:.2} W/m²"
+    );
+    assert!(
+        min_flux < -10.0,
+        "Expected negative nighttime flux, got {min_flux:.2} W/m²"
+    );
+
+    // ---- AC4: amplitude ≥80 W/m² ----
+    let amplitude = max_flux - min_flux;
+    assert!(
+        amplitude >= 80.0,
+        "Amplitude {amplitude:.2} W/m² is below 80 W/m² minimum"
+    );
+}
+
+// =============================================================================
+// Test 9: CSV reference parity — read the synthetic diurnal CSV and verify
 // GaugeSolver shadow-mode output matches each hourly reference value.
 // =============================================================================
 


### PR DESCRIPTION
## Summary

Add test_case_900_gauge_fiver1c_diurnal_parity (Test 8) to tests/gauge_validation_case_900.rs. Drives both solvers through identical 24-hour synthetic Case 900 diurnal forcing.

## Physics Note

The test currently FAILS. GaugeSolver is steady-state (no thermal mass) while FiveR1C is transient (tau approx 25.6h). This produces 100-5000% per-hour disagreement -- a fundamental architectural difference. See .agents/results/issue-1465-diurnal-parity.py for full analysis.

## Files Changed
- tests/gauge_validation_case_900.rs: +169 lines
- .agents/results/issue-1465-diurnal-parity.py: Python verification script