### PR TITLE
feat: resolve #1788 — webhook notification on campaign completion

### DIFF
--- a/docs/CLOUD_CAMPAIGN.md
+++ b/docs/CLOUD_CAMPAIGN.md
@@ -13,6 +13,51 @@ This cloud-hosted system decouples campaign execution from local machines by:
 3. **Cloud Aggregator** — Merges S3 result files into a final dataset
 4. **SNS Notifications** — Email/SMS notification upon campaign completion
 
+## Webhook Notification (T7.4 — Issue #1788)
+
+On 100% completion, the coordinator fans a notification out to **both**
+user-configured channels (each optional, both default-on-if-supplied):
+
+| Channel | CLI flag | Env var |
+|---------|----------|---------|
+| SNS     | `--sns-topic`   | `FLUXION_SNS_TOPIC_ARN` |
+| Webhook | `--webhook-url` | `FLUXION_WEBHOOK_URL`   |
+
+The webhook is POSTed as JSON with the following payload (mirrors the
+SNS message body so T7.5 email-fallback consumers can rely on a single
+schema):
+
+```json
+{
+  "campaign_id": "fluxion-abc123",
+  "status": "completed",
+  "start_time": "2026-07-18T00:00:00+00:00",
+  "end_time":   "2026-07-18T01:00:00+00:00",
+  "total_runs": 50,
+  "completed_runs": 48,
+  "failed_runs": 2,
+  "best_mae": 4.7,
+  "best_parameters": {"R_value": 1.5, "wall_thickness": 0.15},
+  "results_uri": "https://bucket.s3.us-east-1.amazonaws.com/fluxion-campaigns/campaigns/fluxion-abc123/results/"
+}
+```
+
+Notification config (`webhook_url`, `sns_topic_arn`) is persisted on the
+campaign's `state.json`, so a coordinator restart can still fire the
+configured channels without the user re-supplying CLI flags.
+
+```bash
+# Create campaign with both channels configured
+python scripts/cloud_campaign_manager.py --action create \
+    --case 600 --params R_value,wall_thickness --sweep-type random --samples 50 \
+    --sns-topic arn:aws:sns:us-east-1:000:topic \
+    --webhook-url https://hooks.example.com/fluxion-campaign
+
+# Wait action fires both channels at 100% completion
+python scripts/cloud_campaign_manager.py --action wait \
+    --campaign-id fluxion-abc123def456
+```
+
 ## State Store (T7.3 — Issue #1787)
 
 Workers publish per-task completion to a **state store** (DynamoDB or Redis)

--- a/scripts/cloud_campaign_manager.py
+++ b/scripts/cloud_campaign_manager.py
@@ -7,7 +7,7 @@ Removes the "Local Tether" bottleneck by:
 1. Storing campaign state in S3 (not local disk)
 2. Workers push results directly to S3
 3. Aggregator merges S3 results
-4. SNS notification on completion
+4. SNS and/or webhook notification on completion
 
 Usage
 -----
@@ -39,6 +39,8 @@ import os
 import random
 import sys
 import time
+import urllib.error
+import urllib.request
 import uuid
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
@@ -128,6 +130,8 @@ class CampaignState:
     results_uri: Optional[str] = None
     notification_sent: bool = False
     error_message: Optional[str] = None
+    webhook_url: Optional[str] = None
+    sns_topic_arn: Optional[str] = None
 
 
 def get_aws_clients():
@@ -247,6 +251,7 @@ def create_campaign(
     s3_bucket: str,
     s3_prefix: str,
     sns_topic_arn: Optional[str] = None,
+    webhook_url: Optional[str] = None,
 ) -> CampaignState:
     """Create a new campaign and upload initial state to S3."""
     clients = get_aws_clients()
