### PR TITLE
docs: resolve #1722 — Add rustdoc comments to HeatConductionSolver, ThermalModelTrait, and VentilationSchedule

### DIFF
--- a/src/physics/solver_trait.rs
+++ b/src/physics/solver_trait.rs
@@ -161,11 +161,34 @@ pub type PhysicsResult<T> = Result<T, PhysicsError>;
 /// This trait defines the interface for calculating heat transfer through
 /// building envelope constructions (walls, roofs, floors).
 ///
+/// # Query vs State-Advancing Separation
+///
+/// The trait provides two complementary operational modes:
+///
+/// - **`step()`** — Advances the solver's internal thermal-mass state by one
+///   timestep `dt`. The return value is the heat flux that flowed through the
+///   surface *during that transition*; the solver's node temperatures are
+///   mutated in place. Successive calls accumulate the transient response.
+///   Do **not** call this method when you only need a steady-state value —
+///   use `steady_state_flux()` instead.
+///
+/// - **`steady_state_flux()`** — A *pure query* that returns the closed-form
+///   steady-state heat flux for the given boundary temperatures. This method
+///   does **not** mutate solver state and may be called an arbitrary number of
+///   times without side effects. ML-surrogate swap-points (e.g.
+///   `SurfaceHeatFluxProvider`) rely on this contract for parity checks against
+///   the physics path.
+///
+/// Calling `step()` changes the solver's internal state; calling
+/// `steady_state_flux()` never does. For the same `(T_interior, T_exterior)`
+/// inputs, `steady_state_flux()` returns a deterministic value independent of
+/// prior `step()` invocations.
+///
 /// # Lifecycle
 ///
 /// 1. Create solver instance
 /// 2. Call `initialize()` with wall construction
-/// 3. Call `step()` at each timestep
+/// 3. Call `step()` at each timestep (or `steady_state_flux()` for queries)
 /// 4. Query results via `energy_storage_rate()`
 ///
 /// # Example

--- a/src/sim/thermal_model.rs
+++ b/src/sim/thermal_model.rs
@@ -1,7 +1,55 @@
-//! Thermal Model Trait - Modular architecture for swapping physics/surrogate models.
+//! Thermal Model Trait — modular architecture for swapping physics / surrogate models.
 //!
-//! This module defines the core trait interface for thermal modeling, allowing
-//! easy swapping between traditional physics-based approaches and AI surrogate models.
+//! This module defines the core trait interface for building-energy thermal modeling,
+//! allowing different implementations (physics-based, surrogate-based, or hybrid) to be
+//! swapped at runtime without changing calling code.
+//!
+//! # Trait Hierarchy
+//!
+//! [`ThermalModelTrait`] is the top-level trait. Three [`ThermalModelMode`] variants
+//! select the execution strategy:
+//!
+//! | Variant | Behavior |
+//! |---------|----------|
+//! | [`ThermalModelMode::Physics`][pm] | Full analytical 5R1C / 9R4C thermal network. Default. |
+//! | [`ThermalModelMode::Surrogate`][sm] | Neural-network inference via [`SurrogateManager`]. |
+//! | [`ThermalModelMode::Hybrid`][hm] | Per-subsystem routing via [`HybridRouting`]; the default policy routes loads to the surrogate and keeps conduction / ventilation / HVAC on physics. |
+//!
+//! [pm]: ThermalModelMode::Physics
+//! [sm]: ThermalModelMode::Surrogate
+//! [hm]: ThermalModelMode::Hybrid
+//!
+//! # [`HybridRouting`] Flags
+//!
+//! When [`ThermalModelMode::Hybrid`][hm] is selected, a [`HybridRouting`] value
+//! determines which subsystems consult the [`SurrogateManager`]:
+//!
+//! - **`use_surrogate_conduction`** — 5R1C / 9R4C thermal network solve
+//! - **`use_surrogate_ventilation`** — ventilation heat transfer coefficient `h_ve`
+//! - **`use_surrogate_loads`** — internal / external load prediction  *(default: `true`)*
+//! - **`use_surrogate_hvac`** — HVAC power demand
+//!
+//! The default policy is the highest-value / lowest-risk split: only load
+//! prediction runs on the surrogate; all other subsystems remain on the analytical
+//! physics path. See Issue #1431.
+//!
+//! # Concrete Implementations
+//!
+//! | Type | Mode | Notes |
+//! |------|------|-------|
+//! | [`PhysicsThermalModel`] | [`ThermalModelMode::Physics`][pm] | Default; analytical 5R1C / 9R4C |
+//! | [`SurrogateThermalModel`] | [`ThermalModelMode::Surrogate`][sm] | ONNX inference with optional physics fallback |
+//! | [`HybridThermalModel`] | [`ThermalModelMode::Hybrid`][hm] | Per-component routing; default policy via [`HybridRouting::default`] |
+//! | [`UnifiedThermalModel`] | Any | Runtime-switchable; thin wrapper over the above |
+//!
+//! Use [`ThermalModelBuilder`] to construct the desired concrete type from a
+//! fluent configuration DSL.
+//!
+//! # Design Philosophy
+//!
+//! - Easy addition of new surrogate models (ONNX-based)
+//! - Fallback from surrogate to physics-based when needed
+//! - Hybrid mode where some components use surrogates, others use physics
 
 use crate::ai::surrogate::SurrogateManager;
 use crate::physics::cta::{ContinuousTensor, VectorField};

