### PR TITLE
feat: resolve #1792 — worker-side KPI aggregation before S3 sync

### DIFF
--- a/docs/CLOUD_CAMPAIGN.md
+++ b/docs/CLOUD_CAMPAIGN.md
@@ -20,7 +20,7 @@ This cloud-hosted system decouples campaign execution from local machines by:
 │ Cloud Campaign   │────▶│  S3 Bucket  │◀────│  S3 Worker      │
 │ Manager          │     │             │     │  (Remote VM/EC2)│
 └──────────────────┘     │  work-units │     └─────────────────┘
-       │                 │  results/   │              │
+       │                 │  kpi-results/│              │
        │                 │  state.json  │              │
        │                 └─────────────┘              │
        ▼                                                │
@@ -29,6 +29,10 @@ This cloud-hosted system decouples campaign execution from local machines by:
 │ (Email/SMS)     │         (on completion)
 └──────────────────┘
 ```
+
+**Worker-side KPI Aggregation (T8.3):** Workers compute and emit only aggregated KPIs
+before S3 sync, cutting transfer volume. Raw results are included only when
+`--emit-raw` is specified.
 
 ## Quick Start
 
@@ -153,6 +157,47 @@ aws s3api put-bucket-versioning \
   --bucket your-bucket-name \
   --versioning-configuration Status=Enabled
 ```
+
+## KPI Schema
+
+Worker-side aggregation emits `KPIResult` JSON files with the following structure:
+
+```json
+{
+  "work_unit_id": "wu-0001",
+  "campaign_id": "fluxion-abc123",
+  "run_id": "a1b2c3d4",
+  "case_id": "600",
+  "parameters": {"R_value": 2.5, "wall_thickness": 0.15},
+  "num_runs": 5,
+  "timestamp": "2026-07-17T12:00:00Z",
+
+  "heating_mae_mean": 5.2,
+  "heating_mae_std": 0.8,
+  "heating_mae_min": 4.1,
+  "heating_mae_max": 6.3,
+  "cooling_mae_mean": 4.8,
+  "cooling_mae_std": 0.6,
+  "cooling_mae_min": 3.9,
+  "cooling_mae_max": 5.7,
+
+  "peak_heating_mae_mean": 8.2,
+  "peak_cooling_mae_mean": 7.1,
+  "temperature_mae_mean": 3.4,
+
+  "overall_pass_rate": 0.8,
+  "duration_ms_mean": 45200,
+
+  "error_message": null,
+  "raw_results": null
+}
+```
+
+**Fields:**
+- All MAE values are percentages (%)
+- `num_runs` indicates how many simulation runs were aggregated
+- `raw_results` is only populated when `--emit-raw` is specified
+- `overall_pass_rate` is the fraction of runs that passed (0.0 to 1.0)
 
 ### SNS Topic
 

--- a/scripts/s3_worker.py
+++ b/scripts/s3_worker.py
@@ -75,6 +75,104 @@ class WorkUnitResult:
     error_message: Optional[str] = None
 
 
