### PR TITLE
feat: resolve #1793 — compress result files before S3 upload

### DIFF
--- a/scripts/s3_aggregator.py
+++ b/scripts/s3_aggregator.py
@@ -37,6 +37,11 @@ except ImportError:
     boto3 = None
     ClientError = Exception
 
+try:
+    import zstandard as zstd
+except ImportError:
+    zstd = None
+
 
 @dataclass
 class AggregatedResult:
@@ -103,7 +108,17 @@ def collect_results_from_s3(s3_client, bucket: str, results_prefix: str) -> list
         for page in paginator.paginate(Bucket=bucket, Prefix=f"{results_prefix}/"):
             for obj in page.get("Contents", []):
                 key = obj["Key"]
-                if key.endswith(".json") and not key.endswith("_placeholder"):
+                if key.endswith(".json.zst") and not key.endswith("_placeholder"):
+                    try:
+                        response = s3_client.get_object(Bucket=bucket, Key=key)
+                        body_bytes = response["Body"].read()
+                        if zstd is not None:
+                            body_bytes = zstd.decompress(body_bytes)
+                        data = json.loads(body_bytes.decode("utf-8"))
+                        results.append(AggregatedResult(**data))
+                    except (json.JSONDecodeError, TypeError) as e:
+                        print(f"[WARN] Failed to parse {key}: {e}", file=sys.stderr)
+                elif key.endswith(".json") and not key.endswith("_placeholder"):
                     try:
                         response = s3_client.get_object(Bucket=bucket, Key=key)
                         data = json.loads(response["Body"].read().decode("utf-8"))

--- a/scripts/s3_worker.py
+++ b/scripts/s3_worker.py
@@ -42,6 +42,11 @@ except ImportError:
     boto3 = None
     ClientError = Exception
 
+try:
+    import zstandard as zstd
+except ImportError:
+    zstd = None
+
 
 TRACE_BASE = Path(".sdd/traces/diagnostic")
 CARGO_TEST_CMD = ["cargo", "test", "--test=ashrae_140_validation", "--", "--nocapture"]
@@ -124,13 +129,22 @@ def parse_s3_uri(uri: str) -> tuple[str, str]:
 def push_result_to_s3(result: WorkUnitResult, s3_prefix: str, clients: dict) -> str:
     """Push work unit result directly to S3. Returns the S3 URI."""
     bucket, prefix = parse_s3_uri(s3_prefix)
-    result_key = f"{prefix}/results/{result.work_unit_id}.json"
+    result_key = f"{prefix}/results/{result.work_unit_id}.json.zst"
+
+    json_body = json.dumps(asdict(result), indent=2)
+
+    if zstd is not None:
+        body = zstd.compress(json_body.encode("utf-8"))
+        content_type = "application/zstd"
+    else:
+        body = json_body.encode("utf-8")
+        content_type = "application/json"
 
     clients["s3"].put_object(
         Bucket=bucket,
         Key=result_key,
-        Body=json.dumps(asdict(result), indent=2),
-        ContentType="application/json",
+        Body=body,
+        ContentType=content_type,
     )
 
     return f"s3://{bucket}/{result_key}"


### PR DESCRIPTION
Closes #1793

Worker sync scripts now compress (zstd) KPI/result payloads before upload. Decompression is verified on the aggregator side. This reduces transfer volume significantly for large result sets.