--- a/src/sim/ventilation.rs
+++ b/src/sim/ventilation.rs
@@ -8,6 +8,25 @@
 //! - **Constant**: Fixed ACH regardless of conditions
 //! - **Scheduled**: Time-based ACH changes (e.g., night ventilation)
 //! - **Weather-Responsive**: ACH varies with outdoor temperature and wind speed
+//!
+//! # `ach_to_conductance` Formula
+//!
+//! The [`ach_to_conductance`] function converts an air change rate (ACH) to a
+//! thermal conductance `h_ve` [W/K] representing ventilation heat transfer:
+//!
+//! ```text
+//! h_ve = (ACH × V × ρ × c_p) / 3600
+//! ```
+//!
+//! Where:
+//! - `ACH` — air changes per hour [1/h]
+//! - `V`   — zone volume [m³]
+//! - `ρ`   — air density [kg/m³] (standard: 1.2)
+//! - `c_p` — specific heat of air [J/kg·K] (standard: 1005)
+//! - `3600` — seconds per hour conversion factor
+//!
+//! **Validation**: For `ACH=0.5`, `V=129.6 m³`, `ρ=1.2`, `c_p=1005`:
+//! Fluxion ≈ 21.71 W/K vs EnergyPlus ≈ 21.6 W/K (Δ < 0.5%). See Issue #918.
 
 use crate::physics::units::{FromF64, ThermalConductance};
 use serde::{Deserialize, Serialize};
@@ -112,16 +131,24 @@ pub fn calculate_combined_infiltration_ach(
 /// Trait for defining air change rate (ACH) schedules.
 ///
 /// All implementations should return weather-dependent ACH when applicable,
-/// using the provided weather parameters.
+/// using the provided weather parameters. The returned ACH is multiplied by
+/// zone volume and air properties in [`ach_to_conductance`] to produce the
+/// ventilation heat transfer coefficient `h_ve` [W/K] used in the zone energy
+/// balance.
 pub trait VentilationSchedule: Debug + Send + Sync {
     /// Returns the air change rate (ACH) for a given hour.
     ///
     /// # Arguments
-    /// * `hour` - Hour of day (0-23)
-    /// * `T_outdoor` - Outdoor temperature [C]
-    /// * `T_indoor` - Indoor temperature [C]
-    /// * `wind_speed` - Wind speed [m/s]
-    /// * `volume` - Zone volume [m³]
+    /// * `hour` — Hour of day (0–23)
+    /// * `T_outdoor` — Outdoor dry-bulb temperature [°C]
+    /// * `T_indoor` — Indoor air temperature [°C]
+    /// * `wind_speed` — Wind speed at building height [m/s]
+    /// * `volume` — Zone volume [m³]
+    ///
+    /// # Returns
+    /// Air change rate [1/h]. Implementations may ignore weather arguments
+    /// (e.g. [`ConstantVentilation`]) or use them to modulate the rate
+    /// (e.g. [`WeatherDependentVentilation`]).
     fn get_ach(
         &self,
         hour: usize,
@@ -130,6 +157,7 @@ pub trait VentilationSchedule: Debug + Send + Sync {
         wind_speed: f64,
         volume: f64,
     ) -> f64;
+
     /// Clones the schedule into a boxed trait object.
     fn clone_box(&self) -> Box<dyn VentilationSchedule>;
 }


### PR DESCRIPTION
Closes #1722

Add comprehensive rustdoc documentation to HeatConductionSolver, ThermalModelTrait, and VentilationSchedule traits explaining their contracts, parameters, and usage.