+@dataclass
+class KPIResult:
+    """
+    Aggregated KPI result emitted by workers before S3 sync.
+
+    KPI Schema
+    ----------
+    All MAE (Mean Absolute Error) values are percentages (%).
+    Statistics are computed across multiple runs of the same work unit.
+
+    Fields
+    ------
+    work_unit_id : str
+        Unique work unit identifier.
+    campaign_id : str
+        Campaign this work unit belongs to.
+    run_id : str
+        Execution run identifier.
+    case_id : str
+        ASHRAE 140 case identifier (e.g., "600", "600_00001").
+    parameters : dict[str, float]
+        Input parameters swept for this work unit.
+    num_runs : int
+        Number of simulation runs aggregated into this KPI.
+    timestamp : str
+        ISO 8601 timestamp of result emission.
+
+    Aggregated MAE Statistics
+    -------------------------
+    heating_mae_mean : float
+        Mean heating MAE across runs (%).
+    heating_mae_std : float
+        Standard deviation of heating MAE across runs (%).
+    heating_mae_min : float
+        Minimum heating MAE across runs (%).
+    heating_mae_max : float
+        Maximum heating MAE across runs (%).
+
+    cooling_mae_mean : float
+        Mean cooling MAE across runs (%).
+    cooling_mae_std : float
+        Standard deviation of cooling MAE across runs (%).
+    cooling_mae_min : float
+        Minimum cooling MAE across runs (%).
+    cooling_mae_max : float
+        Maximum cooling MAE across runs (%).
+
+    peak_heating_mae_mean : float
+        Mean peak heating MAE across runs (%).
+    peak_cooling_mae_mean : float
+        Mean peak cooling MAE across runs (%).
+    temperature_mae_mean : float
+        Mean temperature MAE across runs (%).
+
+    Pass Rate
+    ---------
+    overall_pass_rate : float
+        Fraction of runs that passed (0.0 to 1.0).
+
+    Performance
+    -----------
+    duration_ms_mean : float
+        Mean execution duration across runs (ms).
+
+    Error Handling
+    --------------
+    error_message : Optional[str]
+        Error message if all runs failed, None otherwise.
+
+    Raw Results
+    -----------
+    raw_results : Optional[list[WorkUnitResult]]
+        Individual run results if --emit-raw was specified, None otherwise.
+    """
+    work_unit_id: str
+    campaign_id: str
+    run_id: str
+    case_id: str
+    parameters: dict[str, float]
+    num_runs: int
+    timestamp: str
+    heating_mae_mean: float
+    heating_mae_std: float
+    heating_mae_min: float
+    heating_mae_max: float
+    cooling_mae_mean: float
+    cooling_mae_std: float
+    cooling_mae_min: float
+    cooling_mae_max: float
+    peak_heating_mae_mean: float
+    peak_cooling_mae_mean: float
+    temperature_mae_mean: float
+    overall_pass_rate: float
+    duration_ms_mean: float
+    error_message: Optional[str] = None
+    raw_results: Optional[list] = None
+
+
 def get_aws_clients():
     """Get configured boto3 clients."""
     if boto3 is None:
@@ -121,8 +219,8 @@ def parse_s3_uri(uri: str) -> tuple[str, str]:
     return parts[0], parts[1] if len(parts) > 1 else ""
 
 
-def push_result_to_s3(result: WorkUnitResult, s3_prefix: str, clients: dict) -> str:
-    """Push work unit result directly to S3. Returns the S3 URI."""
+def push_result_to_s3(result: WorkUnitResult | KPIResult, s3_prefix: str, clients: dict) -> str:
+    """Push work unit result or KPI result directly to S3. Returns the S3 URI."""
     bucket, prefix = parse_s3_uri(s3_prefix)
     result_key = f"{prefix}/results/{result.work_unit_id}.json"
 
@@ -251,59 +349,150 @@ def parse_cargo_output(output: str) -> dict[str, Any]:
     return metrics
 
 
-def run_worker(work_unit: WorkUnit) -> WorkUnitResult:
-    """Execute a single work unit and push result to S3."""
+def compute_kpi_stats(values: list[float]) -> tuple[float, float, float, float]:
+    """Compute mean, std, min, max from a list of values."""
+    if not values:
+        return 0.0, 0.0, 0.0, 0.0
+    mean_val = sum(values) / len(values)
+    std_val = (sum((v - mean_val) ** 2 for v in values) / len(values)) ** 0.5 if len(values) > 1 else 0.0
+    return mean_val, std_val, min(values), max(values)
+
+
+def run_worker(work_unit: WorkUnit, emit_raw: bool = False, num_runs: int = 1) -> KPIResult:
+    """
+    Execute a work unit and emit aggregated KPIs to S3.
+
+    Parameters
+    ----------
+    work_unit : WorkUnit
+        Work unit to execute.
+    emit_raw : bool
+        If True, include individual run results in output.
+    num_runs : int
+        Number of simulation runs to aggregate (default 1).
+
+    Returns
+    -------
+    KPIResult
+        Aggregated KPI result with statistics.
+    """
     clients = get_aws_clients()
     run_id = str(uuid.uuid4())[:8]
 
     print(f"[*] Starting work unit {work_unit.work_unit_id}")
     print(f"[*] Campaign: {work_unit.campaign_id}")
     print(f"[*] Parameters: {work_unit.parameters}")
+    print(f"[*] Running {num_runs} simulation(s) for aggregation")
 
     update_campaign_progress(
         work_unit.campaign_id, work_unit.work_unit_id, "running", clients
     )
 
-    start = time.time()
-    metrics, raw_output = run_simulation(work_unit)
-    duration_ms = int((time.time() - start) * 1000)
+    raw_results: list[WorkUnitResult] = []
+    heating_maes = []
+    cooling_maes = []
+    peak_heating_maes = []
+    peak_cooling_maes = []
+    temperature_maes = []
+    pass_count = 0
+    durations = []
 
