### PR TITLE
feat: resolve #1795 — expose 9R4C internal config via PyO3

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1676,6 +1676,13 @@ fn fluxion(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(pyo3::wrap_pyfunction!(python::osm_bindings::import_osm, m)?)?;
     m.add_function(pyo3::wrap_pyfunction!(python::osm_bindings::export_osm, m)?)?;
 
+    // Register 9R4C Multi-Node Solver classes
+    m.add_class::<python::multi_node_bindings::PyThermalMassNode>()?;
+    m.add_class::<python::multi_node_bindings::PyMultiNodeThermalMass>()?;
+    m.add_class::<python::multi_node_bindings::PyMassAirCouplingMode>()?;
+    m.add_class::<python::multi_node_bindings::PySurfaceExteriorTemperatures>()?;
+    m.add_class::<python::multi_node_bindings::PyMultiNodeSolver>()?;
+
     Ok(())
 }
 

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -5,10 +5,14 @@ pub mod bindings;
 #[cfg(feature = "python-bindings")]
 pub mod hvac_bindings;
 #[cfg(feature = "python-bindings")]
+pub mod multi_node_bindings;
+#[cfg(feature = "python-bindings")]
 pub mod osm_bindings;
 
 #[cfg(feature = "python-bindings")]
 pub use hvac_bindings::*;
+#[cfg(feature = "python-bindings")]
+pub use multi_node_bindings::*;
 #[cfg(feature = "python-bindings")]
 pub use osm_bindings::*;
 
@@ -40,6 +44,13 @@ pub fn fluxion_python(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<osm_bindings::PyOsmWriter>()?;
     m.add_function(pyo3::wrap_pyfunction!(osm_bindings::import_osm, m)?)?;
     m.add_function(pyo3::wrap_pyfunction!(osm_bindings::export_osm, m)?)?;
+
+    // Register 9R4C Multi-Node Solver classes
+    m.add_class::<multi_node_bindings::PyThermalMassNode>()?;
+    m.add_class::<multi_node_bindings::PyMultiNodeThermalMass>()?;
+    m.add_class::<multi_node_bindings::PyMassAirCouplingMode>()?;
+    m.add_class::<multi_node_bindings::PySurfaceExteriorTemperatures>()?;
+    m.add_class::<multi_node_bindings::PyMultiNodeSolver>()?;
 
     Ok(())
 }

