### PR TITLE
feat(api): wire POST /v1/import/epjson endpoint

### DIFF
--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -380,8 +380,9 @@ paths:
         - `osm` — OpenStudio Model (delegates to `crate::interop::osm::import_osm`)
         - `gbxml` — gbXML (delegates to `crate::interop::gbxml::import_gbxml`)
         - `ifc` — IFC4 STEP physical file (delegates to `crate::interop::ifc::import_ifc`)
-        - `idf` — EnergyPlus IDF — **returns 501 Not Implemented**; no IDF
-          reader exists in `src/interop/*` yet (out of scope for #1342).
+        - `idf` — EnergyPlus IDF text (delegates to `crate::io::idf::IdfParser::from_str`)
+        - `epjson` — EnergyPlus epJSON (JSON representation of IDF; delegates to
+          `crate::io::idf::IdfParser::from_epjson_str`)
 
         On success, the schema is stored under an auto-generated id and the
         id + schema are returned. Callers can fetch the schema later via
@@ -391,10 +392,10 @@ paths:
         - name: fmt
           in: path
           required: true
-          description: Source format (`osm`, `gbxml`, `ifc`, or `idf`)
+          description: Source format (`osm`, `gbxml`, `ifc`, `idf`, or `epjson`)
           schema:
             type: string
-            enum: [osm, gbxml, ifc, idf]
+            enum: [osm, gbxml, ifc, idf, epjson]
       requestBody:
         required: true
         content:

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -664,6 +664,15 @@ async fn import_format(
             let tmp = tempfile_for_bytes(&body, "ifc")?;
             ifc::import_ifc(&tmp).map_err(|e| ApiError::ImportFailed(e.to_string()))?
         }
+        "epjson" => {
+            let body_str = std::str::from_utf8(&body)
+                .map_err(|e| ApiError::ImportFailed(format!("invalid UTF-8 in epJSON body: {e}")))?;
+            let idf: IdfFile = IdfParser::from_epjson_str(body_str)
+                .map_err(|e| ApiError::ImportFailed(format!("epJSON parse error: {e}")))?;
+            let schema = SimulationSchemaV1::try_from(&idf)
+                .map_err(|e| ApiError::ImportFailed(format!("IDF conversion error: {e}")))?;
+            schema
+        }
         other => return Err(ApiError::UnsupportedFormat(other.to_string())),
     };
 

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -665,8 +665,9 @@ async fn import_format(
             ifc::import_ifc(&tmp).map_err(|e| ApiError::ImportFailed(e.to_string()))?
         }
         "epjson" => {
-            let body_str = std::str::from_utf8(&body)
-                .map_err(|e| ApiError::ImportFailed(format!("invalid UTF-8 in epJSON body: {e}")))?;
+            let body_str = std::str::from_utf8(&body).map_err(|e| {
+                ApiError::ImportFailed(format!("invalid UTF-8 in epJSON body: {e}"))
+            })?;
             let idf: IdfFile = IdfParser::from_epjson_str(body_str)
                 .map_err(|e| ApiError::ImportFailed(format!("epJSON parse error: {e}")))?;
             let schema = SimulationSchemaV1::try_from(&idf)

--- a/tests/api_integration_tests.rs
+++ b/tests/api_integration_tests.rs
@@ -252,6 +252,32 @@ BuildingSurface:Detailed, Wall-South, Wall, ExtWall, Zone1, , Outdoors, SunExpos
 }
 
 #[tokio::test]
+async fn import_epjson_returns_200_with_valid_epjson() {
+    let (base, _state, _shutdown) = start_server().await;
+    let epjson_body = r#"{
+  "Version": {
+    "Version 1": {
+      "version_identifier": "25.2"
+    }
+  },
+  "Building": {
+    "TestBuilding": {
+      "name": "TestBuilding",
+      "north_axis": 0.0,
+      "terrain": "Suburbs"
+    }
+  }
+}"#;
+    let resp = http_client()
+        .post(format!("{base}/v1/import/epjson"))
+        .body(epjson_body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "valid epJSON should return 200");
+}
+
+#[tokio::test]
 async fn import_unknown_format_returns_400() {
     let (base, _state, _shutdown) = start_server().await;
     let resp = http_client()


### PR DESCRIPTION
Wires IdfParser::from_epjson_str into the REST API POST /v1/import/epjson endpoint, following the existing IDF pattern.

## Changes
- **src/api/server.rs**: add 'epjson' match arm in import_format handler
- **src/api/openapi.yaml**: document epjson format and add to enum  
- **tests/api_integration_tests.rs**: add import_epjson_returns_200 test

## Testing
- `cargo test --test api_integration_tests` — 22 passed
- `cargo test --lib openapi_yaml_paths_match_router` — passed
- Build compiled successfully