-    if "error" in metrics:
-        result = WorkUnitResult(
-            work_unit_id=work_unit.work_unit_id,
-            campaign_id=work_unit.campaign_id,
-            run_id=run_id,
-            case_id=work_unit.case_id,
-            parameters=work_unit.parameters,
-            heating_mae=999.0,
-            cooling_mae=999.0,
-            peak_heating_mae=999.0,
-            peak_cooling_mae=999.0,
-            temperature_mae=999.0,
-            overall_pass=False,
-            duration_ms=duration_ms,
-            timestamp=datetime.now(timezone.utc).isoformat(),
-            error_message=str(metrics.get("error", "unknown")),
-        )
-    else:
-        result = WorkUnitResult(
-            work_unit_id=work_unit.work_unit_id,
-            campaign_id=work_unit.campaign_id,
-            run_id=run_id,
-            case_id=work_unit.case_id,
-            parameters=work_unit.parameters,
-            heating_mae=metrics.get("heating_mae", 999.0),
-            cooling_mae=metrics.get("cooling_mae", 999.0),
-            peak_heating_mae=metrics.get("peak_heating_mae", 999.0),
-            peak_cooling_mae=metrics.get("peak_cooling_mae", 999.0),
-            temperature_mae=metrics.get("temperature_mae", 999.0),
-            overall_pass=metrics.get("overall_pass", False),
-            duration_ms=duration_ms,
-            timestamp=datetime.now(timezone.utc).isoformat(),
-        )
+    for run_idx in range(num_runs):
+        start = time.time()
+        metrics, raw_output = run_simulation(work_unit)
+        duration_ms = int((time.time() - start) * 1000)
+        durations.append(duration_ms)
+
+        if "error" in metrics:
+            raw_results.append(WorkUnitResult(
+                work_unit_id=work_unit.work_unit_id,
+                campaign_id=work_unit.campaign_id,
+                run_id=f"{run_id}-{run_idx}",
+                case_id=work_unit.case_id,
+                parameters=work_unit.parameters,
+                heating_mae=999.0,
+                cooling_mae=999.0,
+                peak_heating_mae=999.0,
+                peak_cooling_mae=999.0,
+                temperature_mae=999.0,
+                overall_pass=False,
+                duration_ms=duration_ms,
+                timestamp=datetime.now(timezone.utc).isoformat(),
+                error_message=str(metrics.get("error", "unknown")),
+            ))
+        else:
+            heating = metrics.get("heating_mae", 999.0)
+            cooling = metrics.get("cooling_mae", 999.0)
+            peak_heat = metrics.get("peak_heating_mae", 999.0)
+            peak_cool = metrics.get("peak_cooling_mae", 999.0)
+            temp = metrics.get("temperature_mae", 999.0)
+            passed = metrics.get("overall_pass", False)
+
+            heating_maes.append(heating)
+            cooling_maes.append(cooling)
+            peak_heating_maes.append(peak_heat)
+            peak_cooling_maes.append(peak_cool)
+            temperature_maes.append(temp)
+            if passed:
+                pass_count += 1
+
+            raw_results.append(WorkUnitResult(
+                work_unit_id=work_unit.work_unit_id,
+                campaign_id=work_unit.campaign_id,
+                run_id=f"{run_id}-{run_idx}",
+                case_id=work_unit.case_id,
+                parameters=work_unit.parameters,
+                heating_mae=heating,
+                cooling_mae=cooling,
+                peak_heating_mae=peak_heat,
+                peak_cooling_mae=peak_cool,
+                temperature_mae=temp,
+                overall_pass=passed,
+                duration_ms=duration_ms,
+                timestamp=datetime.now(timezone.utc).isoformat(),
+            ))
+
+    # Compute aggregated KPIs
+    h_mean, h_std, h_min, h_max = compute_kpi_stats(heating_maes)
+    c_mean, c_std, c_min, c_max = compute_kpi_stats(cooling_maes)
+    ph_mean, _, _, _ = compute_kpi_stats(peak_heating_maes)
+    pc_mean, _, _, _ = compute_kpi_stats(peak_cooling_maes)
+    t_mean, _, _, _ = compute_kpi_stats(temperature_maes)
+    dur_mean, _, _, _ = compute_kpi_stats(durations)
+    pass_rate = pass_count / num_runs if num_runs > 0 else 0.0
+
+    has_error = any(r.error_message is not None for r in raw_results)
+    error_msg = None
+    if has_error and all(r.error_message is not None for r in raw_results):
+        error_msg = "; ".join(set(r.error_message for r in raw_results if r.error_message))
+
+    result = KPIResult(
+        work_unit_id=work_unit.work_unit_id,
+        campaign_id=work_unit.campaign_id,
+        run_id=run_id,
+        case_id=work_unit.case_id,
+        parameters=work_unit.parameters,
+        num_runs=num_runs,
+        timestamp=datetime.now(timezone.utc).isoformat(),
+        heating_mae_mean=h_mean,
+        heating_mae_std=h_std,
+        heating_mae_min=h_min,
+        heating_mae_max=h_max,
+        cooling_mae_mean=c_mean,
+        cooling_mae_std=c_std,
+        cooling_mae_min=c_min,
+        cooling_mae_max=c_max,
+        peak_heating_mae_mean=ph_mean,
+        peak_cooling_mae_mean=pc_mean,
+        temperature_mae_mean=t_mean,
+        overall_pass_rate=pass_rate,
+        duration_ms_mean=dur_mean,
+        error_message=error_msg,
+        raw_results=raw_results if emit_raw else None,
+    )
 
     result_uri = push_result_to_s3(result, work_unit.s3_result_prefix, clients)