--- a/src/python/multi_node_bindings.rs
+++ b/src/python/multi_node_bindings.rs
@@ -1,0 +1,640 @@
+//! Python bindings for 9R4C Multi-Node Thermal Solver
+//!
+//! This module provides PyO3 bindings for the 9R4C multi-node thermal model
+//! used for heavy-mass buildings (Case 900+ series).
+
+use crate::physics::multi_node_solver::{MultiNodeSolver, SurfaceExteriorTemperatures};
+use fluxion_core::multi_node::{MassAirCouplingMode, MultiNodeThermalMass, ThermalMassNode};
+use pyo3::prelude::*;
+
+#[pyclass(name = "ThermalMassNode")]
+#[derive(Clone, Debug)]
+pub struct PyThermalMassNode {
+    pub temperature: f64,
+    pub capacitance: f64,
+    pub h_tr_ms: f64,
+    pub h_tr_em: f64,
+    pub h_tr_me: f64,
+    pub heat_flux_cumulative: f64,
+}
+
+impl From<&ThermalMassNode> for PyThermalMassNode {
+    fn from(node: &ThermalMassNode) -> Self {
+        Self {
+            temperature: node.temperature,
+            capacitance: node.capacitance,
+            h_tr_ms: node.h_tr_ms,
+            h_tr_em: node.h_tr_em,
+            h_tr_me: node.h_tr_me,
+            heat_flux_cumulative: node.heat_flux_cumulative,
+        }
+    }
+}
+
+#[pymethods]
+impl PyThermalMassNode {
+    #[new]
+    pub fn new(
+        temperature: f64,
+        capacitance: f64,
+        h_tr_ms: f64,
+        h_tr_em: f64,
+        h_tr_me: f64,
+    ) -> Self {
+        Self {
+            temperature,
+            capacitance,
+            h_tr_ms,
+            h_tr_em,
+            h_tr_me,
+            heat_flux_cumulative: 0.0,
+        }
+    }
+
+    #[getter]
+    pub fn temperature(&self) -> f64 {
+        self.temperature
+    }
+
+    #[setter]
+    pub fn set_temperature(&mut self, value: f64) {
+        self.temperature = value;
+    }
+
+    #[getter]
+    pub fn capacitance(&self) -> f64 {
+        self.capacitance
+    }
+
+    #[setter]
+    pub fn set_capacitance(&mut self, value: f64) {
+        self.capacitance = value;
+    }
+
+    #[getter]
+    pub fn h_tr_ms(&self) -> f64 {
+        self.h_tr_ms
+    }
+
+    #[setter]
+    pub fn set_h_tr_ms(&mut self, value: f64) {
+        self.h_tr_ms = value;
+    }
+
+    #[getter]
+    pub fn h_tr_em(&self) -> f64 {
+        self.h_tr_em
+    }
+
+    #[setter]
+    pub fn set_h_tr_em(&mut self, value: f64) {
+        self.h_tr_em = value;
+    }
+
+    #[getter]
+    pub fn h_tr_me(&self) -> f64 {
+        self.h_tr_me
+    }
+
+    #[setter]
+    pub fn set_h_tr_me(&mut self, value: f64) {
+        self.h_tr_me = value;
+    }
+
+    #[getter]
+    pub fn heat_flux_cumulative(&self) -> f64 {
+        self.heat_flux_cumulative
+    }
+}
+
+#[pyclass(name = "MultiNodeThermalMass")]
+#[derive(Clone, Debug)]
+pub struct PyMultiNodeThermalMass {
+    pub wall: PyThermalMassNode,
+    pub roof: PyThermalMassNode,
+    pub floor: PyThermalMassNode,
+    pub internal: PyThermalMassNode,
+}
+
+impl From<&MultiNodeThermalMass> for PyMultiNodeThermalMass {
+    fn from(mass: &MultiNodeThermalMass) -> Self {
+        Self {
+            wall: PyThermalMassNode::from(&mass.wall),
+            roof: PyThermalMassNode::from(&mass.roof),
+            floor: PyThermalMassNode::from(&mass.floor),
+            internal: PyThermalMassNode::from(&mass.internal),
+        }
+    }
+}
+
+#[pymethods]
+impl PyMultiNodeThermalMass {
+    #[new]
+    pub fn new(
+        wall: PyThermalMassNode,
+        roof: PyThermalMassNode,
+        floor: PyThermalMassNode,
+        internal: PyThermalMassNode,
+    ) -> Self {
+        Self {
+            wall,
+            roof,
+            floor,
+            internal,
+        }
+    }
+
+    #[getter]
+    pub fn wall(&self) -> PyThermalMassNode {
+        self.wall.clone()
+    }
+
+    #[setter]
+    pub fn set_wall(&mut self, value: PyThermalMassNode) {
+        self.wall = value;
+    }
+
+    #[getter]
+    pub fn roof(&self) -> PyThermalMassNode {
+        self.roof.clone()
+    }
+
+    #[setter]
+    pub fn set_roof(&mut self, value: PyThermalMassNode) {
+        self.roof = value;
+    }
+
+    #[getter]
+    pub fn floor(&self) -> PyThermalMassNode {
+        self.floor.clone()
+    }
+
+    #[setter]
+    pub fn set_floor(&mut self, value: PyThermalMassNode) {
+        self.floor = value;
+    }
+
+    #[getter]
+    pub fn internal(&self) -> PyThermalMassNode {
+        self.internal.clone()
+    }
+
+    #[setter]
+    pub fn set_internal(&mut self, value: PyThermalMassNode) {
+        self.internal = value;
+    }
+}
+
+#[pyclass(name = "MassAirCouplingMode", eq, eq_int)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum PyMassAirCouplingMode {
+    AdditiveSum,
+    ParallelResistance,
+}
+
+impl From<MassAirCouplingMode> for PyMassAirCouplingMode {
+    fn from(mode: MassAirCouplingMode) -> Self {
+        match mode {
+            MassAirCouplingMode::AdditiveSum => PyMassAirCouplingMode::AdditiveSum,
+            MassAirCouplingMode::ParallelResistance => PyMassAirCouplingMode::ParallelResistance,
+        }
+    }
+}
+
+impl From<PyMassAirCouplingMode> for MassAirCouplingMode {
+    fn from(mode: PyMassAirCouplingMode) -> Self {
+        match mode {
+            PyMassAirCouplingMode::AdditiveSum => MassAirCouplingMode::AdditiveSum,
+            PyMassAirCouplingMode::ParallelResistance => MassAirCouplingMode::ParallelResistance,
+        }
+    }
+}
+
+#[pymethods]
+impl PyMassAirCouplingMode {
+    fn __repr__(&self) -> &'static str {
+        match self {
+            PyMassAirCouplingMode::AdditiveSum => "MassAirCouplingMode.AdditiveSum",
+            PyMassAirCouplingMode::ParallelResistance => "MassAirCouplingMode.ParallelResistance",
+        }
+    }
+}
+
+#[pyclass(name = "SurfaceExteriorTemperatures")]
+#[derive(Clone, Debug)]
+pub struct PySurfaceExteriorTemperatures {
+    pub t_ext_wall: f64,
+    pub t_ext_roof: f64,
+    pub t_ext_floor: f64,
+}
+
+impl From<&SurfaceExteriorTemperatures> for PySurfaceExteriorTemperatures {
+    fn from(temps: &SurfaceExteriorTemperatures) -> Self {
+        Self {
+            t_ext_wall: temps.t_ext_wall,
+            t_ext_roof: temps.t_ext_roof,
+            t_ext_floor: temps.t_ext_floor,
+        }
+    }
+}
+
+impl From<&PySurfaceExteriorTemperatures> for SurfaceExteriorTemperatures {
+    fn from(temps: &PySurfaceExteriorTemperatures) -> Self {
+        SurfaceExteriorTemperatures {
+            t_ext_wall: temps.t_ext_wall,
+            t_ext_roof: temps.t_ext_roof,
+            t_ext_floor: temps.t_ext_floor,
+        }
+    }
+}
+
+#[pymethods]
+impl PySurfaceExteriorTemperatures {
+    #[new]
+    pub fn new(t_ext_wall: f64, t_ext_roof: f64, t_ext_floor: f64) -> Self {
+        Self {
+            t_ext_wall,
+            t_ext_roof,
+            t_ext_floor,
+        }
+    }
+
+    #[getter]
+    pub fn t_ext_wall(&self) -> f64 {
+        self.t_ext_wall
+    }
+
+    #[setter]
+    pub fn set_t_ext_wall(&mut self, value: f64) {
+        self.t_ext_wall = value;
+    }
+
+    #[getter]
+    pub fn t_ext_roof(&self) -> f64 {
+        self.t_ext_roof
+    }
+
+    #[setter]
+    pub fn set_t_ext_roof(&mut self, value: f64) {
+        self.t_ext_roof = value;
+    }
+
+    #[getter]
+    pub fn t_ext_floor(&self) -> f64 {
+        self.t_ext_floor
+    }
+
+    #[setter]
+    pub fn set_t_ext_floor(&mut self, value: f64) {
+        self.t_ext_floor = value;
+    }
+}
+
+#[pyclass(name = "MultiNodeSolver")]
+#[derive(Clone, Debug)]
+pub struct PyMultiNodeSolver {
+    pub mass: PyMultiNodeThermalMass,
+    pub h_tr_is: f64,
+    pub zone_temperature: f64,
+    pub surface_temperature: f64,
+    pub exterior_temperature: f64,
+    pub exterior_temperatures: PySurfaceExteriorTemperatures,
+    pub timestep_seconds: f64,
+    pub coupling_mode: PyMassAirCouplingMode,
+    pub r_total: f64,
+    pub r_se: f64,
+    pub initialized: bool,
+    pub last_dt: f64,
+}
+
+impl From<&MultiNodeSolver> for PyMultiNodeSolver {
+    fn from(solver: &MultiNodeSolver) -> Self {
+        Self {
+            mass: PyMultiNodeThermalMass::from(&solver.mass),
+            h_tr_is: solver.h_tr_is,
+            zone_temperature: solver.zone_temperature,
+            surface_temperature: solver.surface_temperature,
+            exterior_temperature: solver.exterior_temperature,
+            exterior_temperatures: PySurfaceExteriorTemperatures::from(
+                &solver.exterior_temperatures,
+            ),
+            timestep_seconds: solver.timestep_seconds,
+            coupling_mode: PyMassAirCouplingMode::from(solver.coupling_mode),
+            r_total: solver.r_total,
+            r_se: solver.r_se,
+            initialized: solver.initialized,
+            last_dt: solver.last_dt,
+        }
+    }
+}
+
+#[pymethods]
+impl PyMultiNodeSolver {
+    #[new]
+    pub fn new(
+        h_tr_is: f64,
+        wall: PyThermalMassNode,
+        roof: PyThermalMassNode,
+        floor: PyThermalMassNode,
+        internal: PyThermalMassNode,
+    ) -> Self {
+        let wall_node = ThermalMassNode::new(
+            wall.temperature,
+            wall.capacitance,
+            wall.h_tr_ms,
+            wall.h_tr_em,
+        )
+        .with_h_tr_me(wall.h_tr_me);
+        let roof_node = ThermalMassNode::new(
+            roof.temperature,
+            roof.capacitance,
+            roof.h_tr_ms,
+            roof.h_tr_em,
+        )
+        .with_h_tr_me(roof.h_tr_me);
+        let floor_node = ThermalMassNode::new(
+            floor.temperature,
+            floor.capacitance,
+            floor.h_tr_ms,
+            floor.h_tr_em,
+        )
+        .with_h_tr_me(floor.h_tr_me);
+        let internal_node = ThermalMassNode::new(
+            internal.temperature,
+            internal.capacitance,
+            internal.h_tr_ms,
+            internal.h_tr_em,
+        )
+        .with_h_tr_me(internal.h_tr_me);
+
+        let solver = MultiNodeSolver::new(h_tr_is, wall_node, roof_node, floor_node, internal_node);
+
+        Self::from(&solver)
+    }
+
+    #[getter]
+    pub fn mass(&self) -> PyMultiNodeThermalMass {
+        self.mass.clone()
+    }
+
+    #[setter]
+    pub fn set_mass(&mut self, value: PyMultiNodeThermalMass) {
+        self.mass = value;
+    }
+
+    #[getter]
+    pub fn h_tr_is(&self) -> f64 {
+        self.h_tr_is
+    }
+
+    #[setter]
+    pub fn set_h_tr_is(&mut self, value: f64) {
+        self.h_tr_is = value;
+    }
+
+    #[getter]
+    pub fn zone_temperature(&self) -> f64 {
+        self.zone_temperature
+    }
+
+    #[setter]
+    pub fn set_zone_temperature(&mut self, value: f64) {
+        self.zone_temperature = value;
+    }
+
+    #[getter]
+    pub fn surface_temperature(&self) -> f64 {
+        self.surface_temperature
+    }
+
+    #[setter]
+    pub fn set_surface_temperature(&mut self, value: f64) {
+        self.surface_temperature = value;
+    }
+
+    #[getter]
+    pub fn exterior_temperature(&self) -> f64 {
+        self.exterior_temperature
+    }
+
+    #[setter]
+    pub fn set_exterior_temperature(&mut self, value: f64) {
+        self.exterior_temperature = value;
+    }
+
+    #[getter]
+    pub fn exterior_temperatures(&self) -> PySurfaceExteriorTemperatures {
+        self.exterior_temperatures.clone()
+    }
+
+    #[setter]
+    pub fn set_exterior_temperatures(&mut self, value: PySurfaceExteriorTemperatures) {
+        self.exterior_temperatures = value;
+    }
+
+    #[getter]
+    pub fn timestep_seconds(&self) -> f64 {
+        self.timestep_seconds
+    }
+
+    #[setter]
+    pub fn set_timestep_seconds(&mut self, value: f64) {
+        self.timestep_seconds = value;
+    }
+
+    #[getter]
+    pub fn coupling_mode(&self) -> PyMassAirCouplingMode {
+        self.coupling_mode
+    }
+
+    #[setter]
+    pub fn set_coupling_mode(&mut self, value: PyMassAirCouplingMode) {
+        self.coupling_mode = value;
+    }
+
+    #[getter]
+    pub fn r_total(&self) -> f64 {
+        self.r_total
+    }
+
+    #[setter]
+    pub fn set_r_total(&mut self, value: f64) {
+        self.r_total = value;
+    }
+
+    #[getter]
+    pub fn r_se(&self) -> f64 {
+        self.r_se
+    }
+
+    #[setter]
+    pub fn set_r_se(&mut self, value: f64) {
+        self.r_se = value;
+    }
+
+    #[getter]
+    pub fn initialized(&self) -> bool {
+        self.initialized
+    }
+
+    #[setter]
+    pub fn set_initialized(&mut self, value: bool) {
+        self.initialized = value;
+    }
+
+    #[getter]
+    pub fn last_dt(&self) -> f64 {
+        self.last_dt
+    }
+
+    #[setter]
+    pub fn set_last_dt(&mut self, value: f64) {
+        self.last_dt = value;
+    }
+
+    pub fn wall_temperature(&self) -> f64 {
+        self.mass.wall.temperature
+    }
+
+    pub fn roof_temperature(&self) -> f64 {
+        self.mass.roof.temperature
+    }
+
+    pub fn floor_temperature(&self) -> f64 {
+        self.mass.floor.temperature
+    }
+
+    pub fn internal_temperature(&self) -> f64 {
+        self.mass.internal.temperature
+    }
+
+    pub fn set_wall_conductances(&mut self, h_tr_em: f64, h_tr_ms: f64) {
+        self.mass.wall.h_tr_em = h_tr_em;
+        self.mass.wall.h_tr_ms = h_tr_ms;
+    }
+
+    pub fn set_roof_conductances(&mut self, h_tr_em: f64, h_tr_ms: f64) {
+        self.mass.roof.h_tr_em = h_tr_em;
+        self.mass.roof.h_tr_ms = h_tr_ms;
+    }
+
+    pub fn set_floor_conductances(&mut self, h_tr_em: f64, h_tr_ms: f64) {
+        self.mass.floor.h_tr_em = h_tr_em;
+        self.mass.floor.h_tr_ms = h_tr_ms;
+    }
+
+    pub fn set_internal_conductance(&mut self, h_tr_me: f64) {
+        self.mass.internal.h_tr_me = h_tr_me;
+    }
+
+    pub fn set_wall_capacitance(&mut self, cm: f64) {
+        self.mass.wall.capacitance = cm;
+    }
+
+    pub fn set_roof_capacitance(&mut self, cm: f64) {
+        self.mass.roof.capacitance = cm;
+    }
+
+    pub fn set_floor_capacitance(&mut self, cm: f64) {
+        self.mass.floor.capacitance = cm;
+    }
+
+    pub fn set_internal_capacitance(&mut self, cm: f64) {
+        self.mass.internal.capacitance = cm;
+    }
+
+    pub fn initialize_temperatures(&mut self, t_initial: f64) {
+        self.mass.wall.temperature = t_initial;
+        self.mass.roof.temperature = t_initial;
+        self.mass.floor.temperature = t_initial;
+        self.mass.internal.temperature = t_initial;
+        self.zone_temperature = t_initial;
+        self.surface_temperature = t_initial;
+    }
+
+    pub fn step(&mut self, dt: f64) {
+        let mut solver = self.to_solver();
+        solver.step(dt);
+        self.sync_from_solver(&solver);
+    }
+
+    pub fn effective_time_constant(&self) -> f64 {
+        let c_total = self.mass.wall.capacitance
+            + self.mass.roof.capacitance
+            + self.mass.floor.capacitance
+            + self.mass.internal.capacitance;
+        let h_tr_ms_total =
+            self.mass.wall.h_tr_ms + self.mass.roof.h_tr_ms + self.mass.floor.h_tr_ms;
+        let h_eff = self.h_tr_is + h_tr_ms_total / 3.0;
+        c_total / h_eff
+    }
+}
+
+impl PyMultiNodeSolver {
+    fn to_solver(&self) -> MultiNodeSolver {
+        let wall_node = ThermalMassNode::new(
+            self.mass.wall.temperature,
+            self.mass.wall.capacitance,
+            self.mass.wall.h_tr_ms,
+            self.mass.wall.h_tr_em,
+        )
+        .with_h_tr_me(self.mass.wall.h_tr_me);
+        let roof_node = ThermalMassNode::new(
+            self.mass.roof.temperature,
+            self.mass.roof.capacitance,
+            self.mass.roof.h_tr_ms,
+            self.mass.roof.h_tr_em,
+        )
+        .with_h_tr_me(self.mass.roof.h_tr_me);
+        let floor_node = ThermalMassNode::new(
+            self.mass.floor.temperature,
+            self.mass.floor.capacitance,
+            self.mass.floor.h_tr_ms,
+            self.mass.floor.h_tr_em,
+        )
+        .with_h_tr_me(self.mass.floor.h_tr_me);
+        let internal_node = ThermalMassNode::new(
+            self.mass.internal.temperature,
+            self.mass.internal.capacitance,
+            self.mass.internal.h_tr_ms,
+            self.mass.internal.h_tr_em,
+        )
+        .with_h_tr_me(self.mass.internal.h_tr_me);
+
+        let mut solver = MultiNodeSolver::new(
+            self.h_tr_is,
+            wall_node,
+            roof_node,
+            floor_node,
+            internal_node,
+        );
+        solver.zone_temperature = self.zone_temperature;
+        solver.surface_temperature = self.surface_temperature;
+        solver.exterior_temperature = self.exterior_temperature;
+        solver.exterior_temperatures =
+            SurfaceExteriorTemperatures::from(&self.exterior_temperatures);
+        solver.timestep_seconds = self.timestep_seconds;
+        solver.coupling_mode = MassAirCouplingMode::from(self.coupling_mode);
+        solver.r_total = self.r_total;
+        solver.r_se = self.r_se;
+        solver.initialized = self.initialized;
+        solver.last_dt = self.last_dt;
+        solver
+    }
+
+    fn sync_from_solver(&mut self, solver: &MultiNodeSolver) {
+        self.mass = PyMultiNodeThermalMass::from(&solver.mass);
+        self.h_tr_is = solver.h_tr_is;
+        self.zone_temperature = solver.zone_temperature;
+        self.surface_temperature = solver.surface_temperature;
+        self.exterior_temperature = solver.exterior_temperature;
+        self.exterior_temperatures =
+            PySurfaceExteriorTemperatures::from(&solver.exterior_temperatures);
+        self.timestep_seconds = solver.timestep_seconds;
+        self.coupling_mode = PyMassAirCouplingMode::from(solver.coupling_mode);
+        self.r_total = solver.r_total;
+        self.r_se = solver.r_se;
+        self.initialized = solver.initialized;
+        self.last_dt = solver.last_dt;
+    }
+}

