### PR TITLE
feat: resolve #1787 — worker status push to DynamoDB/Redis state-store

### DIFF
--- a/docs/CLOUD_CAMPAIGN.md
+++ b/docs/CLOUD_CAMPAIGN.md
@@ -13,6 +13,61 @@ This cloud-hosted system decouples campaign execution from local machines by:
 3. **Cloud Aggregator** — Merges S3 result files into a final dataset
 4. **SNS Notifications** — Email/SMS notification upon campaign completion
 
+## State Store (T7.3 — Issue #1787)
+
+Workers publish per-task completion to a **state store** (DynamoDB or Redis)
+instead of relying solely on result-file presence in S3. The coordinator then
+**aggregates** state-store entries to compute overall campaign progress.
+The state-store path is the authoritative one; the S3 listing in
+`check_campaign_progress` remains as a fallback for pre-T7.3 deployments.
+
+### Backends
+
+| Backend | Use case                                    | Configuration                                  |
+|---------|---------------------------------------------|------------------------------------------------|
+| DynamoDB| Serverless-native, no extra infra           | `FLUXION_STATE_STORE=dynamodb` + `FLUXION_CAMPAIGN_TABLE` (or `boto3` env) |
+| Redis   | Sub-second polling for very large campaigns | `FLUXION_STATE_STORE=redis` + `FLUXION_REDIS_URL` |
+| Memory  | Local-dev / tests                           | `FLUXION_STATE_STORE=memory`                   |
+
+### Schema
+
+- **DynamoDB**
+  - Partition key: `campaign_id` (S)
+  - Sort key:     `work_unit_id` (S)
+  - Attributes:   `status` (S), `timestamp` (S), `error_message` (S, optional),
+    `metrics` (M, optional).
+- **Redis**
+  - Hash per task:   `fluxion:campaign:{campaign_id}:task:{work_unit_id}`
+  - Sorted set per campaign: `fluxion:campaign:{campaign_id}:tasks`
+    (member = `work_unit_id`, score = epoch-ms of last update).
+
+### Aggregation
+
+`StateStore.aggregate_progress(campaign_id, total)` returns a
+`CampaignProgress` snapshot with `pending`, `running`, `completed`, `failed`,
+`progress_pct`, and `is_complete`. The coordinator uses this to update the
+campaign state on every poll without ever listing S3.
+
+### CLI
+
+```bash
+# Use DynamoDB explicitly
+python scripts/cloud_campaign_manager.py --action status \
+    --campaign-id fluxion-abc --state-store dynamodb
+
+# Use Redis explicitly
+python scripts/cloud_campaign_manager.py --action status \
+    --campaign-id fluxion-abc --state-store redis
+
+# Memory (local dev)
+python scripts/cloud_campaign_manager.py --action status \
+    --campaign-id fluxion-abc --state-store memory
+
+# Auto (consults FLUXION_STATE_STORE, then falls back to legacy S3 listing)
+python scripts/cloud_campaign_manager.py --action status \
+    --campaign-id fluxion-abc --state-store auto
+```
+
 ## Architecture
 
 ```

--- a/scripts/cloud_campaign_manager.py
+++ b/scripts/cloud_campaign_manager.py
@@ -53,6 +53,20 @@ except ImportError:
     boto3 = None
     ClientError = Exception
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    from state_store import (  # type: ignore[import-not-found]
+        CampaignProgress,
+        StateStore,
+        TaskState,
+        TaskStatus,
+    )
+except ImportError:  # pragma: no cover - defensive
+    CampaignProgress = None  # type: ignore[assignment]
+    StateStore = None  # type: ignore[assignment]
+    TaskState = None  # type: ignore[assignment]
+    TaskStatus = None  # type: ignore[assignment]
+
 
 TRACE_BASE = Path(".sdd/traces/diagnostic")
 
@@ -149,6 +163,44 @@ def get_required_env(var: str) -> str:
     if not value:
         raise ValueError(f"Required environment variable not set: {var}")
     return value
+
+
+def _resolve_state_store(selection: str) -> Optional["StateStore"]:
+    """Translate the ``--state-store`` CLI flag into a concrete store.
+
+    ``auto`` consults ``FLUXION_STATE_STORE`` (with backward-compatible
+    fall-through to ``FLUXION_CAMPAIGN_TABLE`` for pre-T7.3 deployments
+    that only configured the legacy DynamoDB table name).
+    ``memory`` returns an :class:`InMemoryStateStore` (handy for tests
+    and smoke checks that should not touch AWS).
+    """
+    if StateStore is None:
+        return None
+    selection = (selection or "auto").strip().lower()
+    if selection == "auto":
+        env = (os.environ.get("FLUXION_STATE_STORE") or "").strip().lower()
+        if env:
+            selection = env
+        elif os.environ.get("FLUXION_CAMPAIGN_TABLE") or os.environ.get("FLUXION_REDIS_URL"):
+            selection = (
+                "dynamodb"
+                if os.environ.get("FLUXION_CAMPAIGN_TABLE")
+                else "redis"
+            )
+        else:
+            return None
+    if selection in ("memory", "inmemory"):
+        return StateStore.create("memory")
+    if selection in ("dynamodb", "redis"):
+        try:
+            return StateStore.create(selection)
+        except Exception as exc:  # pragma: no cover - transport errors
+            print(
+                f"[WARN] Could not build {selection} state store: {exc}",
+                file=sys.stderr,
+            )
+            return None
+    return None
 
 
 def ensure_s3_prefix(s3_client, bucket: str, prefix: str) -> None:
@@ -312,8 +364,62 @@ def update_campaign_state(state: CampaignState, s3_bucket: str, s3_prefix: str) 
     )
 
 
-def check_campaign_progress(state: CampaignState, s3_bucket: str, s3_prefix: str) -> CampaignState:
-    """Check progress by counting completed work units in S3."""
+def check_campaign_progress(
+    state: CampaignState,
+    s3_bucket: str,
+    s3_prefix: str,
+    *,
+    state_store: Optional["StateStore"] = None,
+) -> CampaignState:
+    """Check progress by aggregating worker state-store entries.
+
+    Resolution order
+    ----------------
+    1. ``state_store`` argument (preferred — tests / local pipeline).
+    2. ``FLUXION_STATE_STORE`` env (``dynamodb`` or ``redis``).
+    3. Legacy S3 listing — counts ``results/*.json`` blobs produced by
+       older worker versions that predate the state-store refactor.
+
+    The state-store aggregation is authoritative when available because
+    workers now publish per-task completion directly to it, including
+    metrics and error_message that the S3-listing path cannot recover.
+    """
+    progress: Optional[CampaignProgress] = None
+    if state_store is not None and CampaignProgress is not None:
+        progress = state_store.aggregate_progress(
+            state.campaign_id, total=len(state.work_units)
+        )
+    elif StateStore is not None:
+        backend = (os.environ.get("FLUXION_STATE_STORE") or "").strip().lower()
+        if backend in ("dynamodb", "redis"):
+            try:
+                store = StateStore.from_env()
+                progress = store.aggregate_progress(
+                    state.campaign_id, total=len(state.work_units)
+                )
+            except Exception as exc:  # pragma: no cover - transport errors
+                print(
+                    f"[WARN] StateStore aggregate failed: {exc}",
+                    file=sys.stderr,
+                )
+
+    if progress is not None:
+        state.completed_units = progress.completed
+        state.failed_units = progress.failed
+        total = len(state.work_units)
+        if state.status == "created" and progress.in_flight > 0:
+            state.status = "running"
+        if progress.is_complete and total > 0:
+            state.status = "completed"
+        print(
+            f"[*] Campaign {state.campaign_id} (state-store): "
+            f"{progress.completed}/{total} completed, "
+            f"{progress.failed} failed, {progress.in_flight} in-flight "
+            f"({progress.progress_pct:.1f}%)"
+        )
+        return state
+
+    # --- Legacy S3 listing fallback -----------------------------------
     clients = get_aws_clients()
 
     completed = 0
@@ -338,9 +444,9 @@ def check_campaign_progress(state: CampaignState, s3_bucket: str, s3_prefix: str
     state.failed_units = failed
 
     total = len(state.work_units)
-    progress = (completed + failed) / total * 100 if total > 0 else 0
+    progress_pct = (completed + failed) / total * 100 if total > 0 else 0
 
-    print(f"[*] Campaign {state.campaign_id}: {completed}/{total} completed, {failed} failed ({progress:.1f}%)")
+    print(f"[*] Campaign {state.campaign_id}: {completed}/{total} completed, {failed} failed ({progress_pct:.1f}%)")
 
     if state.status == "created" and (completed + failed) > 0:
         state.status = "running"
@@ -351,7 +457,12 @@ def check_campaign_progress(state: CampaignState, s3_bucket: str, s3_prefix: str
 
 
 def wait_for_completion(
-    campaign_id: str, s3_bucket: str, s3_prefix: str, poll_interval: int = 30
+    campaign_id: str,
+    s3_bucket: str,
+    s3_prefix: str,
+    poll_interval: int = 30,
+    *,
+    state_store: Optional["StateStore"] = None,
 ) -> CampaignState:
     """Poll until campaign is complete."""
     print(f"[*] Waiting for campaign {campaign_id} to complete...")
@@ -362,7 +473,9 @@ def wait_for_completion(
             print(f"[ERROR] Campaign {campaign_id} not found")
             sys.exit(1)
 
-        state = check_campaign_progress(state, s3_bucket, s3_prefix)
+        state = check_campaign_progress(
+            state, s3_bucket, s3_prefix, state_store=state_store
+        )
         update_campaign_state(state, s3_bucket, s3_prefix)
 
         if state.status in ("completed", "failed"):
@@ -534,7 +647,20 @@ def main() -> int:
         default=30,
         help="Poll interval in seconds for wait action",
     )
+    parser.add_argument(
+        "--state-store",
+        type=str,
+        choices=["dynamodb", "redis", "memory", "auto"],
+        default="auto",
+        help=(
+            "State-store backend for per-task progress (T7.3). "
+            "'auto' uses FLUXION_STATE_STORE when set, otherwise falls "
+            "back to legacy S3 listing."
+        ),
+    )
     args = parser.parse_args()
+
+    state_store = _resolve_state_store(args.state_store)
 
     s3_bucket = args.s3_bucket
     s3_prefix = args.s3_prefix.rstrip("/")
@@ -577,20 +703,41 @@ def main() -> int:
     if args.action == "status":
         if not args.campaign_id:
             parser.error("--campaign-id is required for status action")
-        if not s3_bucket:
-            parser.error("--s3-bucket is required (or set FLUXION_S3_BUCKET env var)")
+        if not s3_bucket and state_store is None:
+            parser.error(
+                "--s3-bucket is required (or set FLUXION_S3_BUCKET env var) "
+                "or pass --state-store"
+            )
 
-        state = get_campaign_state(args.campaign_id, s3_bucket, s3_prefix)
-        if state is None:
-            print(f"[ERROR] Campaign {args.campaign_id} not found")
-            return 1
+        if state_store is None:
+            state = get_campaign_state(args.campaign_id, s3_bucket, s3_prefix)
+        else:
+            # State-store-only mode: synthesize a minimal CampaignState
+            # from the campaign definition stored in S3 (if any) or just
+            # use the live aggregate.
+            state = (
+                get_campaign_state(args.campaign_id, s3_bucket, s3_prefix)
+                if s3_bucket
+                else CampaignState(
+                    campaign_id=args.campaign_id,
+                    config={},
+                    work_units=[],
+                    status="created",
+                    start_time=datetime.now(timezone.utc).isoformat(),
+                )
+            )
+            if state is None:
+                print(f"[ERROR] Campaign {args.campaign_id} not found")
+                return 1
 
-        state = check_campaign_progress(state, s3_bucket, s3_prefix)
+        state = check_campaign_progress(
+            state, s3_bucket, s3_prefix, state_store=state_store
+        )
 
         print(f"\nCampaign: {state.campaign_id}")
         print(f"Status: {state.status}")
         print(f"Start: {state.start_time}")
-        print(f"Completed: {state.completed_units}/{len(state.work_units)}")
+        print(f"Completed: {state.completed_units}/{len(state.work_units) or '?'}")
         print(f"Failed: {state.failed_units}")
         print(f"Best MAE: {state.best_mae:.2f}%")
 
@@ -599,10 +746,49 @@ def main() -> int:
     if args.action == "wait":
         if not args.campaign_id:
             parser.error("--campaign-id is required for wait action")
-        if not s3_bucket:
-            parser.error("--s3-bucket is required (or set FLUXION_S3_BUCKET env var)")
+        if not s3_bucket and state_store is None:
+            parser.error(
+                "--s3-bucket is required (or set FLUXION_S3_BUCKET env var) "
+                "or pass --state-store"
+            )
 
-        state = wait_for_completion(args.campaign_id, s3_bucket, s3_prefix, args.poll_interval)
+        if s3_bucket:
+            state = wait_for_completion(
+                args.campaign_id,
+                s3_bucket,
+                s3_prefix,
+                args.poll_interval,
+                state_store=state_store,
+            )
+        else:
+            # State-store-only wait loop
+            print(f"[*] Waiting for campaign {args.campaign_id} to complete...")
+            while True:
+                progress = (
+                    state_store.aggregate_progress(args.campaign_id, total=0)
+                    if state_store is not None
+                    else None
+                )
+                if progress is None:
+                    print("[ERROR] No state store available")
+                    return 1
+                print(
+                    f"[*] {progress.completed} completed, "
+                    f"{progress.failed} failed, "
+                    f"{progress.in_flight} in-flight"
+                )
+                if progress.is_complete:
+                    state = CampaignState(
+                        campaign_id=args.campaign_id,
+                        config={},
+                        work_units=[],
+                        status="completed",
+                        start_time=datetime.now(timezone.utc).isoformat(),
+                        completed_units=progress.completed,
+                        failed_units=progress.failed,
+                    )
+                    break
+                time.sleep(args.poll_interval)
 
         print(f"\n[*] Campaign {args.campaign_id} is now: {state.status}")
         print(f"    Completed: {state.completed_units}")

--- a/scripts/s3_worker.py
+++ b/scripts/s3_worker.py
@@ -47,6 +47,20 @@ try:
 except ImportError:
     zstd = None
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    from state_store import (  # type: ignore[import-not-found]
+        InMemoryStateStore,
+        StateStore,
+        TaskState,
+        TaskStatus,
+    )
+except ImportError:  # pragma: no cover - defensive
+    InMemoryStateStore = None  # type: ignore[assignment]
+    StateStore = None  # type: ignore[assignment]
+    TaskState = None  # type: ignore[assignment]
+    TaskStatus = None  # type: ignore[assignment]
+
 
 TRACE_BASE = Path(".sdd/traces/diagnostic")
 CARGO_TEST_CMD = ["cargo", "test", "--test=ashrae_140_validation", "--", "--nocapture"]
@@ -273,9 +287,90 @@ def push_result_to_s3(result: WorkUnitResult | KPIResult, s3_prefix: str, client
 
 
 def update_campaign_progress(
-    campaign_id: str, work_unit_id: str, status: str, clients: dict
+    campaign_id: str,
+    work_unit_id: str,
+    status: str,
+    clients: dict,
+    *,
+    store: Optional["StateStore"] = None,
+    metrics: Optional[dict[str, float]] = None,
+    error_message: Optional[str] = None,
 ) -> None:
-    """Update campaign progress in DynamoDB or S3."""
+    """Update campaign progress in the configured state store.
+
+    Resolution order:
+      1. Explicit ``store`` argument (preferred for tests and the local
+         pipeline that wires a concrete backend).
+      2. ``FLUXION_STATE_STORE`` environment variable — ``dynamodb`` or
+         ``redis`` select the cloud backends; ``memory`` selects the
+         process-local :class:`InMemoryStateStore`.
+      3. Legacy S3 fallback (``FLUXION_CAMPAIGN_STATE_PREFIX``) for
+         pre-T7.3 deployments; writes a per-task JSON marker that the
+         coordinator's S3-listing path understands.
+
+    The worker always writes the full task state (status + timestamp +
+    optional metrics / error message) so the coordinator can derive a
+    campaign-wide progress snapshot directly from the state store.
+    """
+    if store is not None and TaskState is not None:
+        state = TaskState.now(
+            campaign_id=campaign_id,
+            work_unit_id=work_unit_id,
+            status=status,
+            metrics=metrics,
+            error_message=error_message,
+        )
+        try:
+            store.set_state(state)
+            return
+        except Exception as exc:  # pragma: no cover - transport errors
+            print(f"[WARN] StateStore write failed: {exc}", file=sys.stderr)
+            return
+
+    backend = (os.environ.get("FLUXION_STATE_STORE") or "").strip().lower()
+    if backend == "dynamodb" and StateStore is not None:
+        try:
+            store = StateStore.create("dynamodb", dynamodb_client=clients["dynamodb"])
+        except Exception as exc:  # pragma: no cover - transport errors
+            print(f"[WARN] Could not build DynamoDB store: {exc}", file=sys.stderr)
+            return
+        if store is not None and TaskState is not None:
+            try:
+                store.set_state(
+                    TaskState.now(
+                        campaign_id=campaign_id,
+                        work_unit_id=work_unit_id,
+                        status=status,
+                        metrics=metrics,
+                        error_message=error_message,
+                    )
+                )
+                return
+            except Exception as exc:  # pragma: no cover - transport errors
+                print(f"[WARN] DynamoDB write failed: {exc}", file=sys.stderr)
+                return
+    if backend == "redis" and StateStore is not None:
+        try:
+            store = StateStore.create("redis")
+        except Exception as exc:  # pragma: no cover - transport errors
+            print(f"[WARN] Could not build Redis store: {exc}", file=sys.stderr)
+            return
+        if store is not None and TaskState is not None:
+            try:
+                store.set_state(
+                    TaskState.now(
+                        campaign_id=campaign_id,
+                        work_unit_id=work_unit_id,
+                        status=status,
+                        metrics=metrics,
+                        error_message=error_message,
+                    )
+                )
+                return
+            except Exception as exc:  # pragma: no cover - transport errors
+                print(f"[WARN] Redis write failed: {exc}", file=sys.stderr)
+                return
+
     table_name = os.environ.get("FLUXION_CAMPAIGN_TABLE")
     if table_name:
         dynamodb = clients["dynamodb"]
@@ -290,25 +385,29 @@ def update_campaign_progress(
                     ":now": {"S": datetime.now(timezone.utc).isoformat()},
                 },
             )
+            return
         except ClientError as e:
             print(f"[WARN] Failed to update DynamoDB: {e}", file=sys.stderr)
-    else:
-        s3_state_prefix = os.environ.get("FLUXION_CAMPAIGN_STATE_PREFIX", "")
-        if s3_state_prefix:
-            bucket, prefix = parse_s3_uri(s3_state_prefix)
-            state_key = f"{prefix}/{campaign_id}/progress/{work_unit_id}.json"
-            clients["s3"].put_object(
-                Bucket=bucket,
-                Key=state_key,
-                Body=json.dumps(
-                    {
-                        "work_unit_id": work_unit_id,
-                        "status": status,
-                        "timestamp": datetime.now(timezone.utc).isoformat(),
-                    }
-                ),
-                ContentType="application/json",
-            )
+            return
+
+    s3_state_prefix = os.environ.get("FLUXION_CAMPAIGN_STATE_PREFIX", "")
+    if s3_state_prefix:
+        bucket, prefix = parse_s3_uri(s3_state_prefix)
+        state_key = f"{prefix}/{campaign_id}/progress/{work_unit_id}.json"
+        clients["s3"].put_object(
+            Bucket=bucket,
+            Key=state_key,
+            Body=json.dumps(
+                {
+                    "work_unit_id": work_unit_id,
+                    "status": status,
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "error_message": error_message,
+                    "metrics": metrics,
+                }
+            ),
+            ContentType="application/json",
+        )
 
 
 def run_simulation(work_unit: WorkUnit) -> tuple[dict[str, Any], str]:
@@ -396,7 +495,13 @@ def compute_kpi_stats(values: list[float]) -> tuple[float, float, float, float]:
     return mean_val, std_val, min(values), max(values)
 
 
-def run_worker(work_unit: WorkUnit, emit_raw: bool = False, num_runs: int = 1) -> KPIResult:
+def run_worker(
+    work_unit: WorkUnit,
+    emit_raw: bool = False,
+    num_runs: int = 1,
+    *,
+    state_store: Optional["StateStore"] = None,
+) -> KPIResult:
     """
     Execute a work unit and emit aggregated KPIs to S3.
 
@@ -408,6 +513,8 @@ def run_worker(work_unit: WorkUnit, emit_raw: bool = False, num_runs: int = 1) -
         If True, include individual run results in output.
     num_runs : int
         Number of simulation runs to aggregate (default 1).
+    state_store : StateStore, optional
+        Backend state store (DynamoDB/Redis/in-memory) for progress tracking.
 
     Returns
     -------
@@ -423,7 +530,11 @@ def run_worker(work_unit: WorkUnit, emit_raw: bool = False, num_runs: int = 1) -
     print(f"[*] Running {num_runs} simulation(s) for aggregation")
 
     update_campaign_progress(
-        work_unit.campaign_id, work_unit.work_unit_id, "running", clients
+        work_unit.campaign_id,
+        work_unit.work_unit_id,
+        "running",
+        clients,
+        store=state_store,
     )
 
     raw_results: list[WorkUnitResult] = []
@@ -490,6 +601,20 @@ def run_worker(work_unit: WorkUnit, emit_raw: bool = False, num_runs: int = 1) -
                 timestamp=datetime.now(timezone.utc).isoformat(),
             ))
 
+        # Push per-run progress to state store
+        update_campaign_progress(
+            work_unit.campaign_id,
+            work_unit.work_unit_id,
+            "running",
+            clients,
+            store=state_store,
+            metrics={
+                "run_idx": run_idx,
+                "num_runs": num_runs,
+                "duration_ms": duration_ms,
+            },
+        )
+
     # Compute aggregated KPIs
     h_mean, h_std, h_min, h_max = compute_kpi_stats(heating_maes)
     c_mean, c_std, c_min, c_max = compute_kpi_stats(cooling_maes)
@@ -529,17 +654,38 @@ def run_worker(work_unit: WorkUnit, emit_raw: bool = False, num_runs: int = 1) -
         raw_results=raw_results if emit_raw else None,
     )
 
+    # Push aggregated completion status to state store
+    update_campaign_progress(
+        work_unit.campaign_id,
+        work_unit.work_unit_id,
+        "completed" if error_msg is None else "failed",
+        clients,
+        store=state_store,
+        metrics={
+            "heating_mae_mean": h_mean,
+            "cooling_mae_mean": c_mean,
+            "peak_heating_mae_mean": ph_mean,
+            "peak_cooling_mae_mean": pc_mean,
+            "temperature_mae_mean": t_mean,
+            "overall_pass_rate": pass_rate,
+            "duration_ms_mean": dur_mean,
+        },
+        error_message=error_msg,
+    )
+
     result_uri = push_result_to_s3(result, work_unit.s3_result_prefix, clients)
     print(f"[*] KPI result pushed to: {result_uri}")
-
-    update_campaign_progress(
-        work_unit.campaign_id, work_unit.work_unit_id, "completed", clients
-    )
 
     return result
 
 
-def run_sqs_worker(queue_url: str, emit_raw: bool = False, num_runs: int = 1) -> None:
+def run_sqs_worker(
+    queue_url: str,
+    emit_raw: bool = False,
+    num_runs: int = 1,
+    *,
+    state_store: Optional["StateStore"] = None,
+) -> None:
     """Long-running SQS worker that processes messages from a queue."""
     clients = get_aws_clients()
     sqs = clients["sqs"] if "sqs" in clients else boto3.client("sqs")
@@ -561,7 +707,7 @@ def run_sqs_worker(queue_url: str, emit_raw: bool = False, num_runs: int = 1) ->
                 work_unit = download_work_unit(body["param_file"], clients)
 
                 try:
-                    run_worker(work_unit, emit_raw=emit_raw, num_runs=num_runs)
+                    run_worker(work_unit, emit_raw=emit_raw, num_runs=num_runs, state_store=state_store)
                     sqs.delete_message(
                         QueueUrl=queue_url, ReceiptHandle=message["ReceiptHandle"]
                     )
@@ -570,8 +716,10 @@ def run_sqs_worker(queue_url: str, emit_raw: bool = False, num_runs: int = 1) ->
                     update_campaign_progress(
                         work_unit.campaign_id,
                         work_unit.work_unit_id,
-                        f"failed: {e}",
+                        "failed",
                         clients,
+                        store=state_store,
+                        error_message=str(e),
                     )
 
         except KeyboardInterrupt:

--- a/scripts/state_store.py
+++ b/scripts/state_store.py
@@ -1,0 +1,668 @@
+#!/usr/bin/env python3
+"""
+State Store for Fluxion Campaigns (Issue #1787 / T7.3)
+======================================================
+
+Workers write per-task completion directly to a cloud state-store
+(DynamoDB or Redis) rather than back to the client. The coordinator
+aggregates state-store entries to compute overall campaign progress.
+
+Backends
+--------
+- :class:`DynamoDBStateStore`  — Atomic ``UpdateItem`` with a composite key
+  (``campaign_id`` PK + ``work_unit_id`` SK). Status / metrics are stored as
+  typed attributes so the coordinator can ``Query`` per campaign without a
+  full table scan.
+- :class:`RedisStateStore`     — One hash per task plus a sorted set per
+  campaign for cheap ordering and progress queries.
+- :class:`InMemoryStateStore`  — Process-local, useful for unit tests and
+  the local-dev path that has no cloud credentials.
+
+Selection is driven by ``FLUXION_STATE_STORE`` (values: ``dynamodb``,
+``redis``, ``memory``) plus backend-specific configuration. All backends
+share the :class:`StateStore` interface so workers and the coordinator
+can be backend-agnostic.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from abc import ABC, abstractmethod
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Iterable, Optional
+
+LOGGER = logging.getLogger("fluxion.state_store")
+
+# DynamoDB limits work-unit IDs up to 2048 bytes; we stay well below.
+MAX_WORK_UNIT_ID_LEN = 512
+MAX_CAMPAIGN_ID_LEN = 256
+
+
+class TaskStatus(str, Enum):
+    """Lifecycle of a single work unit within a campaign."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+    @classmethod
+    def coerce(cls, value: Any) -> "TaskStatus":
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, str):
+            key = value.strip().lower()
+            for member in cls:
+                if member.value == key:
+                    return member
+        raise ValueError(f"Unknown TaskStatus: {value!r}")
+
+
+@dataclass
+class TaskState:
+    """A single per-task entry written by a worker."""
+
+    campaign_id: str
+    work_unit_id: str
+    status: TaskStatus
+    timestamp: str
+    error_message: Optional[str] = None
+    metrics: Optional[dict[str, float]] = None
+
+    def __post_init__(self) -> None:
+        if not self.campaign_id:
+            raise ValueError("campaign_id is required")
+        if not self.work_unit_id:
+            raise ValueError("work_unit_id is required")
+        if len(self.campaign_id) > MAX_CAMPAIGN_ID_LEN:
+            raise ValueError(f"campaign_id exceeds {MAX_CAMPAIGN_ID_LEN} chars")
+        if len(self.work_unit_id) > MAX_WORK_UNIT_ID_LEN:
+            raise ValueError(f"work_unit_id exceeds {MAX_WORK_UNIT_ID_LEN} chars")
+        self.status = TaskStatus.coerce(self.status)
+        if not self.timestamp:
+            self.timestamp = datetime.now(timezone.utc).isoformat()
+
+    @classmethod
+    def now(
+        cls,
+        campaign_id: str,
+        work_unit_id: str,
+        status: TaskStatus | str,
+        *,
+        error_message: Optional[str] = None,
+        metrics: Optional[dict[str, float]] = None,
+    ) -> "TaskState":
+        return cls(
+            campaign_id=campaign_id,
+            work_unit_id=work_unit_id,
+            status=TaskStatus.coerce(status),
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            error_message=error_message,
+            metrics=metrics,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "campaign_id": self.campaign_id,
+            "work_unit_id": self.work_unit_id,
+            "status": self.status.value,
+            "timestamp": self.timestamp,
+            "error_message": self.error_message,
+            "metrics": self.metrics,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "TaskState":
+        return cls(
+            campaign_id=str(data["campaign_id"]),
+            work_unit_id=str(data["work_unit_id"]),
+            status=TaskStatus.coerce(data["status"]),
+            timestamp=str(data.get("timestamp") or ""),
+            error_message=data.get("error_message"),
+            metrics=data.get("metrics"),
+        )
+
+
+@dataclass
+class CampaignProgress:
+    """Aggregated campaign-level progress computed from state-store entries."""
+
+    campaign_id: str
+    total: int = 0
+    pending: int = 0
+    running: int = 0
+    completed: int = 0
+    failed: int = 0
+    work_unit_ids: list[str] = field(default_factory=list)
+
+    @property
+    def finished(self) -> int:
+        """Tasks in a terminal state (completed + failed)."""
+        return self.completed + self.failed
+
+    @property
+    def in_flight(self) -> int:
+        return self.running
+
+    @property
+    def is_complete(self) -> bool:
+        """``True`` iff every expected task has reached a terminal state."""
+        return self.total > 0 and self.finished >= self.total
+
+    @property
+    def progress_pct(self) -> float:
+        if self.total <= 0:
+            return 0.0
+        return min(100.0, self.finished * 100.0 / self.total)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "campaign_id": self.campaign_id,
+            "total": self.total,
+            "pending": self.pending,
+            "running": self.running,
+            "completed": self.completed,
+            "failed": self.failed,
+            "finished": self.finished,
+            "in_flight": self.in_flight,
+            "is_complete": self.is_complete,
+            "progress_pct": round(self.progress_pct, 2),
+            "work_unit_ids": list(self.work_unit_ids),
+        }
+
+
+class StateStore(ABC):
+    """Abstract state-store interface shared by all backends."""
+
+    backend_name: str = "abstract"
+
+    @abstractmethod
+    def set_state(self, state: TaskState) -> None:
+        """Idempotently write or update the state of a single task."""
+
+    @abstractmethod
+    def get_state(self, campaign_id: str, work_unit_id: str) -> Optional[TaskState]:
+        """Return the current state of a single task, or ``None``."""
+
+    @abstractmethod
+    def list_states(self, campaign_id: str) -> list[TaskState]:
+        """Return all known task states for a campaign (any status)."""
+
+    def aggregate_progress(
+        self, campaign_id: str, total: Optional[int] = None
+    ) -> CampaignProgress:
+        """Aggregate per-task states into a campaign-wide progress snapshot.
+
+        ``total`` is the number of tasks the campaign manager expects; when
+        omitted it is inferred from the number of entries seen so far.
+        """
+        states = self.list_states(campaign_id)
+        progress = CampaignProgress(campaign_id=campaign_id)
+        for s in states:
+            progress.work_unit_ids.append(s.work_unit_id)
+            if s.status == TaskStatus.COMPLETED:
+                progress.completed += 1
+            elif s.status == TaskStatus.FAILED:
+                progress.failed += 1
+            elif s.status == TaskStatus.RUNNING:
+                progress.running += 1
+            else:
+                progress.pending += 1
+        # Tasks may have been claimed by a worker before the coordinator
+        # knew about them — prefer the larger of the two counts.
+        progress.total = max(total or 0, len(states))
+        return progress
+
+    # --- Convenience constructors -----------------------------------------
+    @classmethod
+    def from_env(cls) -> "StateStore":
+        backend = (os.environ.get("FLUXION_STATE_STORE") or "").strip().lower()
+        if backend == "dynamodb":
+            return DynamoDBStateStore.from_env()
+        if backend == "redis":
+            return RedisStateStore.from_env()
+        if backend in ("memory", "inmemory", ""):
+            return InMemoryStateStore()
+        raise ValueError(f"Unknown FLUXION_STATE_STORE backend: {backend!r}")
+
+    @classmethod
+    def create(
+        cls,
+        backend: str,
+        *,
+        dynamodb_client: Any = None,
+        redis_client: Any = None,
+        table_name: Optional[str] = None,
+        key_prefix: Optional[str] = None,
+        redis_url: Optional[str] = None,
+    ) -> "StateStore":
+        backend = (backend or "memory").strip().lower()
+        if backend == "dynamodb":
+            client = dynamodb_client
+            if client is None:
+                # Defer import / construction so this remains test-friendly.
+                return DynamoDBStateStore.from_env()
+            return DynamoDBStateStore(
+                dynamodb_client=client,
+                table_name=table_name or os.environ.get(
+                    "FLUXION_CAMPAIGN_TABLE", "fluxion-campaign-state"
+                ),
+            )
+        if backend == "redis":
+            if redis_client is not None:
+                return RedisStateStore(
+                    redis_client=redis_client,
+                    key_prefix=key_prefix
+                    or os.environ.get("FLUXION_REDIS_PREFIX", "fluxion:campaign"),
+                )
+            return RedisStateStore(
+                key_prefix=key_prefix
+                or os.environ.get("FLUXION_REDIS_PREFIX", "fluxion:campaign"),
+                redis_url=redis_url or os.environ.get("FLUXION_REDIS_URL"),
+            )
+        if backend in ("memory", "inmemory", ""):
+            return InMemoryStateStore()
+        raise ValueError(f"Unknown state-store backend: {backend!r}")
+
+
+class InMemoryStateStore(StateStore):
+    """Process-local store useful for unit tests and the local-dev path."""
+
+    backend_name = "memory"
+
+    def __init__(self) -> None:
+        # {campaign_id: {work_unit_id: TaskState}}
+        self._states: dict[str, dict[str, TaskState]] = {}
+
+    def set_state(self, state: TaskState) -> None:
+        self._states.setdefault(state.campaign_id, {})[state.work_unit_id] = state
+
+    def get_state(self, campaign_id: str, work_unit_id: str) -> Optional[TaskState]:
+        return self._states.get(campaign_id, {}).get(work_unit_id)
+
+    def list_states(self, campaign_id: str) -> list[TaskState]:
+        return list(self._states.get(campaign_id, {}).values())
+
+    def clear(self, campaign_id: Optional[str] = None) -> None:
+        """Test helper. Removes entries for a campaign (or all campaigns)."""
+        if campaign_id is None:
+            self._states.clear()
+        else:
+            self._states.pop(campaign_id, None)
+
+
+class DynamoDBStateStore(StateStore):
+    """DynamoDB-backed state store.
+
+    Schema
+    ------
+    Partition key : ``campaign_id`` (S)
+    Sort key      : ``work_unit_id`` (S)
+
+    Item attributes::
+
+        status        (S) — pending | running | completed | failed
+        timestamp     (S) — ISO 8601 UTC
+        error_message (S, optional)
+        metrics       (M, optional) — {heating_mae, cooling_mae, ...}
+
+    The table is expected to be created out-of-band by IaC. The helper
+    :meth:`ensure_table` will create it on demand for tests and local dev.
+    """
+
+    backend_name = "dynamodb"
+
+    def __init__(self, dynamodb_client: Any, table_name: str) -> None:
+        if not dynamodb_client:
+            raise ValueError("dynamodb_client is required for DynamoDBStateStore")
+        if not table_name:
+            raise ValueError("table_name is required for DynamoDBStateStore")
+        self.client = dynamodb_client
+        self.table_name = table_name
+
+    @classmethod
+    def from_env(cls) -> "DynamoDBStateStore":
+        try:
+            import boto3  # type: ignore
+        except ImportError as exc:  # pragma: no cover - import guard
+            raise RuntimeError(
+                "boto3 is required for DynamoDBStateStore; install with `pip install boto3`"
+            ) from exc
+        session = boto3.Session(
+            aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID"),
+            aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY"),
+            aws_session_token=os.environ.get("AWS_SESSION_TOKEN"),
+            region_name=os.environ.get("AWS_REGION", "us-east-1"),
+        )
+        return cls(
+            dynamodb_client=session.client("dynamodb"),
+            table_name=os.environ.get(
+                "FLUXION_CAMPAIGN_TABLE", "fluxion-campaign-state"
+            ),
+        )
+
+    def ensure_table(self) -> None:
+        """Create the DynamoDB table if it does not already exist (test helper)."""
+        try:
+            self.client.describe_table(TableName=self.table_name)
+            return
+        except Exception:
+            pass
+        try:
+            from botocore.exceptions import ClientError  # type: ignore
+        except ImportError:  # pragma: no cover - import guard
+            ClientError = Exception
+
+        try:
+            self.client.create_table(
+                TableName=self.table_name,
+                KeySchema=[
+                    {"AttributeName": "campaign_id", "KeyType": "HASH"},
+                    {"AttributeName": "work_unit_id", "KeyType": "RANGE"},
+                ],
+                AttributeDefinitions=[
+                    {"AttributeName": "campaign_id", "AttributeType": "S"},
+                    {"AttributeName": "work_unit_id", "AttributeType": "S"},
+                ],
+                BillingMode="PAY_PER_REQUEST",
+            )
+        except ClientError as exc:  # pragma: no cover - best-effort
+            LOGGER.warning("ensure_table: create_table failed: %s", exc)
+
+    def set_state(self, state: TaskState) -> None:
+        set_parts = ["#s = :s", "#t = :t"]
+        remove_parts: list[str] = []
+        expr_names: dict[str, str] = {"#s": "status", "#t": "timestamp"}
+        expr_values: dict[str, Any] = {
+            ":s": {"S": state.status.value},
+            ":t": {"S": state.timestamp},
+        }
+        if state.error_message is not None:
+            set_parts.append("#e = :e")
+            expr_names["#e"] = "error_message"
+            expr_values[":e"] = {"S": state.error_message}
+        else:
+            remove_parts.append("#e")
+            expr_names["#e"] = "error_message"
+        if state.metrics is not None:
+            set_parts.append("#m = :m")
+            expr_names["#m"] = "metrics"
+            expr_values[":m"] = {"M": _to_dynamodb_map(state.metrics)}
+        else:
+            remove_parts.append("#m")
+            expr_names["#m"] = "metrics"
+
+        update_expr = "SET " + ", ".join(set_parts)
+        if remove_parts:
+            update_expr += " REMOVE " + ", ".join(remove_parts)
+
+        self.client.update_item(
+            TableName=self.table_name,
+            Key={
+                "campaign_id": {"S": state.campaign_id},
+                "work_unit_id": {"S": state.work_unit_id},
+            },
+            UpdateExpression=update_expr,
+            ExpressionAttributeNames=expr_names,
+            ExpressionAttributeValues=expr_values,
+        )
+
+    def get_state(self, campaign_id: str, work_unit_id: str) -> Optional[TaskState]:
+        response = self.client.get_item(
+            TableName=self.table_name,
+            Key={
+                "campaign_id": {"S": campaign_id},
+                "work_unit_id": {"S": work_unit_id},
+            },
+        )
+        item = response.get("Item")
+        if not item:
+            return None
+        return _from_dynamodb_item(item)
+
+    def list_states(self, campaign_id: str) -> list[TaskState]:
+        states: list[TaskState] = []
+        kwargs: dict[str, Any] = {
+            "TableName": self.table_name,
+            "KeyConditionExpression": "campaign_id = :cid",
+            "ExpressionAttributeValues": {":cid": {"S": campaign_id}},
+        }
+        while True:
+            response = self.client.query(**kwargs)
+            for item in response.get("Items", []):
+                states.append(_from_dynamodb_item(item))
+            last_key = response.get("LastEvaluatedKey")
+            if not last_key:
+                break
+            kwargs["ExclusiveStartKey"] = last_key
+        return states
+
+
+class RedisStateStore(StateStore):
+    """Redis-backed state store.
+
+    Layout
+    ------
+    ``fluxion:campaign:{campaign_id}:task:{work_unit_id}`` — hash with fields:
+        status        (str)
+        timestamp     (str — ISO 8601)
+        error_message (str, optional)
+        metrics       (JSON-encoded string)
+
+    ``fluxion:campaign:{campaign_id}:tasks`` — sorted set whose members are
+    work-unit IDs scored by epoch-ms, used for cheap enumeration.
+    """
+
+    backend_name = "redis"
+
+    def __init__(
+        self,
+        redis_client: Any = None,
+        key_prefix: str = "fluxion:campaign",
+        redis_url: Optional[str] = None,
+    ) -> None:
+        self.key_prefix = key_prefix
+        if redis_client is None:
+            try:
+                import redis  # type: ignore
+            except ImportError as exc:  # pragma: no cover - import guard
+                raise RuntimeError(
+                    "redis is required for RedisStateStore; install with `pip install redis`"
+                ) from exc
+            redis_client = redis.Redis.from_url(
+                redis_url or os.environ.get("FLUXION_REDIS_URL", "redis://localhost:6379/0")
+            )
+        self.client = redis_client
+
+    @classmethod
+    def from_env(cls) -> "RedisStateStore":
+        return cls(key_prefix=os.environ.get("FLUXION_REDIS_PREFIX", "fluxion:campaign"))
+
+    def _task_key(self, campaign_id: str, work_unit_id: str) -> str:
+        return f"{self.key_prefix}:{campaign_id}:task:{work_unit_id}"
+
+    def _index_key(self, campaign_id: str) -> str:
+        return f"{self.key_prefix}:{campaign_id}:tasks"
+
+    @staticmethod
+    def _epoch_ms(timestamp: str) -> float:
+        try:
+            ts = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            return ts.timestamp() * 1000.0
+        except Exception:
+            return 0.0
+
+    def set_state(self, state: TaskState) -> None:
+        mapping: dict[str, str] = {
+            "status": state.status.value,
+            "timestamp": state.timestamp,
+        }
+        task_key = self._task_key(state.campaign_id, state.work_unit_id)
+        pipe = self.client.pipeline()
+
+        if state.error_message is not None:
+            mapping["error_message"] = state.error_message
+        else:
+            pipe.hdel(task_key, "error_message")
+        if state.metrics is not None:
+            mapping["metrics"] = json.dumps(state.metrics)
+        else:
+            pipe.hdel(task_key, "metrics")
+
+        pipe.hset(task_key, mapping=mapping)
+        pipe.zadd(
+            self._index_key(state.campaign_id),
+            {state.work_unit_id: self._epoch_ms(state.timestamp)},
+        )
+        pipe.execute()
+
+    def get_state(self, campaign_id: str, work_unit_id: str) -> Optional[TaskState]:
+        raw = self.client.hgetall(self._task_key(campaign_id, work_unit_id))
+        if not raw:
+            return None
+        decoded = _decode_redis_hash(raw)
+        metrics_raw = decoded.pop("metrics", None)
+        metrics = json.loads(metrics_raw) if metrics_raw else None
+        return TaskState(
+            campaign_id=campaign_id,
+            work_unit_id=work_unit_id,
+            status=TaskStatus.coerce(decoded.get("status", "pending")),
+            timestamp=decoded.get("timestamp", ""),
+            error_message=decoded.get("error_message"),
+            metrics=metrics,
+        )
+
+    def list_states(self, campaign_id: str) -> list[TaskState]:
+        ids = self.client.zrange(self._index_key(campaign_id), 0, -1)
+        if not ids:
+            return []
+        pipe = self.client.pipeline()
+        for wid in ids:
+            pipe.hgetall(self._task_key(campaign_id, wid))
+        results = pipe.execute()
+        out: list[TaskState] = []
+        for raw_work_unit_id, raw in zip(ids, results):
+            if not raw:
+                continue
+            decoded = _decode_redis_hash(raw)
+            metrics_raw = decoded.pop("metrics", None)
+            metrics = json.loads(metrics_raw) if metrics_raw else None
+            out.append(
+                TaskState(
+                    campaign_id=campaign_id,
+                    work_unit_id=_ensure_str(raw_work_unit_id),
+                    status=TaskStatus.coerce(decoded.get("status", "pending")),
+                    timestamp=decoded.get("timestamp", ""),
+                    error_message=decoded.get("error_message"),
+                    metrics=metrics,
+                )
+            )
+        return out
+
+    def clear(self, campaign_id: Optional[str] = None) -> None:
+        """Test helper: drop all task entries for a campaign (or all)."""
+        if campaign_id is None:
+            # Caller is responsible for full cleanup; do nothing destructive.
+            return
+        ids = self.client.zrange(self._index_key(campaign_id), 0, -1)
+        pipe = self.client.pipeline()
+        for wid in ids:
+            pipe.delete(self._task_key(campaign_id, wid))
+        pipe.delete(self._index_key(campaign_id))
+        pipe.execute()
+
+
+# ---------------------------------------------------------------------------
+# Codec helpers
+# ---------------------------------------------------------------------------
+
+
+def _to_dynamodb_map(metrics: dict[str, Any]) -> dict[str, Any]:
+    """Convert a flat metric dict to DynamoDB's typed-map format."""
+    out: dict[str, Any] = {}
+    for key, value in metrics.items():
+        if isinstance(value, bool):
+            out[key] = {"BOOL": value}
+        elif isinstance(value, (int, float)):
+            out[key] = {"N": str(value)}
+        elif isinstance(value, str):
+            out[key] = {"S": value}
+        else:
+            out[key] = {"S": json.dumps(value)}
+    return out
+
+
+def _from_dynamodb_item(item: dict[str, Any]) -> TaskState:
+    metrics: Optional[dict[str, float]] = None
+    raw_metrics = item.get("metrics")
+    if isinstance(raw_metrics, dict) and "M" in raw_metrics:
+        metrics_map = raw_metrics["M"]
+        metrics = {}
+        for k, v in metrics_map.items():
+            if "N" in v:
+                try:
+                    metrics[k] = float(v["N"])
+                except ValueError:
+                    continue
+            elif "S" in v:
+                metrics[k] = v["S"]
+    return TaskState(
+        campaign_id=item["campaign_id"]["S"],
+        work_unit_id=item["work_unit_id"]["S"],
+        status=TaskStatus.coerce(item.get("status", {}).get("S", "pending")),
+        timestamp=item.get("timestamp", {}).get("S", ""),
+        error_message=item.get("error_message", {}).get("S"),
+        metrics=metrics,
+    )
+
+
+def _decode_redis_hash(raw: Any) -> dict[str, str]:
+    """Decode a redis-py hash (bytes/str keys) into ``str -> str``."""
+    decoded: dict[str, str] = {}
+    for k, v in raw.items():
+        key = _ensure_str(k)
+        value = _ensure_str(v)
+        decoded[key] = value
+    return decoded
+
+
+def _ensure_str(value: Any) -> str:
+    """Decode ``bytes`` (or bytearray) to ``str``; pass-through otherwise."""
+    if isinstance(value, (bytes, bytearray)):
+        return value.decode()
+    return value
+
+
+__all__ = [
+    "TaskStatus",
+    "TaskState",
+    "CampaignProgress",
+    "StateStore",
+    "InMemoryStateStore",
+    "DynamoDBStateStore",
+    "RedisStateStore",
+]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    # Tiny smoke test: pick a backend and round-trip one task.
+    logging.basicConfig(level=logging.INFO)
+    store = StateStore.from_env()
+    print(f"Using backend: {store.backend_name}", file=sys.stderr)
+    sample = TaskState.now(
+        campaign_id="smoke-test",
+        work_unit_id="wu-0001",
+        status=TaskStatus.RUNNING,
+    )
+    store.set_state(sample)
+    fetched = store.get_state(sample.campaign_id, sample.work_unit_id)
+    assert fetched is not None and fetched.status == TaskStatus.RUNNING
+    progress = store.aggregate_progress(sample.campaign_id, total=1)
+    print(progress.to_dict())

--- a/tests/python/test_state_store.py
+++ b/tests/python/test_state_store.py
@@ -1,0 +1,612 @@
+"""
+Unit tests for the campaign state-store (Issue #1787 / T7.3).
+
+Covers:
+- :mod:`scripts.state_store` for all three backends (in-memory, DynamoDB
+  via ``moto``, and Redis via a self-contained stub that satisfies the
+  small surface area the real ``redis-py`` client exposes).
+- The worker's :func:`update_campaign_progress` and :func:`run_worker`
+  end-to-end paths through the new state-store.
+- The coordinator's :func:`check_campaign_progress` aggregation path
+  when a state-store is provided.
+
+The tests intentionally avoid invoking ``cargo`` or hitting AWS — they
+exercise the pure data path so they stay fast and CI-friendly. A live
+DynamoDB / Redis integration test would belong in a separate suite
+gated on ``FLUXION_RUN_CLOUD_INTEGRATION=1``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+STATE_STORE_SCRIPT = SCRIPTS_DIR / "state_store.py"
+S3_WORKER_SCRIPT = SCRIPTS_DIR / "s3_worker.py"
+CLOUD_MANAGER_SCRIPT = SCRIPTS_DIR / "cloud_campaign_manager.py"
+
+
+def _load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def state_store_module():
+    return _load_module(STATE_STORE_SCRIPT, "state_store")
+
+
+@pytest.fixture(scope="module")
+def s3_worker_module():
+    return _load_module(S3_WORKER_SCRIPT, "s3_worker_under_test")
+
+
+@pytest.fixture(scope="module")
+def cloud_manager_module():
+    return _load_module(CLOUD_MANAGER_SCRIPT, "cloud_campaign_manager_under_test")
+
+
+# ---------------------------------------------------------------------------
+# Backend-agnostic behavioural tests — run against every store implementation.
+# ---------------------------------------------------------------------------
+
+
+def _exercise_store(store, state_store_module):
+    """Push a campaign through the store and assert observable invariants."""
+    state_store_module.TaskState.now("camp-A", "wu-1", "running")
+    entries = [
+        ("wu-1", "running", None, None),
+        ("wu-2", "completed", {"heating_mae": 1.0, "cooling_mae": 0.5}, None),
+        ("wu-3", "failed", None, "timeout"),
+        ("wu-4", "pending", None, None),
+    ]
+    for wid, status, metrics, err in entries:
+        store.set_state(
+            state_store_module.TaskState.now(
+                "camp-A", wid, status, metrics=metrics, error_message=err
+            )
+        )
+
+    progress = store.aggregate_progress("camp-A", total=4)
+    assert progress.completed == 1
+    assert progress.failed == 1
+    assert progress.running == 1
+    assert progress.pending == 1
+    assert progress.total == 4
+    assert progress.progress_pct == pytest.approx(50.0, abs=0.01)
+    assert not progress.is_complete
+
+    # Mark wu-1 and wu-4 as terminal; campaign becomes complete.
+    store.set_state(state_store_module.TaskState.now("camp-A", "wu-1", "completed"))
+    store.set_state(state_store_module.TaskState.now("camp-A", "wu-4", "failed", error_message="boom"))
+    progress = store.aggregate_progress("camp-A", total=4)
+    assert progress.completed == 2
+    assert progress.failed == 2
+    assert progress.is_complete
+    assert progress.progress_pct == pytest.approx(100.0, abs=0.01)
+
+    # get_state round-trip on the only entry that has metrics.
+    fetched = store.get_state("camp-A", "wu-2")
+    assert fetched is not None
+    assert fetched.status == state_store_module.TaskStatus.COMPLETED
+    assert fetched.metrics == {"heating_mae": 1.0, "cooling_mae": 0.5}
+
+    # Re-setting wu-2 with no metrics should clear the optional field.
+    store.set_state(state_store_module.TaskState.now("camp-A", "wu-2", "completed"))
+    assert store.get_state("camp-A", "wu-2").metrics is None
+
+    # Different campaigns are isolated.
+    store.set_state(
+        state_store_module.TaskState.now("camp-B", "wu-1", "completed")
+    )
+    progress_b = store.aggregate_progress("camp-B", total=1)
+    assert progress_b.completed == 1
+    assert progress_b.is_complete
+
+
+def test_in_memory_store_round_trip(state_store_module):
+    store = state_store_module.InMemoryStateStore()
+    assert store.backend_name == "memory"
+    _exercise_store(store, state_store_module)
+
+
+def test_in_memory_store_list_is_independent_of_insertion_order(state_store_module):
+    store = state_store_module.InMemoryStateStore()
+    for i in range(5):
+        store.set_state(
+            state_store_module.TaskState.now("camp", f"wu-{i}", "pending")
+        )
+    assert len(store.list_states("camp")) == 5
+
+
+def test_task_state_validation(state_store_module):
+    with pytest.raises(ValueError):
+        state_store_module.TaskState(
+            campaign_id="",
+            work_unit_id="wu",
+            status="running",
+            timestamp="now",
+        )
+    with pytest.raises(ValueError):
+        state_store_module.TaskState(
+            campaign_id="c",
+            work_unit_id="",
+            status="running",
+            timestamp="now",
+        )
+    with pytest.raises(ValueError):
+        state_store_module.TaskState(
+            campaign_id="c",
+            work_unit_id="wu",
+            status="not-a-status",
+            timestamp="now",
+        )
+
+
+def test_task_state_to_from_dict(state_store_module):
+    original = state_store_module.TaskState(
+        campaign_id="c1",
+        work_unit_id="wu-1",
+        status="completed",
+        timestamp="2026-01-01T00:00:00+00:00",
+        metrics={"heating_mae": 1.0},
+        error_message=None,
+    )
+    payload = original.to_dict()
+    restored = state_store_module.TaskState.from_dict(payload)
+    assert restored.campaign_id == original.campaign_id
+    assert restored.work_unit_id == original.work_unit_id
+    assert restored.status == original.status
+    assert restored.timestamp == original.timestamp
+    assert restored.metrics == original.metrics
+
+
+def test_dynamodb_store_round_trip(state_store_module):
+    moto = pytest.importorskip("moto")
+    import boto3
+
+    with moto.mock_aws():
+        ddb = boto3.client("dynamodb", region_name="us-east-1")
+        store = state_store_module.DynamoDBStateStore(
+            dynamodb_client=ddb, table_name="fluxion-state-test"
+        )
+        store.ensure_table()
+        _exercise_store(store, state_store_module)
+
+
+def test_dynamodb_store_ensure_table_is_idempotent(state_store_module):
+    moto = pytest.importorskip("moto")
+    import boto3
+
+    with moto.mock_aws():
+        ddb = boto3.client("dynamodb", region_name="us-east-1")
+        store = state_store_module.DynamoDBStateStore(
+            dynamodb_client=ddb, table_name="fluxion-state-test"
+        )
+        store.ensure_table()
+        store.ensure_table()
+        # Should not raise; querying should be empty.
+        assert store.list_states("nope") == []
+
+
+# ---------------------------------------------------------------------------
+# Redis backend — fake client satisfying the redis-py surface area we use.
+# ---------------------------------------------------------------------------
+
+
+class _FakePipe:
+    def __init__(self, parent: "_FakeRedis") -> None:
+        self.parent = parent
+        self.queue: list[tuple] = []
+
+    def hset(self, key, mapping=None, **_kw):
+        self.queue.append(("hset", key, dict(mapping or {})))
+        return self
+
+    def hdel(self, key, *fields):
+        self.queue.append(("hdel", key, list(fields)))
+        return self
+
+    def zadd(self, key, mapping):
+        self.queue.append(("zadd", key, dict(mapping)))
+        return self
+
+    def hgetall(self, key):
+        self.queue.append(("hgetall", key))
+        return self
+
+    def delete(self, key):
+        self.queue.append(("delete", key))
+        return self
+
+    def execute(self):
+        results = []
+        for cmd in self.queue:
+            results.append(self.parent._run(cmd))
+        self.queue.clear()
+        return results
+
+
+class _FakeRedis:
+    def __init__(self) -> None:
+        self.hashes: dict[str, dict[str, str]] = {}
+        self.zsets: dict[str, dict[str, float]] = {}
+
+    def pipeline(self):
+        return _FakePipe(self)
+
+    # Direct-call APIs (used by .clear() and for cleanliness in tests).
+    def hset(self, key, mapping=None, **_kw):
+        self.hashes.setdefault(key, {}).update(mapping or {})
+        return 1
+
+    def hdel(self, key, *fields):
+        existing = self.hashes.get(key, {})
+        removed = sum(1 for f in fields if existing.pop(f, None) is not None)
+        return removed
+
+    def hgetall(self, key):
+        return dict(self.hashes.get(key, {}))
+
+    def zadd(self, key, mapping):
+        self.zsets.setdefault(key, {}).update(
+            {
+                m.decode() if isinstance(m, bytes) else m: float(s)
+                for m, s in mapping.items()
+            }
+        )
+        return 1
+
+    def zrange(self, key, start, end):
+        items = self.zsets.get(key, {})
+        ordered = sorted(items.items(), key=lambda kv: kv[1])
+        if end == -1:
+            end = len(ordered) - 1
+        return [k for k, _ in ordered[start : end + 1]]
+
+    def delete(self, key):
+        existed = key in self.hashes or key in self.zsets
+        self.hashes.pop(key, None)
+        self.zsets.pop(key, None)
+        return 1 if existed else 0
+
+    # Internal helper used by the pipeline.
+    def _run(self, cmd):
+        kind = cmd[0]
+        if kind == "hset":
+            _, key, mapping = cmd
+            self.hset(key, mapping=mapping)
+            return 1
+        if kind == "hdel":
+            _, key, fields = cmd
+            return self.hdel(key, *fields)
+        if kind == "zadd":
+            _, key, mapping = cmd
+            self.zadd(key, mapping)
+            return 1
+        if kind == "hgetall":
+            _, key = cmd
+            return self.hgetall(key)
+        if kind == "delete":
+            _, key = cmd
+            return self.delete(key)
+        raise AssertionError(f"unknown fake-redis cmd: {kind}")
+
+
+@pytest.fixture
+def fake_redis():
+    return _FakeRedis()
+
+
+def test_redis_store_round_trip(state_store_module, fake_redis):
+    store = state_store_module.RedisStateStore(redis_client=fake_redis)
+    assert store.backend_name == "redis"
+    _exercise_store(store, state_store_module)
+
+
+def test_redis_store_clear(state_store_module, fake_redis):
+    store = state_store_module.RedisStateStore(redis_client=fake_redis)
+    store.set_state(state_store_module.TaskState.now("camp", "wu-1", "completed"))
+    store.clear("camp")
+    assert store.list_states("camp") == []
+    assert store.aggregate_progress("camp", total=1).progress_pct == 0.0
+
+
+def test_redis_store_handles_unicode_work_unit_ids(state_store_module, fake_redis):
+    store = state_store_module.RedisStateStore(redis_client=fake_redis)
+    store.set_state(
+        state_store_module.TaskState.now("camp-ü", "wu-日本語", "completed")
+    )
+    fetched = store.get_state("camp-ü", "wu-日本語")
+    assert fetched is not None
+    assert fetched.status == state_store_module.TaskStatus.COMPLETED
+
+
+# ---------------------------------------------------------------------------
+# Factory / from_env tests.
+# ---------------------------------------------------------------------------
+
+
+def test_create_factory_dispatch(state_store_module, fake_redis):
+    assert isinstance(
+        state_store_module.StateStore.create("memory"), state_store_module.InMemoryStateStore
+    )
+    redis_store = state_store_module.StateStore.create("redis", redis_client=fake_redis)
+    assert isinstance(redis_store, state_store_module.RedisStateStore)
+
+
+def test_create_factory_rejects_unknown_backend(state_store_module):
+    with pytest.raises(ValueError):
+        state_store_module.StateStore.create("not-a-backend")
+
+
+def test_from_env_respects_explicit_backend(state_store_module, monkeypatch):
+    monkeypatch.setenv("FLUXION_STATE_STORE", "memory")
+    store = state_store_module.StateStore.from_env()
+    assert store.backend_name == "memory"
+
+
+def test_from_env_unknown_backend_raises(state_store_module, monkeypatch):
+    monkeypatch.setenv("FLUXION_STATE_STORE", "invalid")
+    with pytest.raises(ValueError):
+        state_store_module.StateStore.from_env()
+
+
+# ---------------------------------------------------------------------------
+# Worker integration: update_campaign_progress + run_worker
+# ---------------------------------------------------------------------------
+
+
+def _stub_clients():
+    class _FakeS3:
+        def __init__(self):
+            self.objects: list[tuple[str, bytes]] = []
+
+        def put_object(self, **kwargs):
+            self.objects.append((kwargs.get("Key", ""), kwargs.get("Body", b"")))
+            return {"ETag": "fake"}
+
+        def get_object(self, **_kwargs):
+            class _Body:
+                def read(self_inner):
+                    return b"{}"
+
+            return {"Body": _Body()}
+
+    s3 = _FakeS3()
+    return {"s3": s3, "dynamodb": object(), "sns": object()}
+
+
+def test_update_campaign_progress_uses_injected_store(state_store_module, s3_worker_module):
+    store = state_store_module.InMemoryStateStore()
+    clients = _stub_clients()
+    s3_worker_module.update_campaign_progress(
+        "camp-A", "wu-1", "completed", clients, store=store,
+        metrics={"heating_mae": 2.0},
+    )
+    fetched = store.get_state("camp-A", "wu-1")
+    assert fetched is not None
+    assert fetched.status == state_store_module.TaskStatus.COMPLETED
+    assert fetched.metrics == {"heating_mae": 2.0}
+
+
+def test_update_campaign_progress_failure_path_writes_error(state_store_module, s3_worker_module):
+    store = state_store_module.InMemoryStateStore()
+    clients = _stub_clients()
+    s3_worker_module.update_campaign_progress(
+        "camp-A", "wu-1", "failed", clients, store=store, error_message="kaboom",
+    )
+    fetched = store.get_state("camp-A", "wu-1")
+    assert fetched.status == state_store_module.TaskStatus.FAILED
+    assert fetched.error_message == "kaboom"
+
+
+def test_run_worker_success_path(state_store_module, s3_worker_module):
+    store = state_store_module.InMemoryStateStore()
+    clients = _stub_clients()
+
+    wu = s3_worker_module.WorkUnit(
+        work_unit_id="wu-1",
+        campaign_id="camp-A",
+        case_id="600",
+        parameters={"R_value": 2.0},
+        s3_result_prefix="s3://bucket/prefix",
+        config={},
+    )
+
+    def fake_simulation(_wu):
+        return (
+            {
+                "heating_mae": 1.0,
+                "cooling_mae": 0.5,
+                "peak_heating_mae": 2.0,
+                "peak_cooling_mae": 1.0,
+                "temperature_mae": 0.7,
+                "overall_pass": True,
+            },
+            "",
+        )
+
+    with patch.object(s3_worker_module, "get_aws_clients", lambda: clients), \
+         patch.object(s3_worker_module, "push_result_to_s3", lambda *a, **k: "s3://bucket/prefix/wu-1.json"), \
+         patch.object(s3_worker_module, "run_simulation", fake_simulation):
+        result = s3_worker_module.run_worker(wu, state_store=store)
+
+    assert result.error_message is None
+    assert result.heating_mae == pytest.approx(1.0)
+    state = store.get_state("camp-A", "wu-1")
+    assert state.status == state_store_module.TaskStatus.COMPLETED
+    assert state.metrics["heating_mae"] == pytest.approx(1.0)
+
+
+def test_run_worker_failure_path(state_store_module, s3_worker_module):
+    store = state_store_module.InMemoryStateStore()
+    clients = _stub_clients()
+
+    wu = s3_worker_module.WorkUnit(
+        work_unit_id="wu-fail",
+        campaign_id="camp-A",
+        case_id="600",
+        parameters={"R_value": 2.0},
+        s3_result_prefix="s3://bucket/prefix",
+        config={},
+    )
+
+    def fake_simulation(_wu):
+        return ({"error": "subprocess timeout"}, "")
+
+    with patch.object(s3_worker_module, "get_aws_clients", lambda: clients), \
+         patch.object(s3_worker_module, "push_result_to_s3", lambda *a, **k: "s3://bucket/prefix/wu-fail.json"), \
+         patch.object(s3_worker_module, "run_simulation", fake_simulation):
+        result = s3_worker_module.run_worker(wu, state_store=store)
+
+    assert result.error_message == "subprocess timeout"
+    state = store.get_state("camp-A", "wu-fail")
+    assert state.status == state_store_module.TaskStatus.FAILED
+    assert state.error_message == "subprocess timeout"
+
+
+# ---------------------------------------------------------------------------
+# Coordinator integration: check_campaign_progress uses state-store.
+# ---------------------------------------------------------------------------
+
+
+def test_check_campaign_progress_uses_state_store(state_store_module, cloud_manager_module):
+    store = state_store_module.InMemoryStateStore()
+    for wid, status in [
+        ("wu-1", "running"),
+        ("wu-2", "completed"),
+        ("wu-3", "failed"),
+    ]:
+        store.set_state(
+            state_store_module.TaskState.now("camp-X", wid, status)
+        )
+    state = cloud_manager_module.CampaignState(
+        campaign_id="camp-X",
+        config={"case_id": "600"},
+        work_units=[{"work_unit_id": w} for w in ("wu-1", "wu-2", "wu-3")],
+        status="created",
+        start_time=datetime.now(timezone.utc).isoformat(),
+    )
+
+    # Patch the AWS clients out so the S3 fallback cannot fire.
+    with patch.object(cloud_manager_module, "get_aws_clients") as fake_clients:
+        fake_clients.return_value = _stub_clients()
+        # Even if the S3 listing ran, it would observe 0 — the assertion
+        # below must therefore come from the state-store path.
+        updated = cloud_manager_module.check_campaign_progress(
+            state, s3_bucket="x", s3_prefix="y", state_store=store
+        )
+
+    assert updated.completed_units == 1
+    assert updated.failed_units == 1
+    # wu-1 is running so the campaign should be marked running, not yet completed.
+    assert updated.status == "running"
+
+    # Now finish the running task.
+    store.set_state(state_store_module.TaskState.now("camp-X", "wu-1", "completed"))
+    with patch.object(cloud_manager_module, "get_aws_clients") as fake_clients:
+        fake_clients.return_value = _stub_clients()
+        updated = cloud_manager_module.check_campaign_progress(
+            state, s3_bucket="x", s3_prefix="y", state_store=store
+        )
+    assert updated.status == "completed"
+    assert updated.completed_units == 2
+    assert updated.failed_units == 1
+
+
+def test_resolve_state_store_memory_short_circuits(cloud_manager_module):
+    store = cloud_manager_module._resolve_state_store("memory")
+    assert store is not None
+    assert store.backend_name == "memory"
+
+
+def test_resolve_state_store_auto_defaults_to_none(cloud_manager_module, monkeypatch):
+    monkeypatch.delenv("FLUXION_STATE_STORE", raising=False)
+    monkeypatch.delenv("FLUXION_CAMPAIGN_TABLE", raising=False)
+    monkeypatch.delenv("FLUXION_REDIS_URL", raising=False)
+    assert cloud_manager_module._resolve_state_store("auto") is None
+
+
+def test_resolve_state_store_auto_picks_dynamodb_from_legacy_env(
+    cloud_manager_module, monkeypatch
+):
+    monkeypatch.delenv("FLUXION_STATE_STORE", raising=False)
+    monkeypatch.delenv("FLUXION_REDIS_URL", raising=False)
+    monkeypatch.setenv("FLUXION_CAMPAIGN_TABLE", "fluxion-campaign-state")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "fake")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "fake")
+    store = cloud_manager_module._resolve_state_store("auto")
+    assert store is not None
+    assert store.backend_name == "dynamodb"
+
+
+def test_full_worker_coordinator_loop(state_store_module, s3_worker_module, cloud_manager_module):
+    """End-to-end: workers push to the store, coordinator aggregates."""
+    store = state_store_module.InMemoryStateStore()
+    clients = _stub_clients()
+
+    work_units = [
+        s3_worker_module.WorkUnit(
+            work_unit_id=f"wu-{i:03d}",
+            campaign_id="camp-loop",
+            case_id="600",
+            parameters={"R_value": 1.0 + i * 0.1},
+            s3_result_prefix="s3://bucket/prefix",
+            config={},
+        )
+        for i in range(4)
+    ]
+
+    def fake_simulation(wu):
+        if wu.work_unit_id == "wu-002":
+            return {"error": "synthetic failure"}, ""
+        return (
+            {
+                "heating_mae": 1.0,
+                "cooling_mae": 0.5,
+                "peak_heating_mae": 2.0,
+                "peak_cooling_mae": 1.0,
+                "temperature_mae": 0.7,
+                "overall_pass": True,
+            },
+            "",
+        )
+
+    with patch.object(s3_worker_module, "get_aws_clients", lambda: clients), \
+         patch.object(s3_worker_module, "push_result_to_s3", lambda *a, **k: ""), \
+         patch.object(s3_worker_module, "run_simulation", fake_simulation):
+        for wu in work_units:
+            s3_worker_module.run_worker(wu, state_store=store)
+
+    state = cloud_manager_module.CampaignState(
+        campaign_id="camp-loop",
+        config={"case_id": "600"},
+        work_units=[{"work_unit_id": wu.work_unit_id} for wu in work_units],
+        status="created",
+        start_time=datetime.now(timezone.utc).isoformat(),
+    )
+
+    with patch.object(cloud_manager_module, "get_aws_clients", lambda: _stub_clients()):
+        progress = cloud_manager_module.check_campaign_progress(
+            state, s3_bucket="x", s3_prefix="y", state_store=store
+        )
+
+    assert progress.completed_units == 3
+    assert progress.failed_units == 1
+    assert progress.status == "completed"
+    # Sanity-check the underlying aggregate too.
+    assert store.aggregate_progress("camp-loop", total=4).is_complete


### PR DESCRIPTION
Closes #1787

Workers now write per-task completion to DynamoDB or Redis. Coordinator aggregates state-store entries to compute overall campaign progress. Blocks T7.4, T7.5, and T8.2.