-    print(f"[*] Result pushed to: {result_uri}")
+    print(f"[*] KPI result pushed to: {result_uri}")
 
     update_campaign_progress(
         work_unit.campaign_id, work_unit.work_unit_id, "completed", clients
@@ -312,12 +501,13 @@ def run_worker(work_unit: WorkUnit) -> WorkUnitResult:
     return result
 
 
-def run_sqs_worker(queue_url: str) -> None:
+def run_sqs_worker(queue_url: str, emit_raw: bool = False, num_runs: int = 1) -> None:
     """Long-running SQS worker that processes messages from a queue."""
     clients = get_aws_clients()
     sqs = clients["sqs"] if "sqs" in clients else boto3.client("sqs")
 
     print(f"[*] Listening on SQS queue: {queue_url}")
+    print(f"[*] Aggregation: {num_runs} runs, emit_raw={emit_raw}")
 
     while True:
         try:
@@ -333,7 +523,7 @@ def run_sqs_worker(queue_url: str) -> None:
                 work_unit = download_work_unit(body["param_file"], clients)
 
                 try:
-                    run_worker(work_unit)
+                    run_worker(work_unit, emit_raw=emit_raw, num_runs=num_runs)
                     sqs.delete_message(
                         QueueUrl=queue_url, ReceiptHandle=message["ReceiptHandle"]
                     )
@@ -383,22 +573,36 @@ def main() -> int:
         type=str,
         help="SQS queue URL (for sqs mode)",
     )
+    parser.add_argument(
+        "--emit-raw",
+        action="store_true",
+        help="Include individual run results in output (increases data transfer)",
+    )
+    parser.add_argument(
+        "--num-runs",
+        type=int,
+        default=1,
+        help="Number of simulation runs to aggregate per work unit (default: 1)",
+    )
     args = parser.parse_args()
 
     if args.mode == "sqs":
         if not args.queue_url:
             parser.error("--queue-url is required for sqs mode")
-        run_sqs_worker(args.queue_url)
+        run_sqs_worker(args.queue_url, emit_raw=args.emit_raw, num_runs=args.num_runs)
         return 0
 
     if not args.param_file:
         parser.error("--param-file is required for single mode")
 
     work_unit = download_work_unit(args.param_file, get_aws_clients())
-    result = run_worker(work_unit)
+    result = run_worker(work_unit, emit_raw=args.emit_raw, num_runs=args.num_runs)
 
     print(f"[*] Work unit complete: {result.work_unit_id}")
-    print(f"    MAE: {result.heating_mae:.2f}% heating, {result.cooling_mae:.2f}% cooling")
+    print(f"    Aggregated KPIs over {result.num_runs} run(s):")
+    print(f"    Heating MAE: {result.heating_mae_mean:.2f}% (std: {result.heating_mae_std:.2f}%)")
+    print(f"    Cooling MAE: {result.cooling_mae_mean:.2f}% (std: {result.cooling_mae_std:.2f}%)")
+    print(f"    Pass rate: {result.overall_pass_rate * 100:.1f}%")
 
     return 0 if result.error_message is None else 1
 


### PR DESCRIPTION
Closes #1792

Workers now compute and emit only aggregated KPIs (plus optional raw on demand), cutting transfer volume for the data that does need to go to S3. This is the prerequisite for T8.4 (compression) and T8.5 (.sql exclusion).