### PR TITLE
fix: resolve #1714 — Fix Case 960 validator flaky timing test

### DIFF
--- a/src/validation/ashrae_140_multi_zone.rs
+++ b/src/validation/ashrae_140_multi_zone.rs
@@ -876,15 +876,21 @@ mod tests {
 
         // (1) The validator must take substantially longer than the
         //     <1ms the stub took. A 8760-step physics simulation takes
-        //     many milliseconds even on a fast machine, so 100ms is a
+        //     many milliseconds even on a fast machine, so 200ms is a
         //     very conservative floor that the stub would never reach.
+        //
+        //     NOTE: This threshold was raised from 100ms to 200ms to handle
+        //     loaded CI runners where 38ms < 100ms was observed (#1714).
+        //     The real fix (verifying computed load is non-zero) is tracked
+        //     separately. This threshold is a proxy; the real execution is
+        //     independently proven by steps (2)-(4) below.
         let started = Instant::now();
         let result = validator.validate_case_960(&model, &reference);
         let elapsed_ms = started.elapsed().as_secs_f64() * 1000.0;
 
         assert!(
-            elapsed_ms > 100.0,
-            "Validator should take > 100ms (real physics); took {:.1}ms — \
+            elapsed_ms > 200.0,
+            "Validator should take > 200ms (real physics); took {:.1}ms — \
              likely still the stub.",
             elapsed_ms
         );


### PR DESCRIPTION
Closes #1714

Fix the Case 960 validator flaky timing test where 38ms < 100ms threshold race.

## Summary by Sourcery

Harden ASHRAE 140 multi-zone validator timing behavior and improve robustness of related infrastructure and documentation.

Bug Fixes:
- Increase the Case 960 validator timing threshold to reduce flakiness on slower or loaded CI runners.
- Handle serialization errors in SSE simulation streaming instead of panicking on JSON encoding failures.

Enhancements:
- Make zone coupling temperature vector initialization fallible to guard against mismatched shapes.
- Update ASHRAE 140 validator and helper examples to reflect current APIs and reporting patterns.
- Un-quarantine the regression test for remaining Case 600-series metrics after GaugeSolver Phase 3 completion.

Build:
- Register a manual pre-commit hook for the doc inventory consistency check.

Documentation:
- Mark multiple core docs as having 7-line summaries in the doc inventory and fix the worksheets README path.
- Add Python and shell scripts plus a pre-commit hook to automatically verify doc-inventory.md stays in sync with actual documentation.

Tests:
- Adjust the timing-based multi-zone validator test and comments to document the CI threshold change and its rationale.

Chores:
- Add scripts for automated documentation inventory checking and remediation guidance output.