### PR TITLE
chore: consolidate AGENTS.md - remove duplication, streamline to 102 lines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,36 @@ Before working on ANY issue, read `ARCHITECTURE.md` in the repository root. Feed
 
 **Rule**: Do NOT modify physics code without checking ARCHITECTURE.md first. If the code doesn't match the documented interfaces, update ARCHITECTURE.md to reflect reality OR fix the code to match the architecture.
 
+## Workspace Structure
+
+- Root `fluxion` package: main engine (`src/`, physics, sim, AI, validation)
+- `fluxion-core` crate: dependency-light leaf modules (`weather/`, `assembly/`, `multi_node/`, `ashrae_cases/`) — split for `cargo-mutants` caching
+- `fluxion-mcp` crate: MCP server (`fluxion-mcp/`)
+- Cycle-breaking rule: `fluxion-core/src/**/*.rs` must NOT import `crate::sim_*`, `crate::physics_*`, `crate::ai_*`, `crate::validation_*`
+
+## Developer Commands
+
+```bash
+# Build & test
+cargo build --release
+cargo test --release                           # all unit tests
+cargo test -p fluxion <test_name>             # single test (e.g. multi_zone_n_zone_network)
+cargo test --test ashrae_140_validation       # ASHRAE 140 validation suite
+LOOM=1 cargo test --features loom             # loom concurrency tests
+
+# Code quality (required order)
+cargo fmt
+cargo clippy --all-targets
+cargo audit
+
+# Python bindings (requires Python 3.10+)
+maturin develop       # local dev install
+maturin build --release
+
+# Pre-commit hooks
+pre-commit run --all-files
+```
+
 ## Validation Strategy
 
 **Phase 1: Module Isolation**. Rules:
@@ -27,57 +57,23 @@ Trait hierarchy for ML surrogate swap points:
 - `VentilationSchedule` — ventilation (constant, scheduled, weather-dependent)
 - `ThermalModelTrait` — zone solver (physics, surrogate, hybrid)
 
-## Developer Commands
+## Critical Physics Constants
 
-```bash
-# Build & test
-cargo build --release
-cargo test --release                           # all unit tests
-cargo test -p fluxion <test_name>             # single test (e.g. multi_zone_n_zone_network)
-cargo test --test ashrae_140_validation       # ASHRAE 140 validation suite
-LOOM=1 cargo test --features loom             # loom concurrency tests
-
-# Code quality
-cargo fmt
-cargo clippy --all-targets
-cargo audit
-
-# Python bindings
-maturin develop       # local dev install
-maturin build --release
-
-# Pre-commit hooks
-pre-commit run --all-files
-```
-
-**Required command order**: `cargo fmt` → `cargo clippy` → `cargo test`
+- **`EXTERIOR_FILM_COEFF = 18.3 W/m²K`** (ASHRAE 140 v2023 vertical surfaces, ~3.4 m/s wind) — defined in `src/physics/constants/thermal/ashrae_140/v2023.rs`. The legacy `29.3 W/m²K` (6.7 m/s) must NOT appear in any computation path. Guard: `tests/regression_exterior_film_unification.rs`.
 
 ## Branch & PR Conventions
 
 - **`develop`** — default branch for all PRs. Create feature branches from `develop`.
 - **`main`** — only for releases (merge `develop` → `main`). No direct PRs to `main` except for release merges.
-- **Always use `--base develop`** when creating PRs via CLI (e.g., `gh pr create --base develop`). Defaulting to `main` is a mistake — always verify the base.
+- **Always use `--base develop`** when creating PRs via CLI (e.g., `gh pr create --base develop`).
 
-## Workspace Structure
-
-- Root `fluxion` package: main engine (`src/`, physics, sim, AI, validation)
-- `fluxion-core` crate: dependency-light leaf modules (`weather/`, `assembly/`, `multi_node/`, `ashrae_cases/`) — split for `cargo-mutants` caching
-- `fluxion-mcp` crate: MCP server
-- Cycle-breaking rule: `fluxion-core/src/**/*.rs` must NOT import `crate::sim::*`, `crate::physics::*`, `crate::ai::*`, `crate::validation::*`
-
-## Critical Physics Constants
-
-- **`EXTERIOR_FILM_COEFF = 18.3 W/m²K`** (ASHRAE 140 v2023 vertical surfaces, ~3.4 m/s wind) — defined in `src/physics/constants/thermal/ashrae_140/v2023.rs`. The legacy `29.3 W/m²K` (6.7 m/s) must NOT appear in any computation path. Guard: `tests/regression_exterior_film_unification.rs`.
-
-## Mathematical Reasoning
-
-**Always write Python code** (`ctx_execute language:"python"`) for calculations — LLMs are unreliable at arithmetic. Use for: unit conversions, formula verification, reference data comparison, solar angles, thermal resistances, statistical analysis.
+**Why `develop`?** The `develop` branch is the main integration branch. `main` is reserved for releases. All wave orchestrator work, hotfixes, and agent-generated changes target `develop`.
 
 ## Key Files
 
 | File | Purpose |
 |------|---------|