--- a/tests/python/test_multi_node_bindings.py
+++ b/tests/python/test_multi_node_bindings.py
@@ -1,0 +1,332 @@
+"""
+Python smoke tests for 9R4C Multi-Node Thermal Solver bindings (Issue #1795)
+"""
+
+import fluxion
+import pytest
+
+ThermalMassNode = getattr(fluxion, "ThermalMassNode", None)
+MultiNodeThermalMass = getattr(fluxion, "MultiNodeThermalMass", None)
+MassAirCouplingMode = getattr(fluxion, "MassAirCouplingMode", None)
+SurfaceExteriorTemperatures = getattr(fluxion, "SurfaceExteriorTemperatures", None)
+MultiNodeSolver = getattr(fluxion, "MultiNodeSolver", None)
+
+if ThermalMassNode is None:
+    pytest.skip("fluxion 9R4C bindings not available", allow_module_level=True)
+
+
+def test_thermal_mass_node_creation():
+    """Test ThermalMassNode creation and property access"""
+    node = ThermalMassNode(
+        temperature=20.0,
+        capacitance=5e6,
+        h_tr_ms=50.0,
+        h_tr_em=20.0,
+        h_tr_me=10.0,
+    )
+    assert node.temperature == 20.0
+    assert node.capacitance == 5e6
+    assert node.h_tr_ms == 50.0
+    assert node.h_tr_em == 20.0
+    assert node.h_tr_me == 10.0
+
+
+def test_thermal_mass_node_setters():
+    """Test ThermalMassNode property setters"""
+    node = ThermalMassNode(20.0, 5e6, 50.0, 20.0, 10.0)
+    node.temperature = 25.0
+    node.capacitance = 6e6
+    node.h_tr_ms = 55.0
+    node.h_tr_em = 22.0
+    node.h_tr_me = 12.0
+    assert node.temperature == 25.0
+    assert node.capacitance == 6e6
+    assert node.h_tr_ms == 55.0
+    assert node.h_tr_em == 22.0
+    assert node.h_tr_me == 12.0
+
+
+def test_mass_air_coupling_mode():
+    """Test MassAirCouplingMode enum values"""
+    assert MassAirCouplingMode.AdditiveSum is not None
+    assert MassAirCouplingMode.ParallelResistance is not None
+    assert MassAirCouplingMode.AdditiveSum != MassAirCouplingMode.ParallelResistance
+
+
+def test_mass_air_coupling_mode_repr():
+    """Test MassAirCouplingMode string representation"""
+    assert repr(MassAirCouplingMode.AdditiveSum) == "MassAirCouplingMode.AdditiveSum"
+    assert repr(MassAirCouplingMode.ParallelResistance) == "MassAirCouplingMode.ParallelResistance"
+
+
+def test_surface_exterior_temps_creation():
+    """Test SurfaceExteriorTemperatures creation"""
+    temps = SurfaceExteriorTemperatures(
+        t_ext_wall=30.0,
+        t_ext_roof=35.0,
+        t_ext_floor=15.0,
+    )
+    assert temps.t_ext_wall == 30.0
+    assert temps.t_ext_roof == 35.0
+    assert temps.t_ext_floor == 15.0
+
+
+def test_surface_exterior_temps_setters():
+    """Test SurfaceExteriorTemperatures property setters"""
+    temps = SurfaceExteriorTemperatures(30.0, 35.0, 15.0)
+    temps.t_ext_wall = 31.0
+    temps.t_ext_roof = 36.0
+    temps.t_ext_floor = 16.0
+    assert temps.t_ext_wall == 31.0
+    assert temps.t_ext_roof == 36.0
+    assert temps.t_ext_floor == 16.0
+
+
+def test_multi_node_thermal_mass_creation():
+    """Test MultiNodeThermalMass creation from ThermalMassNodes"""
+    wall = ThermalMassNode(20.0, 5e6, 50.0, 20.0, 0.0)
+    roof = ThermalMassNode(20.0, 3e6, 30.0, 15.0, 0.0)
+    floor = ThermalMassNode(20.0, 2e6, 20.0, 10.0, 0.0)
+    internal = ThermalMassNode(20.0, 1e6, 0.0, 0.0, 100.0)
+
+    mass = MultiNodeThermalMass(
+        wall=wall,
+        roof=roof,
+        floor=floor,
+        internal=internal,
+    )
+    assert mass.wall.temperature == 20.0
+    assert mass.roof.temperature == 20.0
+    assert mass.floor.temperature == 20.0
+    assert mass.internal.temperature == 20.0
+
+
+def test_multi_node_solver_creation():
+    """Test MultiNodeSolver creation with all parameters"""
+    wall = ThermalMassNode(20.0, 5e6, 50.0, 20.0, 0.0)
+    roof = ThermalMassNode(20.0, 3e6, 30.0, 15.0, 0.0)
+    floor = ThermalMassNode(20.0, 2e6, 20.0, 10.0, 0.0)
+    internal = ThermalMassNode(20.0, 1e6, 0.0, 0.0, 100.0)
+
+    solver = MultiNodeSolver(
+        h_tr_is=10.0,
+        wall=wall,
+        roof=roof,
+        floor=floor,
+        internal=internal,
+    )
+    assert solver.h_tr_is == 10.0
+    assert solver.zone_temperature == 20.0
+    assert solver.exterior_temperature == 10.0
+    assert solver.surface_temperature == 20.0
+    assert solver.timestep_seconds == 3600.0
+    assert solver.initialized == False
+    assert solver.r_total == 0.0
+    assert solver.r_se == 0.0
+
+
+def test_multi_node_solver_config_roundtrip():
+    """Test that all 9R4C config parameters can be set and retrieved"""
+    wall = ThermalMassNode(20.0, 5e6, 50.0, 20.0, 0.0)
+    roof = ThermalMassNode(20.0, 3e6, 30.0, 15.0, 0.0)
+    floor = ThermalMassNode(20.0, 2e6, 20.0, 10.0, 0.0)
+    internal = ThermalMassNode(20.0, 1e6, 0.0, 0.0, 100.0)
+
+    solver = MultiNodeSolver(
+        h_tr_is=10.0,
+        wall=wall,
+        roof=roof,
+        floor=floor,
+        internal=internal,
+    )
+
+    solver.h_tr_is = 12.0
+    solver.zone_temperature = 22.0
+    solver.surface_temperature = 18.0
+    solver.exterior_temperature = 5.0
+    solver.timestep_seconds = 1800.0
+    solver.coupling_mode = MassAirCouplingMode.ParallelResistance
+    solver.r_total = 0.5
+    solver.r_se = 0.04
+    solver.initialized = True
+    solver.last_dt = 1800.0
+
+    assert solver.h_tr_is == 12.0
+    assert solver.zone_temperature == 22.0
+    assert solver.surface_temperature == 18.0
+    assert solver.exterior_temperature == 5.0
+    assert solver.timestep_seconds == 1800.0
+    assert solver.coupling_mode == MassAirCouplingMode.ParallelResistance
+    assert solver.r_total == 0.5
+    assert solver.r_se == 0.04
+    assert solver.initialized == True
+    assert solver.last_dt == 1800.0
+
+
+def test_multi_node_solver_exterior_temps():
+    """Test setting per-surface exterior temperatures"""
+    wall = ThermalMassNode(20.0, 5e6, 50.0, 20.0, 0.0)
+    roof = ThermalMassNode(20.0, 3e6, 30.0, 15.0, 0.0)
+    floor = ThermalMassNode(20.0, 2e6, 20.0, 10.0, 0.0)
+    internal = ThermalMassNode(20.0, 1e6, 0.0, 0.0, 100.0)
+
+    solver = MultiNodeSolver(
+        h_tr_is=10.0,
+        wall=wall,
+        roof=roof,
+        floor=floor,
+        internal=internal,
+    )
+
+    ext_temps = SurfaceExteriorTemperatures(
+        t_ext_wall=30.0,
+        t_ext_roof=35.0,
+        t_ext_floor=15.0,
+    )
+    solver.exterior_temperatures = ext_temps
+    assert solver.exterior_temperatures.t_ext_wall == 30.0
+    assert solver.exterior_temperatures.t_ext_roof == 35.0
+    assert solver.exterior_temperatures.t_ext_floor == 15.0
+
+
+def test_multi_node_solver_node_conductance_setters():
+    """Test setting conductances on individual nodes"""
+    wall = ThermalMassNode(20.0, 5e6, 50.0, 20.0, 0.0)
+    roof = ThermalMassNode(20.0, 3e6, 30.0, 15.0, 0.0)
+    floor = ThermalMassNode(20.0, 2e6, 20.0, 10.0, 0.0)
+    internal = ThermalMassNode(20.0, 1e6, 0.0, 0.0, 100.0)
+
+    solver = MultiNodeSolver(
+        h_tr_is=10.0,
+        wall=wall,
+        roof=roof,
+        floor=floor,
+        internal=internal,
+    )
+
+    solver.set_wall_conductances(h_tr_em=25.0, h_tr_ms=55.0)
+    solver.set_roof_conductances(h_tr_em=20.0, h_tr_ms=40.0)
+    solver.set_floor_conductances(h_tr_em=15.0, h_tr_ms=30.0)
+    solver.set_internal_conductance(h_tr_me=80.0)
+
+    assert solver.mass.wall.h_tr_em == 25.0
+    assert solver.mass.wall.h_tr_ms == 55.0
+    assert solver.mass.roof.h_tr_em == 20.0
+    assert solver.mass.roof.h_tr_ms == 40.0
+    assert solver.mass.floor.h_tr_em == 15.0
+    assert solver.mass.floor.h_tr_ms == 30.0
+    assert solver.mass.internal.h_tr_me == 80.0
+
+
+def test_multi_node_solver_node_capacitance_setters():
+    """Test setting capacitance on individual nodes"""
+    wall = ThermalMassNode(20.0, 5e6, 50.0, 20.0, 0.0)
+    roof = ThermalMassNode(20.0, 3e6, 30.0, 15.0, 0.0)
+    floor = ThermalMassNode(20.0, 2e6, 20.0, 10.0, 0.0)
+    internal = ThermalMassNode(20.0, 1e6, 0.0, 0.0, 100.0)
+
+    solver = MultiNodeSolver(
+        h_tr_is=10.0,
+        wall=wall,
+        roof=roof,
+        floor=floor,
+        internal=internal,
+    )
+
+    solver.set_wall_capacitance(1e7)
+    solver.set_roof_capacitance(2e7)
+    solver.set_floor_capacitance(3e7)
+    solver.set_internal_capacitance(4e6)
+
+    assert solver.mass.wall.capacitance == 1e7
+    assert solver.mass.roof.capacitance == 2e7
+    assert solver.mass.floor.capacitance == 3e7
+    assert solver.mass.internal.capacitance == 4e6
+
+
+def test_multi_node_solver_initialize_temperatures():
+    """Test initializing all temperatures at once"""
+    wall = ThermalMassNode(20.0, 5e6, 50.0, 20.0, 0.0)
+    roof = ThermalMassNode(20.0, 3e6, 30.0, 15.0, 0.0)
+    floor = ThermalMassNode(20.0, 2e6, 20.0, 10.0, 0.0)
+    internal = ThermalMassNode(20.0, 1e6, 0.0, 0.0, 100.0)
+
+    solver = MultiNodeSolver(
+        h_tr_is=10.0,
+        wall=wall,
+        roof=roof,
+        floor=floor,
+        internal=internal,
+    )
+
+    solver.initialize_temperatures(15.0)
+    assert solver.mass.wall.temperature == 15.0
+    assert solver.mass.roof.temperature == 15.0
+    assert solver.mass.floor.temperature == 15.0
+    assert solver.mass.internal.temperature == 15.0
+    assert solver.zone_temperature == 15.0
+    assert solver.surface_temperature == 15.0
+
+
+def test_multi_node_solver_temperature_accessors():
+    """Test temperature accessors for individual nodes"""
+    wall = ThermalMassNode(25.0, 5e6, 50.0, 20.0, 0.0)
+    roof = ThermalMassNode(22.0, 3e6, 30.0, 15.0, 0.0)
+    floor = ThermalMassNode(18.0, 2e6, 20.0, 10.0, 0.0)
+    internal = ThermalMassNode(20.0, 1e6, 0.0, 0.0, 100.0)
+
+    solver = MultiNodeSolver(
+        h_tr_is=10.0,
+        wall=wall,
+        roof=roof,
+        floor=floor,
+        internal=internal,
+    )
+
+    assert solver.wall_temperature() == 25.0
+    assert solver.roof_temperature() == 22.0
+    assert solver.floor_temperature() == 18.0
+    assert solver.internal_temperature() == 20.0
+
+
+def test_multi_node_solver_step():
+    """Test that step() advances the solver"""
+    wall = ThermalMassNode(20.0, 5e6, 50.0, 20.0, 0.0)
+    roof = ThermalMassNode(20.0, 3e6, 30.0, 15.0, 0.0)
+    floor = ThermalMassNode(20.0, 2e6, 20.0, 10.0, 0.0)
+    internal = ThermalMassNode(20.0, 1e6, 0.0, 0.0, 100.0)
+
+    solver = MultiNodeSolver(
+        h_tr_is=10.0,
+        wall=wall,
+        roof=roof,
+        floor=floor,
+        internal=internal,
+    )
+    solver.zone_temperature = 22.0
+    solver.exterior_temperature = 5.0
+    solver.surface_temperature = 18.0
+
+    t_wall_before = solver.wall_temperature()
+    solver.step(dt=3600.0)
+    assert solver.wall_temperature() < t_wall_before
+
+
+def test_multi_node_solver_effective_time_constant():
+    """Test effective time constant calculation"""
+    wall = ThermalMassNode(20.0, 5e6, 50.0, 20.0, 0.0)
+    roof = ThermalMassNode(20.0, 3e6, 30.0, 15.0, 0.0)
+    floor = ThermalMassNode(20.0, 2e6, 20.0, 10.0, 0.0)
+    internal = ThermalMassNode(20.0, 1e6, 0.0, 0.0, 100.0)
+
+    solver = MultiNodeSolver(
+        h_tr_is=10.0,
+        wall=wall,
+        roof=roof,
+        floor=floor,
+        internal=internal,
+    )
+
+    tau = solver.effective_time_constant()
+    assert tau > 0.0
+    assert tau < 1e8


### PR DESCRIPTION
Closes #1795

All 9R4C internal configuration parameters are now exposed via PyO3 with docstrings. Python smoke test round-trips a 9R4C config. This blocks T9.3, T9.5, and T9.7.