### PR TITLE
feat: resolve #1711 — Wire IFC geometry into REST API POST /v1/import/ifc endpoint

### DIFF
--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -61,7 +61,7 @@ use tracing::Level;
 use crate::ai::surrogate::SurrogateManager;
 use crate::api::metrics::{self, metrics_handler};
 use crate::api::schema::{SimulationOutput, SimulationSchema, SimulationSchemaV1};
-use crate::interop::{gbxml, osm};
+use crate::interop::{gbxml, ifc, osm};
 use crate::io::idf::{IdfFile, IdfParser};
 use crate::physics::cta::VectorField;
 use crate::sim::engine::ThermalModel;
@@ -659,6 +659,10 @@ async fn import_format(
             let schema = SimulationSchemaV1::try_from(&idf)
                 .map_err(|e| ApiError::ImportFailed(format!("IDF conversion error: {e}")))?;
             schema
+        }
+        "ifc" => {
+            let tmp = tempfile_for_bytes(&body, "ifc")?;
+            ifc::import_ifc(&tmp).map_err(|e| ApiError::ImportFailed(e.to_string()))?
         }
         other => return Err(ApiError::UnsupportedFormat(other.to_string())),
     };


### PR DESCRIPTION
Closes #1711

Wire IFC geometry into REST API POST /v1/import/ifc endpoint.

## Summary by Sourcery

Integrate IFC import into the REST API and improve documentation, validation ergonomics, and robustness of streaming and thermal coupling utilities.

New Features:
- Add support for importing IFC files via the POST /v1/import/ifc endpoint by wiring the IFC interop module into the format import handler.
- Introduce a doc inventory check script and pre-commit hook to validate documentation presence and 7-line summaries across the repository.

Bug Fixes:
- Handle JSON serialization errors in simulation streaming responses by emitting structured error messages instead of panicking.
- Return errors from ZoneCouplingOptimized::set_temperature_vector when the provided temperature vector shape does not match the number of zones.

Enhancements:
- Update ASHRAE 140 validator examples to reflect current APIs and improve usability of case construction and result reporting.
- Un-quarantine the regression test guarding issue #1457 to reflect completion of GaugeSolver Phase 3.
- Refresh doc-inventory.md statuses to reflect which documents now have 7-line summaries.

Build:
- Add a pre-commit hook configuration for the doc inventory check script to keep documentation metadata in sync.

Documentation:
- Update docs/doc-inventory.md to mark existing summaries as complete and correct the worksheets README path reference.

Tests:
- Enable the previously ignored regression test covering remaining Case 600-series metrics for issue #1457.

Chores:
- Add Python and shell entry points for running the doc inventory check as part of local workflows.