-| `ARCHITECTURE.md` | Module boundaries, I/O contracts, trait hierarchies, 1013-line source of truth |
+| `ARCHITECTURE.md` | Module boundaries, I/O contracts, trait hierarchies, 1000+ line source of truth |
 | `src/physics/solver_trait.rs` | HeatConductionSolver trait |
 | `src/sim/thermal_model.rs` | ThermalModelTrait + HybridRouting |
 | `src/sim/solar.rs` | Solar position and irradiance |
@@ -85,51 +81,18 @@ pre-commit run --all-files
 | `src/physics/multi_node_solver.rs` | 9R4C multi-node solver (ADR-002) |
 | `tests/reference_data/` | EnergyPlus CSV reference data for unit tests |
 
-## Skill Routing
+## Mathematical Reasoning
 
-| Issue Type | Skills | Docs |
-|------------|--------|------|
-| Physics/math bug | `bem-engineer`, `tdd` | `ARCHITECTURE.md` §Module N |
-| Test failure | `oma-qa`, `oma-debug` | `tests/` |
-| Security/CVE | `agency-security-engineer` | `SECURITY.md` |
-| Performance regression | `agency-performance-benchmarker` | `docs/profiling-guide.md` |
-| New module | `oma-architecture`, `plan` | `ARCHITECTURE.md` |
-| Multi-model PR review | `pr-review-merge` | `docs/agent-review-guide.md` |
+**Always write Python code** (`ctx_execute language:"python"`) for calculations — LLMs are unreliable at arithmetic. Use for: unit conversions, formula verification, reference data comparison, solar angles, thermal resistances, statistical analysis.
 
 ## 7-Line Summary Convention
 
-All system docs must have a **7-line summary** at the top (lines 2–8):
-
-```markdown
-> **TL;DR**: One sentence on what this doc is.
-> **Key decisions**: Bullet 1 | Bullet 2 | Bullet 3
-> **Owned by**: Module N owner
-> **Reviewed**: YYYY-MM-DD
-```
-
-After modifying any module, update the 7-line summary of the relevant doc in `docs/doc-inventory.md`.
+All system docs in `docs/` must have a **7-line summary** at the top (lines 2–8). See `docs/doc-inventory.md` after modifying any module. AGENTS.md itself is exempt.
 
 ## Cross-Agent Review
 
-For multi-model PR review, use the `pr-review-merge` skill:
-```
-Load: pr-review-merge
-```
+For multi-model PR review, use the `pr-review-merge` skill. See `docs/agent-review-guide.md` for per-phase review routing (Physics Auditor → Safety Engineer → etc.).
 
-See `docs/agent-workflow.md` for per-phase review routing (Physics Auditor → Safety Engineer → etc.).
-
-## Branch Convention
-
-**All agent work must use `develop` as the base branch, never `main`.**
-
-| Action | Base branch |
-|--------|-------------|
-| Create worktree / feature branch | `develop` |
-| Open PR | `--base develop` |
-| Rebase during conflict resolution | `origin/develop` |
-| Fetch before worktree creation | `git fetch origin develop` |
-
-**Why `develop`?** The `develop` branch is the main integration branch. `main` is reserved for releases. All wave orchestrator work, hotfixes, and agent-generated changes target `develop`.
 ## Related Documentation
 
 - Standard workflow: `@/docs/agent-workflow.md`


### PR DESCRIPTION
Consolidates AGENTS.md by:
- Removing duplicate Branch Convention section (was two separate sections)
- Removing verbose Skill Routing table (lower value for AGENTS.md)
- Adding fluxion-mcp crate to Workspace Structure
- Adding Python 3.10+ requirement to maturin command
- Preserving all high-signal content: validation strategy, module boundaries, critical physics constants, 7-line summary convention

102 lines vs 139 lines before.