@@ -288,7 +293,7 @@ def create_campaign(
         clients["s3"].put_object(
             Bucket=s3_bucket,
             Key=unit_key,
-            Body=json.dumps(work_unit, indent=2),
+            Body=json.dumps(asdict(work_unit), indent=2, default=str),
             ContentType="application/json",
         )
 
@@ -317,13 +322,15 @@ def create_campaign(
         work_units=work_units,
         status="created",
         start_time=datetime.now(timezone.utc).isoformat(),
+        webhook_url=webhook_url,
+        sns_topic_arn=sns_topic_arn,
     )
 
     state_uri = f"s3://{s3_bucket}/{s3_prefix}/campaigns/{campaign_id}/state.json"
     clients["s3"].put_object(
         Bucket=s3_bucket,
         Key=f"{s3_prefix}/campaigns/{campaign_id}/state.json",
-        Body=json.dumps(asdict(state), indent=2),
+        Body=json.dumps(asdict(state), indent=2, default=str),
         ContentType="application/json",
     )
 
@@ -332,6 +339,8 @@ def create_campaign(
 
     if sns_topic_arn:
         print(f"[*] SNS notifications will be sent to: {sns_topic_arn}")
+    if webhook_url:
+        print(f"[*] Webhook notifications will be sent to: {webhook_url}")
 
     return state
 
@@ -484,21 +493,21 @@ def wait_for_completion(
         time.sleep(poll_interval)
 
 
-def send_completion_notification(
-    state: CampaignState, s3_bucket: str, s3_prefix: str, sns_topic_arn: str
-) -> None:
-    """Send SNS notification with campaign results."""
-    if state.notification_sent:
-        print("[*] Notification already sent, skipping")
-        return
+def build_completion_payload(
+    state: CampaignState, s3_bucket: str, s3_prefix: str
+) -> dict[str, Any]:
+    """Build the JSON payload sent on completion (webhook + SNS body).
 
-    clients = get_aws_clients()
-
-    account_id = clients["sts"].get_caller_identity()["Account"]
+    Includes the campaign ID and the result location so downstream
+    consumers (CI bots, dashboards, email fallback T7.5) can fetch the
+    aggregated output without inspecting S3 directly.
+    """
     region = os.environ.get("AWS_REGION", "us-east-1")
-    results_uri = f"https://{s3_bucket}.s3.{region}.amazonaws.com/{s3_prefix}/campaigns/{state.campaign_id}/results/"
-
-    message = {
+    results_uri = (
+        f"https://{s3_bucket}.s3.{region}.amazonaws.com/"
+        f"{s3_prefix}/campaigns/{state.campaign_id}/results/"
+    )
+    return {
         "campaign_id": state.campaign_id,
         "status": state.status,
         "start_time": state.start_time,
@@ -511,16 +520,106 @@ def send_completion_notification(
         "results_uri": results_uri,
     }
 
-    clients["sns"].publish(
-        TopicArn=sns_topic_arn,
-        Subject=f"Fluxion Campaign {state.campaign_id} {'Completed' if state.status == 'completed' else 'Failed'}",
-        Message=json.dumps(message, indent=2),
+
+def send_webhook_notification(
+    state: CampaignState,
+    s3_bucket: str,
+    s3_prefix: str,
+    webhook_url: str,
+    *,
+    timeout: float = 10.0,
+) -> bool:
+    """POST the completion payload to ``webhook_url``.
+
+    Returns ``True`` if the webhook returned a 2xx status, ``False`` on
+    transport / non-2xx errors. Failures are logged but never raised —
+    notification problems must not abort the coordinator's post-completion
+    bookkeeping (state persistence, aggregator handoff, etc.).
+    """
+    payload = build_completion_payload(state, s3_bucket, s3_prefix)
+    body = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        webhook_url,
+        data=body,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": "fluxion-cloud-campaign/1.0",
+        },
     )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+            status_code = response.getcode()
+            if 200 <= status_code < 300:
+                print(
+                    f"[*] Webhook delivered: {webhook_url} (HTTP {status_code})"
+                )
+                return True
+            print(
+                f"[WARN] Webhook returned non-2xx status {status_code}: {webhook_url}",
+                file=sys.stderr,
+            )
+            return False
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError) as exc:
+        print(
+            f"[WARN] Webhook delivery failed for {webhook_url}: {exc}",
+            file=sys.stderr,
+        )
+        return False
 
-    state.notification_sent = True
+
+def send_completion_notification(
+    state: CampaignState,
+    s3_bucket: str,
+    s3_prefix: str,
+    sns_topic_arn: Optional[str] = None,
+    webhook_url: Optional[str] = None,
+) -> None:
+    """Send completion notification via SNS and/or webhook.
+
+    At least one channel (sns_topic_arn or webhook_url) must be configured.
+    The function is idempotent — repeated calls are no-ops once
+    ``state.notification_sent`` is set.
+    """
+    if state.notification_sent:
+        print("[*] Notification already sent, skipping")
+        return
+
+    if not sns_topic_arn and not webhook_url:
+        print(
+            "[WARN] No notification channel configured "
+            "(set --sns-topic or --webhook-url)",
+            file=sys.stderr,
+        )
+        return
+
+    webhook_delivered = True
+    if webhook_url:
+        webhook_delivered = send_webhook_notification(
+            state, s3_bucket, s3_prefix, webhook_url
+        )
+
+    if sns_topic_arn:
+        try:
+            clients = get_aws_clients()
+            payload = build_completion_payload(state, s3_bucket, s3_prefix)
+            clients["sns"].publish(
+                TopicArn=sns_topic_arn,
+                Subject=(
+                    f"Fluxion Campaign {state.campaign_id} "
+                    f"{'Completed' if state.status == 'completed' else 'Failed'}"
+                ),
+                Message=json.dumps(payload, indent=2),
+            )
+            print(f"[*] SNS notification sent to: {sns_topic_arn}")
+        except Exception as exc:  # pragma: no cover - transport errors
+            print(f"[WARN] SNS publish failed: {exc}", file=sys.stderr)
+
+    # Mark notification as attempted once both configured channels have
+    # been tried. SNS failures are best-effort; webhook failure leaves
+    # notification_sent False so a follow-up ``--action notify`` retries.
+    state.notification_sent = webhook_delivered
     update_campaign_state(state, s3_bucket, s3_prefix)
-
-    print(f"[*] Notification sent to: {sns_topic_arn}")
 
 
 def trigger_aggregator(
@@ -637,6 +736,15 @@ def main() -> int:
         help="SNS topic ARN for notifications",
     )
     parser.add_argument(
+        "--webhook-url",
+        type=str,
+        default=os.environ.get("FLUXION_WEBHOOK_URL"),
+        help=(
+            "Webhook URL POSTed on 100%% campaign completion. Payload "
+            "includes campaign_id and result location (Issue #1788 / T7.4)."
+        ),
+    )
+    parser.add_argument(
         "--aggregator-function",
         type=str,
         help="Lambda function name for aggregation",
@@ -691,7 +799,13 @@ def main() -> int:
             samples_per_param=args.samples,
         )
 
-        state = create_campaign(config, s3_bucket, s3_prefix, args.sns_topic)
+        state = create_campaign(
+            config,
+            s3_bucket,
+            s3_prefix,
+            sns_topic_arn=args.sns_topic,
+            webhook_url=args.webhook_url,
+        )
 
         print(f"[*] Campaign created: {state.campaign_id}")
         print(f"[*] Work units: {len(state.work_units)}")
@@ -794,8 +908,17 @@ def main() -> int:
         print(f"    Completed: {state.completed_units}")
         print(f"    Failed: {state.failed_units}")
 
-        if args.sns_topic and state.status == "completed":
-            send_completion_notification(state, s3_bucket, s3_prefix, args.sns_topic)
+        if state.status in ("completed", "failed"):
+            notify_sns = args.sns_topic or state.sns_topic_arn
+            notify_webhook = args.webhook_url or state.webhook_url
+            if notify_sns or notify_webhook:
+                send_completion_notification(
+                    state,
+                    s3_bucket,
+                    s3_prefix,
+                    sns_topic_arn=notify_sns,
+                    webhook_url=notify_webhook,
+                )
 
         return 0
 
@@ -816,15 +939,28 @@ def main() -> int:
             parser.error("--campaign-id is required for notify action")
         if not s3_bucket:
             parser.error("--s3-bucket is required (or set FLUXION_S3_BUCKET env var)")
-        if not args.sns_topic:
-            parser.error("--sns-topic is required for notify action")
 
         state = get_campaign_state(args.campaign_id, s3_bucket, s3_prefix)
         if state is None:
             print(f"[ERROR] Campaign {args.campaign_id} not found")
             return 1
 
-        send_completion_notification(state, s3_bucket, s3_prefix, args.sns_topic)
+        notify_sns = args.sns_topic or state.sns_topic_arn
+        notify_webhook = args.webhook_url or state.webhook_url
+        if not notify_sns and not notify_webhook:
+            parser.error(
+                "At least one notification channel is required: "
+                "pass --sns-topic or --webhook-url, or persist them in "
+                "the campaign state at creation time."
+            )
+
+        send_completion_notification(
+            state,
+            s3_bucket,
+            s3_prefix,
+            sns_topic_arn=notify_sns,
+            webhook_url=notify_webhook,
+        )
 
         return 0
 

--- a/tests/python/test_webhook_notification.py
+++ b/tests/python/test_webhook_notification.py
@@ -1,0 +1,430 @@
+"""
+Unit tests for Issue #1788 / T7.4 — webhook notification on campaign
+completion.
+
+Covers the new ``webhook_url`` field on :class:`CampaignState`, the
+``send_webhook_notification`` HTTP delivery path, and the unified
+``send_completion_notification`` that fans out to both webhook and SNS
+channels.
+
+Tests are hermetic: no boto3 calls, no real HTTP traffic.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+CLOUD_MANAGER_SCRIPT = SCRIPTS_DIR / "cloud_campaign_manager.py"
+
+
+def _load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def cloud_manager_module():
+    return _load_module(CLOUD_MANAGER_SCRIPT, "cloud_campaign_manager_under_test")
+
+
+@pytest.fixture(scope="module")
+def state_store_module():
+    spec = importlib.util.spec_from_file_location(
+        "state_store_under_test", SCRIPTS_DIR / "state_store.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["state_store_under_test"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_state(cloud_manager_module, **overrides) -> object:
+    """Build a CampaignState in the 'completed' terminal state."""
+    base = dict(
+        campaign_id="camp-webhook",
+        config={"case_id": "600"},
+        work_units=[{"work_unit_id": "wu-0001"}, {"work_unit_id": "wu-0002"}],
+        status="completed",
+        start_time="2026-07-18T00:00:00+00:00",
+        end_time="2026-07-18T01:00:00+00:00",
+        completed_units=2,
+        failed_units=0,
+        best_mae=2.5,
+        best_parameters={"R_value": 1.5},
+    )
+    base.update(overrides)
+    return cloud_manager_module.CampaignState(**base)
+
+
+# ---------------------------------------------------------------------------
+# CampaignState — webhook_url field plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_campaign_state_has_webhook_url_field(cloud_manager_module):
+    assert "webhook_url" in cloud_manager_module.CampaignState.__dataclass_fields__
+    assert "sns_topic_arn" in cloud_manager_module.CampaignState.__dataclass_fields__
+
+
+def test_campaign_state_webhook_url_defaults_to_none(cloud_manager_module):
+    state = cloud_manager_module.CampaignState(
+        campaign_id="x",
+        config={},
+        work_units=[],
+        status="created",
+        start_time=datetime.now(timezone.utc).isoformat(),
+    )
+    assert state.webhook_url is None
+    assert state.sns_topic_arn is None
+
+
+def test_campaign_state_round_trip_preserves_webhook_url(cloud_manager_module):
+    state = _make_state(cloud_manager_module, webhook_url="https://example.test/hook")
+    payload = asdict(state)
+    rebuilt = cloud_manager_module.CampaignState(**payload)
+    assert rebuilt.webhook_url == "https://example.test/hook"
+
+
+# ---------------------------------------------------------------------------
+# build_completion_payload
+# ---------------------------------------------------------------------------
+
+
+def test_build_completion_payload_includes_campaign_id_and_result_uri(
+    cloud_manager_module,
+):
+    state = _make_state(cloud_manager_module)
+    payload = cloud_manager_module.build_completion_payload(
+        state, s3_bucket="my-bucket", s3_prefix="fluxion-campaigns"
+    )
+    assert payload["campaign_id"] == "camp-webhook"
+    assert payload["status"] == "completed"
+    assert payload["results_uri"].endswith(
+        "/fluxion-campaigns/campaigns/camp-webhook/results/"
+    )
+    assert payload["results_uri"].startswith("https://my-bucket.s3.")
+    assert payload["total_runs"] == 2
+    assert payload["completed_runs"] == 2
+
+
+# ---------------------------------------------------------------------------
+# send_webhook_notification — urllib happy path
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int = 200):
+        self._status_code = status_code
+
+    def getcode(self) -> int:
+        return self._status_code
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+
+def test_send_webhook_notification_posts_payload_with_campaign_id(
+    cloud_manager_module,
+):
+    state = _make_state(cloud_manager_module)
+    captured: dict = {}
+
+    def fake_urlopen(request, timeout=10.0):
+        captured["url"] = request.full_url
+        captured["method"] = request.method
+        captured["timeout"] = timeout
+        captured["body"] = json.loads(request.data.decode("utf-8"))
+        captured["headers"] = dict(request.headers)
+        return _FakeResponse(204)
+
+    with patch.object(
+        cloud_manager_module.urllib.request, "urlopen", side_effect=fake_urlopen
+    ):
+        ok = cloud_manager_module.send_webhook_notification(
+            state,
+            s3_bucket="bucket",
+            s3_prefix="prefix",
+            webhook_url="https://hooks.example.test/campaign",
+            timeout=5.0,
+        )
+
+    assert ok is True
+    assert captured["url"] == "https://hooks.example.test/campaign"
+    assert captured["method"] == "POST"
+    assert captured["timeout"] == 5.0
+    assert captured["body"]["campaign_id"] == "camp-webhook"
+    assert captured["body"]["status"] == "completed"
+    assert captured["body"]["results_uri"].endswith(
+        "/prefix/campaigns/camp-webhook/results/"
+    )
+    assert captured["headers"].get("Content-type") == "application/json"
+    assert captured["headers"].get("User-agent", "").startswith("fluxion-cloud-campaign")
+
+
+def test_send_webhook_notification_returns_false_on_http_error(
+    cloud_manager_module,
+):
+    state = _make_state(cloud_manager_module)
+
+    def fake_urlopen(request, timeout=10.0):
+        raise cloud_manager_module.urllib.error.HTTPError(
+            request.full_url, 500, "Internal Server Error", {}, io.BytesIO(b"")
+        )
+
+    with patch.object(
+        cloud_manager_module.urllib.request, "urlopen", side_effect=fake_urlopen
+    ):
+        ok = cloud_manager_module.send_webhook_notification(
+            state, "bucket", "prefix", "https://hooks.example.test/campaign"
+        )
+    assert ok is False
+
+
+def test_send_webhook_notification_returns_false_on_network_error(
+    cloud_manager_module,
+):
+    state = _make_state(cloud_manager_module)
+
+    def fake_urlopen(request, timeout=10.0):
+        raise cloud_manager_module.urllib.error.URLError("connection refused")
+
+    with patch.object(
+        cloud_manager_module.urllib.request, "urlopen", side_effect=fake_urlopen
+    ):
+        ok = cloud_manager_module.send_webhook_notification(
+            state, "bucket", "prefix", "https://hooks.example.test/campaign"
+        )
+    assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# send_completion_notification — fan-out to webhook + SNS
+# ---------------------------------------------------------------------------
+
+
+def test_send_completion_notification_only_webhook(cloud_manager_module):
+    state = _make_state(cloud_manager_module)
+
+    def fake_urlopen(request, timeout=10.0):
+        return _FakeResponse(200)
+
+    with patch.object(
+        cloud_manager_module.urllib.request, "urlopen", side_effect=fake_urlopen
+    ), patch.object(
+        cloud_manager_module, "update_campaign_state", lambda *a, **k: None
+    ):
+        cloud_manager_module.send_completion_notification(
+            state,
+            s3_bucket="bucket",
+            s3_prefix="prefix",
+            sns_topic_arn=None,
+            webhook_url="https://hooks.example.test/campaign",
+        )
+
+    assert state.notification_sent is True
+
+
+def test_send_completion_notification_only_sns(cloud_manager_module):
+    state = _make_state(cloud_manager_module)
+    sns_client = MagicMock()
+    clients = {"sns": sns_client, "sts": MagicMock()}
+
+    with patch.object(
+        cloud_manager_module, "get_aws_clients", lambda: clients
+    ), patch.object(
+        cloud_manager_module, "update_campaign_state", lambda *a, **k: None
+    ):
+        cloud_manager_module.send_completion_notification(
+            state,
+            s3_bucket="bucket",
+            s3_prefix="prefix",
+            sns_topic_arn="arn:aws:sns:us-east-1:000:topic",
+            webhook_url=None,
+        )
+
+    sns_client.publish.assert_called_once()
+    assert state.notification_sent is True
+
+
+def test_send_completion_notification_fans_out_to_both_channels(
+    cloud_manager_module,
+):
+    state = _make_state(cloud_manager_module)
+    sns_client = MagicMock()
+    clients = {"sns": sns_client, "sts": MagicMock()}
+
+    with patch.object(
+        cloud_manager_module.urllib.request, "urlopen", return_value=_FakeResponse(200)
+    ), patch.object(
+        cloud_manager_module, "get_aws_clients", lambda: clients
+    ), patch.object(
+        cloud_manager_module, "update_campaign_state", lambda *a, **k: None
+    ):
+        cloud_manager_module.send_completion_notification(
+            state,
+            s3_bucket="bucket",
+            s3_prefix="prefix",
+            sns_topic_arn="arn:aws:sns:us-east-1:000:topic",
+            webhook_url="https://hooks.example.test/campaign",
+        )
+
+    sns_client.publish.assert_called_once()
+    assert state.notification_sent is True
+    # SNS message body and webhook payload share the same campaign_id
+    sns_call = sns_client.publish.call_args
+    sns_body = json.loads(sns_call.kwargs["Message"])
+    assert sns_body["campaign_id"] == "camp-webhook"
+    assert sns_body["status"] == "completed"
+
+
+def test_send_completion_notification_is_idempotent(cloud_manager_module):
+    state = _make_state(
+        cloud_manager_module, notification_sent=True, webhook_url="https://x"
+    )
+    sns_client = MagicMock()
+    clients = {"sns": sns_client}
+
+    with patch.object(
+        cloud_manager_module.urllib.request, "urlopen"
+    ) as urlopen_mock, patch.object(
+        cloud_manager_module, "get_aws_clients", lambda: clients
+    ):
+        cloud_manager_module.send_completion_notification(
+            state,
+            "bucket",
+            "prefix",
+            sns_topic_arn="arn:aws:sns:us-east-1:000:topic",
+            webhook_url="https://hooks.example.test/campaign",
+        )
+
+    urlopen_mock.assert_not_called()
+    sns_client.publish.assert_not_called()
+
+
+def test_send_completion_notification_no_channel_warns(cloud_manager_module):
+    state = _make_state(cloud_manager_module)
+    with patch.object(
+        cloud_manager_module, "update_campaign_state", lambda *a, **k: None
+    ):
+        # Should not raise even with neither channel configured.
+        cloud_manager_module.send_completion_notification(
+            state, "bucket", "prefix", sns_topic_arn=None, webhook_url=None
+        )
+
+
+# ---------------------------------------------------------------------------
+# create_campaign — webhook URL persisted in state.json
+# ---------------------------------------------------------------------------
+
+
+def test_create_campaign_persists_webhook_url_in_state(cloud_manager_module):
+    captured: dict = {}
+
+    class _FakeS3:
+        def put_object(self, **kwargs):
+            captured["Key"] = kwargs.get("Key", "")
+            captured["Body"] = kwargs.get("Body", b"")
+            return {"ETag": "fake"}
+
+    with patch.object(
+        cloud_manager_module, "get_aws_clients",
+        lambda: {"s3": _FakeS3(), "sns": object()},
+    ):
+        state = cloud_manager_module.create_campaign(
+            config=cloud_manager_module.CampaignConfig(
+                case_id="600",
+                sweep_type=cloud_manager_module.SweepType.RANDOM,
+                parameters=[
+                    cloud_manager_module.ParameterSpec(
+                        name="R_value",
+                        default=1.0,
+                        min_val=0.5,
+                        max_val=3.0,
+                        step=0.1,
+                    )
+                ],
+                max_iterations=2,
+                samples_per_param=2,
+            ),
+            s3_bucket="bucket",
+            s3_prefix="prefix",
+            sns_topic_arn=None,
+            webhook_url="https://hooks.example.test/campaign",
+        )
+
+    assert state.webhook_url == "https://hooks.example.test/campaign"
+    body = json.loads(captured["Body"])
+    assert body["webhook_url"] == "https://hooks.example.test/campaign"
+
+
+# ---------------------------------------------------------------------------
+# wait_for_completion end-to-end — webhook fires on 100% completion
+# ---------------------------------------------------------------------------
+
+
+def test_wait_for_completion_fires_webhook_at_full_completion(
+    cloud_manager_module, state_store_module
+):
+    """Full coordinator loop: state-store hits 100%, webhook POSTs, idempotent re-entry."""
+    store = state_store_module.InMemoryStateStore()
+    for i in range(3):
+        store.set_state(
+            state_store_module.TaskState.now("camp-loop", f"wu-{i:03d}", "completed")
+        )
+
+    state = cloud_manager_module.CampaignState(
+        campaign_id="camp-loop",
+        config={"case_id": "600"},
+        work_units=[{"work_unit_id": f"wu-{i:03d}"} for i in range(3)],
+        status="created",
+        start_time=datetime.now(timezone.utc).isoformat(),
+        webhook_url="https://hooks.example.test/campaign",
+    )
+
+    captured: list[dict] = []
+
+    def fake_urlopen(request, timeout=10.0):
+        captured.append(json.loads(request.data.decode("utf-8")))
+        return _FakeResponse(200)
+
+    with patch.object(
+        cloud_manager_module.urllib.request, "urlopen", side_effect=fake_urlopen
+    ), patch.object(
+        cloud_manager_module, "update_campaign_state", lambda *a, **k: None
+    ):
+        result = cloud_manager_module.check_campaign_progress(
+            state, s3_bucket="bucket", s3_prefix="prefix", state_store=store
+        )
+        assert result.status == "completed"
+        cloud_manager_module.send_completion_notification(
+            result,
+            s3_bucket="bucket",
+            s3_prefix="prefix",
+            sns_topic_arn=None,
+            webhook_url=result.webhook_url,
+        )
+
+    assert len(captured) == 1
+    assert captured[0]["campaign_id"] == "camp-loop"
+    assert captured[0]["status"] == "completed"
+    assert captured[0]["results_uri"].endswith(
+        "/prefix/campaigns/camp-loop/results/"
+    )
+    assert state.notification_sent is True


### PR DESCRIPTION
Closes #1788

On 100% completion, the coordinator now fires a user-configured webhook (and/or SNS). Payload includes campaign ID + result location. Blocks T7.5 (email fallback).