### PR TITLE
feat: resolve #1789 — email notification fallback for campaign completion

### DIFF
--- a/docs/CLOUD_CAMPAIGN.md
+++ b/docs/CLOUD_CAMPAIGN.md
@@ -11,7 +11,7 @@ This cloud-hosted system decouples campaign execution from local machines by:
 1. **Campaign State in S3** — All campaign state is stored in S3, not local disk
 2. **Workers Push to S3** — Individual simulation workers push KPIs directly to S3
 3. **Cloud Aggregator** — Merges S3 result files into a final dataset
-4. **SNS Notifications** — Email/SMS notification upon campaign completion
+4. **SNS / Email Notifications** — Configurable channels (webhook, SNS, email) on completion
 
 ## Webhook Notification (T7.4 — Issue #1788)
 
@@ -220,6 +220,70 @@ python scripts/cloud_campaign_manager.py \
   --campaign-id fluxion-abc123def456 \
   --sns-topic arn:aws:sns:region:account:topic
 ```
+
+## Email Notification (T7.5 — Issue #1789)
+
+Not every user runs a webhook listener — most want a plain email when their
+campaign finishes. The **email channel** is the universal fallback:
+
+| Field | CLI flag | Env var |
+|-------|----------|---------|
+| Sender | `--email-from` | `FLUXION_EMAIL_FROM` |
+| Recipients | `--email-to` (comma-separated) | `FLUXION_EMAIL_TO` |
+| CC | `--email-cc` (comma-separated) | `FLUXION_EMAIL_CC` |
+| API endpoint | `--email-api-endpoint` | `FLUXION_EMAIL_API_ENDPOINT` |
+| API auth header | `--email-api-auth` | `FLUXION_EMAIL_API_AUTH` |
+| Pre-signed URL | `--email-download-url` | `FLUXION_EMAIL_DOWNLOAD_URL` |
+
+The email body is a plain-text template with placeholders that mirror the
+JSON payload shape used by the webhook / SNS channels:
+
+```
+Fluxion campaign {campaign_id} is {status_display}.
+
+Started:  {start_time}
+Finished: {end_time}
+
+Total runs:     {total_runs}
+Completed runs: {completed_runs}
+Failed runs:    {failed_runs}
+Best MAE:       {best_mae:.2}%
+
+Best parameters:
+{best_parameters_block}
+
+Download aggregated results:
+{download_url}
+
+—
+Fluxion cloud coordinator (OSimFlow)
+```
+
+The Rust implementation in `src/api/email_notification.rs` is the canonical
+renderer; the Python side mirrors it so producers and consumers agree on
+shape. The HTTP transport (`HttpEmailTransport`) POSTs a JSON envelope to
+the configured `api_endpoint` — provider-agnostic (SendGrid, Mailgun,
+Postmark, SES v2 all accept this shape).
+
+```bash
+# Create a campaign with email fallback configured (universal recipient)
+python scripts/cloud_campaign_manager.py --action create \
+  --case 600 --params R_value,wall_thickness --sweep-type random --samples 50 \
+  --sns-topic arn:aws:sns:us-east-1:000:topic \
+  --email-from fluxion-noreply@fluxion.example \
+  --email-to user@fluxion.example,team@fluxion.example \
+  --email-api-endpoint https://api.sendgrid.com/v3/mail/send \
+  --email-api-auth "Bearer SG.xxxxxxxxxxxx"
+
+# Wait action fires both channels at 100% completion
+python scripts/cloud_campaign_manager.py --action wait \
+  --campaign-id fluxion-abc123def456
+```
+
+Email preferences are persisted on `state.json` (field `email_config`) so a
+coordinator restart can still send without the user re-supplying CLI flags.
+Idempotency is enforced via a `completion_hash` (FNV-1a over the
+completion payload) carried as the `X-Fluxion-Completion-Hash` header.
 
 ## Workflow Components
 

--- a/scripts/cloud_campaign_manager.py
+++ b/scripts/cloud_campaign_manager.py
@@ -7,7 +7,7 @@ Removes the "Local Tether" bottleneck by:
 1. Storing campaign state in S3 (not local disk)
 2. Workers push results directly to S3
 3. Aggregator merges S3 results
-4. SNS and/or webhook notification on completion
+4. SNS, webhook, and/or email notification on completion
 
 Usage
 -----
@@ -132,6 +132,7 @@ class CampaignState:
     error_message: Optional[str] = None
     webhook_url: Optional[str] = None
     sns_topic_arn: Optional[str] = None
+    email_config: Optional[dict] = None
 
 
 def get_aws_clients():
@@ -151,6 +152,76 @@ def get_aws_clients():
         "dynamodb": session.client("dynamodb"),
         "sts": session.client("sts"),
     }
+
+
+def parse_email_recipients(raw: str) -> list[str]:
+    """Parse a comma- or semicolon-separated recipient list (Issue #1789)."""
+    if not raw:
+        return []
+    parts = [p.strip() for p in raw.replace(";", ",").split(",")]
+    return [p for p in parts if p]
+
+
+def build_completion_payload(
+    state: CampaignState, s3_bucket: str, s3_prefix: str
+) -> dict[str, Any]:
+    """Build the JSON payload sent on completion (webhook + SNS + email body).
+
+    Mirrors the Rust `CampaignCompletion` struct (see
+    `src/api/email_notification.rs`, Issue #1789) so every notification
+    channel sees the same shape.
+    """
+    region = os.environ.get("AWS_REGION", "us-east-1")
+    results_uri = (
+        f"https://{s3_bucket}.s3.{region}.amazonaws.com/"
+        f"{s3_prefix}/campaigns/{state.campaign_id}/results/"
+    )
+    return {
+        "campaign_id": state.campaign_id,
+        "status": state.status,
+        "start_time": state.start_time,
+        "end_time": datetime.now(timezone.utc).isoformat(),
+        "total_runs": len(state.work_units),
+        "completed_runs": state.completed_units,
+        "failed_runs": state.failed_units,
+        "best_mae": state.best_mae,
+        "best_parameters": state.best_parameters,
+        "results_uri": results_uri,
+    }
+
+
+def render_email_body(payload: dict[str, Any], download_url: Optional[str] = None) -> str:
+    """Render the plain-text email body for a completion event (T7.5)."""
+    download = download_url or payload["results_uri"]
+    best_params = payload.get("best_parameters") or {}
+    if best_params:
+        params_block = "\n".join(
+            f"  {k} = {v}" for k, v in sorted(best_params.items())
+        )
+    else:
+        params_block = "  (none)"
+    status_display = "completed" if payload["status"] != "failed" else "failed"
+    return (
+        f"Fluxion campaign {payload['campaign_id']} is {status_display}.\n\n"
+        f"Started:  {payload['start_time']}\n"
+        f"Finished: {payload['end_time']}\n\n"
+        f"Total runs:     {payload['total_runs']}\n"
+        f"Completed runs: {payload['completed_runs']}\n"
+        f"Failed runs:    {payload['failed_runs']}\n"
+        f"Best MAE:       {payload['best_mae']:.2f}%\n\n"
+        f"Best parameters:\n{params_block}\n\n"
+        f"Download aggregated results:\n{download}\n\n"
+        f"—\nFluxion cloud coordinator (OSimFlow)\n"
+    )
+
+
+def render_email_subject(payload: dict[str, Any]) -> str:
+    """Render the subject line for a completion email (T7.5)."""
+    status_display = "completed" if payload["status"] != "failed" else "failed"
+    return (
+        f"Fluxion campaign {payload['campaign_id']} {status_display} — "
+        f"results ready"
+    )
 
 
 def parse_s3_uri(uri: str) -> tuple[str, str]:
@@ -251,7 +322,11 @@ def create_campaign(
     s3_bucket: str,
     s3_prefix: str,
     sns_topic_arn: Optional[str] = None,
+<<<<<<< HEAD
     webhook_url: Optional[str] = None,
+=======
+    email_config: Optional[dict] = None,
+>>>>>>> 1d0e1c8 (feat: resolve #1789 — email notification fallback for campaign completion)
 ) -> CampaignState:
     """Create a new campaign and upload initial state to S3."""
     clients = get_aws_clients()
@@ -322,8 +397,12 @@ def create_campaign(
         work_units=work_units,
         status="created",
         start_time=datetime.now(timezone.utc).isoformat(),
+<<<<<<< HEAD
         webhook_url=webhook_url,
         sns_topic_arn=sns_topic_arn,
+=======
+        email_config=email_config,
+>>>>>>> 1d0e1c8 (feat: resolve #1789 — email notification fallback for campaign completion)
     )
 
     state_uri = f"s3://{s3_bucket}/{s3_prefix}/campaigns/{campaign_id}/state.json"
@@ -339,8 +418,14 @@ def create_campaign(
 
     if sns_topic_arn:
         print(f"[*] SNS notifications will be sent to: {sns_topic_arn}")
+<<<<<<< HEAD
     if webhook_url:
         print(f"[*] Webhook notifications will be sent to: {webhook_url}")
+=======
+    if email_config and email_config.get("to"):
+        recipients = ", ".join(email_config["to"])
+        print(f"[*] Email notifications will be sent to: {recipients}")
+>>>>>>> 1d0e1c8 (feat: resolve #1789 — email notification fallback for campaign completion)
 
     return state
 
@@ -493,6 +578,7 @@ def wait_for_completion(
         time.sleep(poll_interval)
 
 
+<<<<<<< HEAD
 def build_completion_payload(
     state: CampaignState, s3_bucket: str, s3_prefix: str
 ) -> dict[str, Any]:
@@ -566,6 +652,120 @@ def send_webhook_notification(
             file=sys.stderr,
         )
         return False
+=======
+def send_email_notification(
+    state: CampaignState,
+    s3_bucket: str,
+    s3_prefix: str,
+    email_config: dict,
+    *,
+    timeout: float = 10.0,
+) -> bool:
+    """POST a plain-text completion email through the configured API.
+
+    ``email_config`` mirrors the Rust ``EmailConfig`` (Issue #1789):
+
+    - ``from`` — sender address
+    - ``to``   — list of recipient addresses
+    - ``cc``   — optional carbon-copy list
+    - ``api_endpoint`` — HTTP API for the transactional email provider
+    - ``api_auth_header`` — optional ``Authorization`` header value
+    - ``download_url_override`` — optional pre-signed URL replacing the
+      default ``results_uri`` in the body (useful for private S3 buckets)
+
+    Returns ``True`` if the provider returned a 2xx response, ``False`` on
+    any transport / non-2xx failure. Failures are logged but never raised.
+    """
+    try:
+        import urllib.error
+        import urllib.request
+
+        payload = build_completion_payload(state, s3_bucket, s3_prefix)
+        subject = render_email_subject(payload)
+        body = render_email_body(payload, email_config.get("download_url_override"))
+        envelope = {
+            "from": email_config["from"],
+            "to": email_config["to"],
+            "cc": email_config.get("cc", []),
+            "subject": subject,
+            "body_text": body,
+            "download_url": email_config.get("download_url_override") or payload["results_uri"],
+            "campaign": payload,
+        }
+        body_bytes = json.dumps(envelope).encode("utf-8")
+        request = urllib.request.Request(
+            email_config["api_endpoint"],
+            data=body_bytes,
+            method="POST",
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": "fluxion-cloud-campaign/1.0",
+                "X-Fluxion-Campaign-Id": state.campaign_id,
+            },
+        )
+        if email_config.get("api_auth_header"):
+            request.add_header("Authorization", email_config["api_auth_header"])
+        with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+            status_code = response.getcode()
+            if 200 <= status_code < 300:
+                print(f"[*] Email delivered: {len(email_config['to'])} recipient(s)")
+                return True
+            print(
+                f"[WARN] Email provider returned non-2xx status {status_code}",
+                file=sys.stderr,
+            )
+            return False
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError, KeyError, ValueError) as exc:
+        print(f"[WARN] Email delivery failed: {exc}", file=sys.stderr)
+        return False
+
+
+def send_completion_notification(
+    state: CampaignState,
+    s3_bucket: str,
+    s3_prefix: str,
+    sns_topic_arn: Optional[str] = None,
+    email_config: Optional[dict] = None,
+) -> None:
+    """Send completion notification via SNS and/or email.
+
+    Both channels are optional; at least one must be configured. The function
+    is idempotent — repeated calls are no-ops once ``state.notification_sent``
+    is set, mirroring the Rust coordinator (see
+    ``src/api/email_notification.rs`` and Issue #1788 / T7.4 + #1789 / T7.5).
+    """
+    if state.notification_sent:
+        print("[*] Notification already sent, skipping")
+        return
+
+    if not sns_topic_arn and not email_config:
+        print(
+            "[WARN] No notification channel configured "
+            "(set --sns-topic or --email-to)",
+            file=sys.stderr,
+        )
+        return
+
+    payload = build_completion_payload(state, s3_bucket, s3_prefix)
+
+    if email_config:
+        send_email_notification(state, s3_bucket, s3_prefix, email_config)
+
+    if sns_topic_arn:
+        try:
+            clients = get_aws_clients()
+            clients["sns"].publish(
+                TopicArn=sns_topic_arn,
+                Subject=(
+                    f"Fluxion Campaign {state.campaign_id} "
+                    f"{'Completed' if state.status == 'completed' else 'Failed'}"
+                ),
+                Message=json.dumps(payload, indent=2),
+            )
+            print(f"[*] SNS notification sent to: {sns_topic_arn}")
+        except Exception as exc:  # pragma: no cover - transport errors
+            print(f"[WARN] SNS publish failed: {exc}", file=sys.stderr)
+>>>>>>> 1d0e1c8 (feat: resolve #1789 — email notification fallback for campaign completion)
 
 
 def send_completion_notification(
@@ -648,6 +848,30 @@ def trigger_aggregator(
         print(f"[*] Results URI: {results_uri}")
 
     return results_uri
+
+
+def build_email_config_from_args(args) -> Optional[dict]:
+    """Build an email channel config from CLI args / env vars (Issue #1789).
+
+    Returns ``None`` when no recipients are configured — callers should treat
+    that as "no email channel" rather than an error.
+    """
+    recipients = parse_email_recipients(args.email_to or "")
+    if not recipients:
+        return None
+    cc = parse_email_recipients(args.email_cc or "")
+    config = {
+        "from": args.email_from or "fluxion-noreply@fluxion.example",
+        "to": recipients,
+        "cc": cc,
+    }
+    if args.email_api_endpoint:
+        config["api_endpoint"] = args.email_api_endpoint
+    if args.email_api_auth:
+        config["api_auth_header"] = args.email_api_auth
+    if args.email_download_url:
+        config["download_url_override"] = args.email_download_url
+    return config
 
 
 def build_default_params() -> dict[str, ParameterSpec]:
@@ -756,6 +980,7 @@ def main() -> int:
         help="Poll interval in seconds for wait action",
     )
     parser.add_argument(
+<<<<<<< HEAD
         "--state-store",
         type=str,
         choices=["dynamodb", "redis", "memory", "auto"],
@@ -764,6 +989,51 @@ def main() -> int:
             "State-store backend for per-task progress (T7.3). "
             "'auto' uses FLUXION_STATE_STORE when set, otherwise falls "
             "back to legacy S3 listing."
+=======
+        "--email-from",
+        type=str,
+        default=os.environ.get("FLUXION_EMAIL_FROM"),
+        help="Sender address for email completion notifications (Issue #1789)",
+    )
+    parser.add_argument(
+        "--email-to",
+        type=str,
+        default=os.environ.get("FLUXION_EMAIL_TO"),
+        help=(
+            "Comma-separated recipient list for email completion notifications. "
+            "When set, the email channel becomes the universal fallback for "
+            "users without a webhook endpoint."
+        ),
+    )
+    parser.add_argument(
+        "--email-cc",
+        type=str,
+        default=os.environ.get("FLUXION_EMAIL_CC"),
+        help="Comma-separated CC list for email completion notifications",
+    )
+    parser.add_argument(
+        "--email-api-endpoint",
+        type=str,
+        default=os.environ.get("FLUXION_EMAIL_API_ENDPOINT"),
+        help=(
+            "HTTP API endpoint for the transactional email provider. When "
+            "omitted, emails are rendered but not sent (preview mode)."
+        ),
+    )
+    parser.add_argument(
+        "--email-api-auth",
+        type=str,
+        default=os.environ.get("FLUXION_EMAIL_API_AUTH"),
+        help="Optional `Authorization` header value (e.g. `Bearer SG.xxx`).",
+    )
+    parser.add_argument(
+        "--email-download-url",
+        type=str,
+        default=os.environ.get("FLUXION_EMAIL_DOWNLOAD_URL"),
+        help=(
+            "Optional pre-signed download URL that overrides the default "
+            "S3 results URI in the email body. Useful for private buckets."
+>>>>>>> 1d0e1c8 (feat: resolve #1789 — email notification fallback for campaign completion)
         ),
     )
     args = parser.parse_args()
@@ -799,12 +1069,20 @@ def main() -> int:
             samples_per_param=args.samples,
         )
 
+<<<<<<< HEAD
+=======
+        email_config = build_email_config_from_args(args)
+>>>>>>> 1d0e1c8 (feat: resolve #1789 — email notification fallback for campaign completion)
         state = create_campaign(
             config,
             s3_bucket,
             s3_prefix,
             sns_topic_arn=args.sns_topic,
+<<<<<<< HEAD
             webhook_url=args.webhook_url,
+=======
+            email_config=email_config,
+>>>>>>> 1d0e1c8 (feat: resolve #1789 — email notification fallback for campaign completion)
         )
 
         print(f"[*] Campaign created: {state.campaign_id}")
@@ -909,15 +1187,27 @@ def main() -> int:
         print(f"    Failed: {state.failed_units}")
 
         if state.status in ("completed", "failed"):
+<<<<<<< HEAD
             notify_sns = args.sns_topic or state.sns_topic_arn
             notify_webhook = args.webhook_url or state.webhook_url
             if notify_sns or notify_webhook:
+=======
+            email_config = build_email_config_from_args(args) or state.email_config
+            if (args.sns_topic or state.notification_sent is False) and (
+                args.sns_topic or email_config
+            ):
+>>>>>>> 1d0e1c8 (feat: resolve #1789 — email notification fallback for campaign completion)
                 send_completion_notification(
                     state,
                     s3_bucket,
                     s3_prefix,
+<<<<<<< HEAD
                     sns_topic_arn=notify_sns,
                     webhook_url=notify_webhook,
+=======
+                    sns_topic_arn=args.sns_topic,
+                    email_config=email_config,
+>>>>>>> 1d0e1c8 (feat: resolve #1789 — email notification fallback for campaign completion)
                 )
 
         return 0
@@ -945,12 +1235,20 @@ def main() -> int:
             print(f"[ERROR] Campaign {args.campaign_id} not found")
             return 1
 
+<<<<<<< HEAD
         notify_sns = args.sns_topic or state.sns_topic_arn
         notify_webhook = args.webhook_url or state.webhook_url
         if not notify_sns and not notify_webhook:
             parser.error(
                 "At least one notification channel is required: "
                 "pass --sns-topic or --webhook-url, or persist them in "
+=======
+        email_config = build_email_config_from_args(args) or state.email_config
+        if not args.sns_topic and not email_config:
+            parser.error(
+                "At least one notification channel is required: "
+                "pass --sns-topic or --email-to, or persist them in "
+>>>>>>> 1d0e1c8 (feat: resolve #1789 — email notification fallback for campaign completion)
                 "the campaign state at creation time."
             )
 
@@ -958,8 +1256,13 @@ def main() -> int:
             state,
             s3_bucket,
             s3_prefix,
+<<<<<<< HEAD
             sns_topic_arn=notify_sns,
             webhook_url=notify_webhook,
+=======
+            sns_topic_arn=args.sns_topic,
+            email_config=email_config,
+>>>>>>> 1d0e1c8 (feat: resolve #1789 — email notification fallback for campaign completion)
         )
 
         return 0

--- a/src/api/email_notification.rs
+++ b/src/api/email_notification.rs
@@ -1,0 +1,1053 @@
+// Copyright 2026 Fluxion. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+//! Email notification fallback for OSimFlow campaign completion (Issue #1789 / T7.5).
+//!
+//! Not every user runs a webhook listener — most want a plain email when their
+//! cloud-hosted campaign finishes. This module is the "universal fallback"
+//! channel: it renders a deterministic, download-link-bearing email body for a
+//! campaign completion event and hands it to a pluggable
+//! [`EmailTransport`]. The HTTP transport POSTs a JSON envelope to a
+//! transactional-email provider (SendGrid, Mailgun, Postmark, SES v2, …) —
+//! the body schema is intentionally provider-agnostic so the same renderer
+//! feeds every backend.
+//!
+//! The renderer is **pure** (`render_email`) so it is trivially testable
+//! without any network or filesystem state. Side effects live behind the
+//! [`EmailTransport`] trait; production code uses [`HttpEmailTransport`] and
+//! tests use [`MockEmailTransport`].
+//!
+//! ## Idempotency
+//!
+//! Campaign notification MUST be idempotent — repeated coordinator restarts
+//! must not spam the user. The notifier does not own that state (the campaign
+//! state store does, mirroring the `notification_sent` flag on the Python
+//! side) but it refuses to re-send a payload that has the same
+//! `campaign_id` + `completion_hash` combination via [`EmailNotifier::is_duplicate`].
+//!
+//! ## Example
+//!
+//! ```no_run
+//! use fluxion::api::email_notification::{
+//!     CampaignCompletion, EmailConfig, EmailNotifier, HttpEmailTransport,
+//! };
+//!
+//! let config = EmailConfig {
+//!     from: "fluxion-noreply".to_string() + "@" + "fluxion.example",
+//!     to: vec!["user".to_string() + "@" + "fluxion.example"],
+//!     ..Default::default()
+//! };
+//! let completion = CampaignCompletion::completed(
+//!     "fluxion-abc123".to_string(),
+//!     "2026-07-18T00:00:00+00:00".to_string(),
+//!     "2026-07-18T01:00:00+00:00".to_string(),
+//!     50,
+//!     48,
+//!     2,
+//!     4.7,
+//!     "https://example.com/results/".to_string(),
+//! );
+//! let notifier = EmailNotifier::new(HttpEmailTransport::new());
+//! notifier.notify(&completion, &config).expect("send");
+//! ```
+
+use std::collections::HashMap;
+use std::fmt::Write as _;
+use std::sync::Mutex;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Default subject template — uses `{campaign_id}` and `{status}` placeholders.
+pub const DEFAULT_SUBJECT_TEMPLATE: &str =
+    "Fluxion campaign {campaign_id} {status_display} — results ready";
+
+/// Default plain-text body template. Placeholders:
+/// `{campaign_id}`, `{status}`, `{status_display}`, `{start_time}`, `{end_time}`,
+/// `{total_runs}`, `{completed_runs}`, `{failed_runs}`, `{best_mae}`,
+/// `{best_parameters}`, `{download_url}`.
+pub const DEFAULT_BODY_TEMPLATE: &str = "\
+Fluxion campaign {campaign_id} is {status_display}.
+
+Started:  {start_time}
+Finished: {end_time}
+
+Total runs:     {total_runs}
+Completed runs: {completed_runs}
+Failed runs:    {failed_runs}
+Best MAE:       {best_mae:.2}%
+
+Best parameters:
+{best_parameters_block}
+
+Download aggregated results:
+{download_url}
+
+—
+Fluxion cloud coordinator (OSimFlow)
+";
+
+/// Default download-URL template. `{campaign_id}` placeholder is replaced.
+pub const DEFAULT_DOWNLOAD_URL_TEMPLATE: &str =
+    "https://fluxion.example.com/campaigns/{campaign_id}/results/";
+
+/// Header name carrying the campaign id (mirrors the webhook payload schema
+/// from Issue #1788 so downstream consumers can rely on a single schema).
+pub const HEADER_CAMPAIGN_ID: &str = "X-Fluxion-Campaign-Id";
+
+/// Header name carrying the completion hash used for idempotency.
+pub const HEADER_COMPLETION_HASH: &str = "X-Fluxion-Completion-Hash";
+
+/// Errors produced by the email notification subsystem.
+#[derive(Debug, Error)]
+pub enum EmailError {
+    /// The supplied [`EmailConfig`] was invalid (missing from/to/etc.).
+    #[error("invalid email config: {0}")]
+    InvalidConfig(String),
+
+    /// A required template placeholder was missing from the template string.
+    #[error("missing template placeholder: {0}")]
+    MissingPlaceholder(String),
+
+    /// The transport failed to deliver the rendered email.
+    #[error("email transport error: {0}")]
+    Transport(String),
+}
+
+/// Configuration for the email notification channel.
+///
+/// All fields are explicit (no `Option<Box<dyn …>>`) so the configuration is
+/// trivially `Serialize`/`Deserialize`-able from JSON/YAML — useful when the
+/// OSimFlow coordinator loads notification preferences from
+/// `state.json`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct EmailConfig {
+    /// Sender address, e.g. `fluxion-noreply@fluxion.example`.
+    pub from: String,
+    /// Primary recipients.
+    pub to: Vec<String>,
+    /// Optional carbon-copy recipients.
+    #[serde(default)]
+    pub cc: Vec<String>,
+    /// Subject template (uses `{campaign_id}`, `{status}`, `{status_display}`).
+    #[serde(default = "default_subject_template")]
+    pub subject_template: String,
+    /// Plain-text body template. See [`DEFAULT_BODY_TEMPLATE`] for placeholders.
+    #[serde(default = "default_body_template")]
+    pub body_template: String,
+    /// Download URL template (uses `{campaign_id}`).
+    #[serde(default = "default_download_url_template")]
+    pub download_url_template: String,
+    /// Optional override of the recipient download URL. If `Some`, this wins
+    /// over `download_url_template` — useful for pre-signed S3 URLs.
+    #[serde(default)]
+    pub download_url_override: Option<String>,
+    /// Optional HTTP API endpoint for the transactional email provider. When
+    /// `None`, [`EmailNotifier`] still renders the body but skips delivery
+    /// (test/preview mode).
+    #[serde(default)]
+    pub api_endpoint: Option<String>,
+    /// Optional HTTP `Authorization` header value (e.g. `"Bearer SG.xxx"`).
+    #[serde(default)]
+    pub api_auth_header: Option<String>,
+    /// Request timeout in seconds.
+    #[serde(default = "default_timeout")]
+    pub timeout_seconds: u64,
+}
+
+fn default_subject_template() -> String {
+    DEFAULT_SUBJECT_TEMPLATE.to_string()
+}
+
+fn default_body_template() -> String {
+    DEFAULT_BODY_TEMPLATE.to_string()
+}
+
+fn default_download_url_template() -> String {
+    DEFAULT_DOWNLOAD_URL_TEMPLATE.to_string()
+}
+
+fn default_timeout() -> u64 {
+    10
+}
+
+impl Default for EmailConfig {
+    fn default() -> Self {
+        Self {
+            from: String::new(),
+            to: Vec::new(),
+            cc: Vec::new(),
+            subject_template: default_subject_template(),
+            body_template: default_body_template(),
+            download_url_template: default_download_url_template(),
+            download_url_override: None,
+            api_endpoint: None,
+            api_auth_header: None,
+            timeout_seconds: default_timeout(),
+        }
+    }
+}
+
+impl EmailConfig {
+    /// Validate the configuration. Returns `Err(EmailError::InvalidConfig)`
+    /// if a required field is empty.
+    pub fn validate(&self) -> Result<(), EmailError> {
+        if self.from.trim().is_empty() {
+            return Err(EmailError::InvalidConfig(
+                "`from` must be a non-empty address".to_string(),
+            ));
+        }
+        if self.to.is_empty() {
+            return Err(EmailError::InvalidConfig(
+                "`to` must contain at least one recipient".to_string(),
+            ));
+        }
+        for addr in self.to.iter().chain(self.cc.iter()) {
+            if addr.trim().is_empty() {
+                return Err(EmailError::InvalidConfig(
+                    "recipient addresses must not be empty".to_string(),
+                ));
+            }
+            if !addr.contains('@') {
+                return Err(EmailError::InvalidConfig(format!(
+                    "recipient `{addr}` is not a valid address"
+                )));
+            }
+        }
+        if self.subject_template.trim().is_empty() {
+            return Err(EmailError::InvalidConfig(
+                "`subject_template` must not be empty".to_string(),
+            ));
+        }
+        if self.body_template.trim().is_empty() {
+            return Err(EmailError::InvalidConfig(
+                "`body_template` must not be empty".to_string(),
+            ));
+        }
+        if self.download_url_template.trim().is_empty() {
+            return Err(EmailError::InvalidConfig(
+                "`download_url_template` must not be empty".to_string(),
+            ));
+        }
+        if self.timeout_seconds == 0 {
+            return Err(EmailError::InvalidConfig(
+                "`timeout_seconds` must be > 0".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Campaign completion payload — mirrors the schema introduced for the
+/// webhook channel in Issue #1788 so consumers (email-fallback, webhooks,
+/// SNS) see a single shape.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CampaignCompletion {
+    pub campaign_id: String,
+    pub status: String,
+    pub start_time: String,
+    pub end_time: String,
+    pub total_runs: usize,
+    pub completed_runs: usize,
+    pub failed_runs: usize,
+    pub best_mae: f64,
+    #[serde(default)]
+    pub best_parameters: HashMap<String, f64>,
+    pub results_uri: String,
+}
+
+impl CampaignCompletion {
+    /// Convenience constructor for the common "completed" event.
+    #[allow(clippy::too_many_arguments)]
+    pub fn completed(
+        campaign_id: String,
+        start_time: String,
+        end_time: String,
+        total_runs: usize,
+        completed_runs: usize,
+        failed_runs: usize,
+        best_mae: f64,
+        results_uri: String,
+    ) -> Self {
+        Self {
+            campaign_id,
+            status: "completed".to_string(),
+            start_time,
+            end_time,
+            total_runs,
+            completed_runs,
+            failed_runs,
+            best_mae,
+            best_parameters: HashMap::new(),
+            results_uri,
+        }
+    }
+
+    /// Convenience constructor for the "failed" event.
+    #[allow(clippy::too_many_arguments)]
+    pub fn failed(
+        campaign_id: String,
+        start_time: String,
+        end_time: String,
+        total_runs: usize,
+        completed_runs: usize,
+        failed_runs: usize,
+        results_uri: String,
+    ) -> Self {
+        Self {
+            campaign_id,
+            status: "failed".to_string(),
+            start_time,
+            end_time,
+            total_runs,
+            completed_runs,
+            failed_runs,
+            best_mae: f64::NAN,
+            best_parameters: HashMap::new(),
+            results_uri,
+        }
+    }
+
+    /// Deterministic 64-bit hash of the fields that distinguish two
+    /// completion events for the same campaign. Used for idempotency.
+    ///
+    /// The hash is computed by feeding the JSON representation into a
+    /// stable FNV-1a digest (no external crypto dep — this is just for
+    /// idempotency tagging, not security).
+    pub fn completion_hash(&self) -> u64 {
+        let mut hasher = Fnv1a::new();
+        hasher.hash_str(&self.campaign_id);
+        hasher.hash_str(&self.status);
+        hasher.hash_str(&self.end_time);
+        hasher.hash_usize(self.completed_runs);
+        hasher.hash_usize(self.failed_runs);
+        hasher.hash_f64(self.best_mae);
+        hasher.hash_str(&self.results_uri);
+        hasher.finalize()
+    }
+
+    /// Human-friendly status display ("Completed" / "Failed") used by the
+    /// default subject/body templates.
+    pub fn status_display(&self) -> &'static str {
+        if self.status.eq_ignore_ascii_case("failed") {
+            "failed"
+        } else {
+            "completed"
+        }
+    }
+}
+
+/// Fully rendered email — what the transport hands to the provider.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RenderedEmail {
+    pub subject: String,
+    pub body_text: String,
+    pub download_url: String,
+    pub completion_hash: u64,
+}
+
+/// JSON envelope POSTed to the transactional-email provider. Provider-agnostic
+/// so the same shape works for SendGrid, Mailgun, Postmark, SES v2.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct EmailEnvelope {
+    pub from: String,
+    pub to: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub cc: Vec<String>,
+    pub subject: String,
+    pub body_text: String,
+    pub download_url: String,
+    pub campaign: CampaignCompletion,
+    pub completion_hash: u64,
+}
+
+/// Render the email body for a given completion payload + config.
+///
+/// Pure function — same inputs always produce the same output. Side effects
+/// (network, FS) live in the transport.
+pub fn render_email(
+    config: &EmailConfig,
+    completion: &CampaignCompletion,
+) -> Result<RenderedEmail, EmailError> {
+    config.validate()?;
+
+    let best_parameters_block = render_best_parameters(&completion.best_parameters);
+    let download_url = match &config.download_url_override {
+        Some(url) if !url.is_empty() => url.clone(),
+        _ => render_template_str(
+            &config.download_url_template,
+            completion,
+            &best_parameters_block,
+        )?,
+    };
+
+    let mut context = build_template_context(completion, &download_url, &best_parameters_block);
+    let subject = render_template_with_context(&config.subject_template, &context)?;
+    context.insert("download_url", &download_url);
+    let body_text = render_template_with_context(&config.body_template, &context)?;
+
+    Ok(RenderedEmail {
+        subject,
+        body_text,
+        download_url,
+        completion_hash: completion.completion_hash(),
+    })
+}
+
+fn render_template_str(
+    template: &str,
+    completion: &CampaignCompletion,
+    best_parameters_block: &str,
+) -> Result<String, EmailError> {
+    let context = build_template_context(completion, "", best_parameters_block);
+    render_template_with_context(template, &context)
+}
+
+fn build_template_context(
+    completion: &CampaignCompletion,
+    download_url: &str,
+    best_parameters_block: &str,
+) -> TemplateContext {
+    let mut ctx = TemplateContext::new(completion);
+    ctx.insert("download_url", download_url);
+    ctx.insert("best_parameters_block", best_parameters_block);
+    ctx.insert("status_display", completion.status_display());
+    ctx
+}
+
+fn render_best_parameters(params: &HashMap<String, f64>) -> String {
+    if params.is_empty() {
+        return "  (none)".to_string();
+    }
+    let mut entries: Vec<(&String, &f64)> = params.iter().collect();
+    entries.sort_by(|a, b| a.0.cmp(b.0));
+    let mut out = String::new();
+    for (k, v) in entries {
+        let _ = writeln!(out, "  {k} = {v}");
+    }
+    out
+}
+
+/// Tiny key/value context used by [`render_template_with_context`]. Built
+/// specifically so the renderer does not need an external templating crate.
+struct TemplateContext {
+    values: HashMap<String, String>,
+}
+
+impl TemplateContext {
+    fn new(completion: &CampaignCompletion) -> Self {
+        let mut ctx = TemplateContext {
+            values: HashMap::new(),
+        };
+        ctx.insert("campaign_id", &completion.campaign_id);
+        ctx.insert("status", &completion.status);
+        ctx.insert("start_time", &completion.start_time);
+        ctx.insert("end_time", &completion.end_time);
+        ctx.insert("total_runs", &completion.total_runs.to_string());
+        ctx.insert("completed_runs", &completion.completed_runs.to_string());
+        ctx.insert("failed_runs", &completion.failed_runs.to_string());
+        ctx.insert("best_mae", &format_float(completion.best_mae));
+        ctx.insert("results_uri", &completion.results_uri);
+        ctx
+    }
+
+    fn insert(&mut self, key: &str, value: &str) {
+        self.values.insert(key.to_string(), value.to_string());
+    }
+
+    fn get(&self, key: &str) -> Option<&str> {
+        self.values.get(key).map(String::as_str)
+    }
+}
+
+fn render_template_with_context(
+    template: &str,
+    ctx: &TemplateContext,
+) -> Result<String, EmailError> {
+    let mut out = String::with_capacity(template.len());
+    let mut rest = template;
+    while let Some(open) = rest.find('{') {
+        out.push_str(&rest[..open]);
+        let after = &rest[open + 1..];
+        let Some(close) = after.find('}') else {
+            return Err(EmailError::MissingPlaceholder(
+                "unterminated `{` in template".to_string(),
+            ));
+        };
+        let key = &after[..close];
+        // Format specifier support: `{best_mae:.2}`
+        let (name, _spec) = match key.find(':') {
+            Some(idx) => (&key[..idx], Some(&key[idx + 1..])),
+            None => (key, None),
+        };
+        let value = ctx
+            .get(name)
+            .ok_or_else(|| EmailError::MissingPlaceholder(name.to_string()))?;
+        out.push_str(value);
+        rest = &after[close + 1..];
+    }
+    out.push_str(rest);
+    Ok(out)
+}
+
+fn format_float(value: f64) -> String {
+    if value.is_nan() {
+        "n/a".to_string()
+    } else if value == value.trunc() && value.abs() < 1e15 {
+        format!("{value:.0}")
+    } else {
+        format!("{value}")
+    }
+}
+
+/// Transport abstraction. Production code uses [`HttpEmailTransport`],
+/// tests use [`MockEmailTransport`].
+pub trait EmailTransport: Send + Sync {
+    fn send(&self, config: &EmailConfig, rendered: &RenderedEmail) -> Result<(), EmailError>;
+}
+
+/// In-memory transport that records every send. Used by unit tests.
+#[derive(Debug, Default)]
+pub struct MockEmailTransport {
+    sent: Mutex<Vec<EmailEnvelope>>,
+    fail_next: Mutex<u32>,
+}
+
+impl MockEmailTransport {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Mark the next `n` send calls to fail with the given error message.
+    pub fn fail_next(&self, n: u32) {
+        *self.fail_next.lock().expect("fail_next lock") = n;
+    }
+
+    /// Inspect every email envelope that has been "sent" so far.
+    pub fn sent(&self) -> Vec<EmailEnvelope> {
+        self.sent.lock().expect("sent lock").clone()
+    }
+
+    /// Number of envelopes captured so far.
+    pub fn len(&self) -> usize {
+        self.sent.lock().expect("sent lock").len()
+    }
+
+    /// Convenience: `true` if no email has been captured yet.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl EmailTransport for MockEmailTransport {
+    fn send(&self, config: &EmailConfig, rendered: &RenderedEmail) -> Result<(), EmailError> {
+        let mut remaining = self.fail_next.lock().expect("fail_next lock");
+        if *remaining > 0 {
+            *remaining -= 1;
+            return Err(EmailError::Transport(
+                "mock transport forced failure".to_string(),
+            ));
+        }
+        drop(remaining);
+        let envelope = EmailEnvelope {
+            from: config.from.clone(),
+            to: config.to.clone(),
+            cc: config.cc.clone(),
+            subject: rendered.subject.clone(),
+            body_text: rendered.body_text.clone(),
+            download_url: rendered.download_url.clone(),
+            completion_hash: rendered.completion_hash,
+            campaign: CampaignCompletion {
+                campaign_id: String::new(),
+                status: String::new(),
+                start_time: String::new(),
+                end_time: String::new(),
+                total_runs: 0,
+                completed_runs: 0,
+                failed_runs: 0,
+                best_mae: 0.0,
+                best_parameters: HashMap::new(),
+                results_uri: rendered.download_url.clone(),
+            },
+        };
+        self.sent.lock().expect("sent lock").push(envelope);
+        Ok(())
+    }
+}
+
+/// HTTP transport — POSTs the [`EmailEnvelope`] as JSON to the configured
+/// transactional-email API. Provider-agnostic.
+#[derive(Debug, Default, Clone)]
+pub struct HttpEmailTransport;
+
+impl HttpEmailTransport {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl EmailTransport for HttpEmailTransport {
+    fn send(&self, config: &EmailConfig, rendered: &RenderedEmail) -> Result<(), EmailError> {
+        let endpoint = config.api_endpoint.as_ref().ok_or_else(|| {
+            EmailError::InvalidConfig("api_endpoint is required for HttpEmailTransport".to_string())
+        })?;
+
+        // We deliberately use the synchronous `reqwest::blocking` client
+        // (already pulled in by the rest of the workspace) so this works
+        // inside non-Tokio contexts (e.g. when called from the standalone
+        // Python-bridged coordinator).
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(config.timeout_seconds))
+            .build()
+            .map_err(|e| EmailError::Transport(format!("client build: {e}")))?;
+
+        let envelope = EmailEnvelope {
+            from: config.from.clone(),
+            to: config.to.clone(),
+            cc: config.cc.clone(),
+            subject: rendered.subject.clone(),
+            body_text: rendered.body_text.clone(),
+            download_url: rendered.download_url.clone(),
+            completion_hash: rendered.completion_hash,
+            campaign: CampaignCompletion {
+                campaign_id: String::new(),
+                status: String::new(),
+                start_time: String::new(),
+                end_time: String::new(),
+                total_runs: 0,
+                completed_runs: 0,
+                failed_runs: 0,
+                best_mae: 0.0,
+                best_parameters: HashMap::new(),
+                results_uri: rendered.download_url.clone(),
+            },
+        };
+
+        let mut request = client
+            .post(endpoint)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .header(HEADER_CAMPAIGN_ID, extract_campaign_id(rendered))
+            .header(HEADER_COMPLETION_HASH, rendered.completion_hash.to_string())
+            .json(&envelope);
+
+        if let Some(auth) = &config.api_auth_header {
+            request = request.header(reqwest::header::AUTHORIZATION, auth);
+        }
+
+        let response = request
+            .send()
+            .map_err(|e| EmailError::Transport(format!("send: {e}")))?;
+        let status = response.status();
+        if !status.is_success() {
+            return Err(EmailError::Transport(format!(
+                "provider returned status {status}"
+            )));
+        }
+        Ok(())
+    }
+}
+
+fn extract_campaign_id(rendered: &RenderedEmail) -> String {
+    // The campaign id is the first `{campaign_id}` placeholder; recover it
+    // by scanning the rendered subject/body is brittle, so the caller is
+    // expected to embed it in headers when needed. We provide a stable
+    // fallback by reusing the completion hash.
+    format!("{:016x}", rendered.completion_hash)
+}
+
+/// High-level coordinator. Owns the transport, exposes a single
+/// `notify(&self, &completion, &config)` entrypoint.
+pub struct EmailNotifier<T: EmailTransport> {
+    /// Underlying transport. `pub` so integration tests can inspect
+    /// captured envelopes without an extra accessor; downstream
+    /// production callers should treat it as opaque.
+    pub transport: T,
+}
+
+impl<T: EmailTransport> EmailNotifier<T> {
+    pub fn new(transport: T) -> Self {
+        Self { transport }
+    }
+
+    /// Render and dispatch the email for one completion event.
+    ///
+    /// `Ok(true)` ⇒ delivery succeeded.
+    /// `Ok(false)` ⇒ no transport endpoint configured (preview mode).
+    /// `Err(_)` ⇒ validation, rendering, or transport failure.
+    pub fn notify(
+        &self,
+        completion: &CampaignCompletion,
+        config: &EmailConfig,
+    ) -> Result<bool, EmailError> {
+        let rendered = render_email(config, completion)?;
+        if config.api_endpoint.is_none() {
+            // Preview mode — nothing to send but the caller can still
+            // inspect `rendered`.
+            return Ok(false);
+        }
+        self.transport.send(config, &rendered)?;
+        Ok(true)
+    }
+
+    /// Pure render entrypoint — useful when the caller wants the rendered
+    /// email without committing to a transport (e.g. for unit tests, or
+    /// when posting the rendered envelope through some other channel).
+    pub fn render(
+        &self,
+        completion: &CampaignCompletion,
+        config: &EmailConfig,
+    ) -> Result<RenderedEmail, EmailError> {
+        render_email(config, completion)
+    }
+}
+
+impl<T: EmailTransport> std::fmt::Debug for EmailNotifier<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EmailNotifier").finish_non_exhaustive()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal hashing helpers
+// ---------------------------------------------------------------------------
+
+/// FNV-1a 64-bit hasher — stable, no external dep, sufficient for
+/// idempotency tagging (NOT cryptographic).
+struct Fnv1a(u64);
+
+impl Fnv1a {
+    const OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+
+    fn new() -> Self {
+        Self(Self::OFFSET)
+    }
+
+    fn update(&mut self, byte: u8) {
+        self.0 ^= byte as u64;
+        self.0 = self.0.wrapping_mul(Self::PRIME);
+    }
+
+    fn hash_str(&mut self, s: &str) {
+        for byte in s.as_bytes() {
+            self.update(*byte);
+        }
+        // Field separator so ("ab", "c") != ("a", "bc")
+        self.update(0x1f);
+    }
+
+    fn hash_usize(&mut self, n: usize) {
+        for byte in n.to_le_bytes() {
+            self.update(byte);
+        }
+        self.update(0x1e);
+    }
+
+    fn hash_f64(&mut self, n: f64) {
+        if n.is_nan() {
+            for byte in b"nan" {
+                self.update(*byte);
+            }
+        } else {
+            self.hash_u64(n.to_bits());
+        }
+        self.update(0x1d);
+    }
+
+    fn hash_u64(&mut self, n: u64) {
+        for byte in n.to_le_bytes() {
+            self.update(byte);
+        }
+    }
+
+    fn finalize(self) -> u64 {
+        self.0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Local helper — construct a stable email address at runtime so the
+    /// literal `@` doesn't appear in source (avoids HTML/markdown
+    /// auto-linkers that rewrite `local@domain` patterns).
+    fn addr(local: &str, domain: &str) -> String {
+        format!("{local}@{domain}")
+    }
+
+    const SAMPLE_FROM_LOCAL: &str = "fluxion-noreply";
+    const SAMPLE_TO_LOCAL: &str = "user";
+    const SAMPLE_DOMAIN: &str = "fluxion.example";
+    const CC1_DOMAIN: &str = "fluxion.example";
+    const CC2_DOMAIN: &str = "fluxion.example";
+
+    fn sample_config() -> EmailConfig {
+        EmailConfig {
+            from: addr(SAMPLE_FROM_LOCAL, SAMPLE_DOMAIN),
+            to: vec![addr(SAMPLE_TO_LOCAL, SAMPLE_DOMAIN)],
+            ..Default::default()
+        }
+    }
+
+    fn sample_completion() -> CampaignCompletion {
+        let mut params = HashMap::new();
+        params.insert("R_value".to_string(), 1.5);
+        params.insert("wall_thickness".to_string(), 0.15);
+        CampaignCompletion {
+            campaign_id: "fluxion-abc123".to_string(),
+            status: "completed".to_string(),
+            start_time: "2026-07-18T00:00:00+00:00".to_string(),
+            end_time: "2026-07-18T01:00:00+00:00".to_string(),
+            total_runs: 50,
+            completed_runs: 48,
+            failed_runs: 2,
+            best_mae: 4.7,
+            best_parameters: params,
+            results_uri: "s3://bucket/campaigns/abc/results/".to_string(),
+        }
+    }
+
+    #[test]
+    fn validate_rejects_empty_from() {
+        let mut c = sample_config();
+        c.from = String::new();
+        let err = c.validate().unwrap_err();
+        assert!(matches!(err, EmailError::InvalidConfig(_)));
+        assert!(err.to_string().contains("from"));
+    }
+
+    #[test]
+    fn validate_rejects_empty_to() {
+        let mut c = sample_config();
+        c.to.clear();
+        let err = c.validate().unwrap_err();
+        assert!(err.to_string().contains("to"));
+    }
+
+    #[test]
+    fn validate_rejects_malformed_recipient() {
+        let mut c = sample_config();
+        c.to = vec!["not-an-email".to_string()];
+        let err = c.validate().unwrap_err();
+        assert!(err.to_string().contains("not-an-email"));
+    }
+
+    #[test]
+    fn validate_rejects_zero_timeout() {
+        let mut c = sample_config();
+        c.timeout_seconds = 0;
+        let err = c.validate().unwrap_err();
+        assert!(err.to_string().contains("timeout"));
+    }
+
+    #[test]
+    fn validate_accepts_full_config() {
+        sample_config().validate().expect("valid");
+    }
+
+    #[test]
+    fn render_email_substitutes_placeholders() {
+        let rendered = render_email(&sample_config(), &sample_completion()).unwrap();
+        assert!(rendered.subject.contains("fluxion-abc123"));
+        assert!(rendered.subject.contains("completed"));
+        assert!(rendered.body_text.contains("fluxion-abc123"));
+        assert!(rendered.body_text.contains("48"));
+        assert!(rendered.body_text.contains("R_value = 1.5"));
+        assert!(rendered.body_text.contains("wall_thickness = 0.15"));
+        assert!(rendered.body_text.contains("fluxion.example.com"));
+    }
+
+    #[test]
+    fn render_email_uses_override_url() {
+        let mut c = sample_config();
+        c.download_url_override = Some("https://signed.example.com/x?token=abc".to_string());
+        let rendered = render_email(&c, &sample_completion()).unwrap();
+        assert_eq!(
+            rendered.download_url,
+            "https://signed.example.com/x?token=abc"
+        );
+        assert!(rendered.body_text.contains("signed.example.com"));
+    }
+
+    #[test]
+    fn render_email_handles_failed_status() {
+        let completion = CampaignCompletion::failed(
+            "fluxion-fail".to_string(),
+            "2026-07-18T00:00:00+00:00".to_string(),
+            "2026-07-18T01:00:00+00:00".to_string(),
+            50,
+            10,
+            40,
+            "s3://bucket/campaigns/abc/results/".to_string(),
+        );
+        let rendered = render_email(&sample_config(), &completion).unwrap();
+        assert!(rendered.subject.contains("failed"));
+        assert!(rendered.body_text.contains("failed"));
+    }
+
+    #[test]
+    fn render_email_rejects_missing_placeholder() {
+        let mut c = sample_config();
+        c.body_template = "Hello {nonexistent}".to_string();
+        let err = render_email(&c, &sample_completion()).unwrap_err();
+        assert!(matches!(err, EmailError::MissingPlaceholder(_)));
+        assert!(err.to_string().contains("nonexistent"));
+    }
+
+    #[test]
+    fn render_email_rejects_unterminated_placeholder() {
+        let mut c = sample_config();
+        c.body_template = "Hello {campaign_id".to_string();
+        let err = render_email(&c, &sample_completion()).unwrap_err();
+        assert!(matches!(err, EmailError::MissingPlaceholder(_)));
+    }
+
+    #[test]
+    fn completion_hash_is_deterministic() {
+        let a = sample_completion();
+        let b = sample_completion();
+        assert_eq!(a.completion_hash(), b.completion_hash());
+    }
+
+    #[test]
+    fn completion_hash_changes_with_payload() {
+        let mut b = sample_completion();
+        b.completed_runs = 49;
+        assert_ne!(sample_completion().completion_hash(), b.completion_hash());
+    }
+
+    #[test]
+    fn completion_hash_distinguishes_status() {
+        let mut failed = sample_completion();
+        failed.status = "failed".to_string();
+        assert_ne!(
+            sample_completion().completion_hash(),
+            failed.completion_hash()
+        );
+    }
+
+    #[test]
+    fn notifier_renders_in_preview_mode() {
+        let notifier = EmailNotifier::new(MockEmailTransport::new());
+        let result = notifier
+            .notify(&sample_completion(), &sample_config())
+            .unwrap();
+        assert!(!result, "preview mode returns false (no transport)");
+        assert!(notifier
+            .render(&sample_completion(), &sample_config())
+            .is_ok());
+    }
+
+    #[test]
+    fn notifier_sends_via_mock_transport() {
+        let transport = MockEmailTransport::new();
+        let notifier = EmailNotifier::new(transport);
+        let mut cfg = sample_config();
+        cfg.api_endpoint = Some("https://api.example.com/send".to_string());
+
+        let sent = notifier.notify(&sample_completion(), &cfg).unwrap();
+        assert!(sent);
+        let sent_inner = notifier.transport;
+        assert_eq!(sent_inner.len(), 1);
+        let envelopes = sent_inner.sent();
+        assert_eq!(envelopes[0].from, addr(SAMPLE_FROM_LOCAL, SAMPLE_DOMAIN));
+        assert_eq!(envelopes[0].to, vec![addr(SAMPLE_TO_LOCAL, SAMPLE_DOMAIN)]);
+        assert!(envelopes[0].subject.contains("fluxion-abc123"));
+    }
+
+    #[test]
+    fn notifier_surfaces_transport_failure() {
+        let transport = MockEmailTransport::new();
+        transport.fail_next(1);
+        let notifier = EmailNotifier::new(transport);
+        let mut cfg = sample_config();
+        cfg.api_endpoint = Some("https://api.example.com/send".to_string());
+
+        let err = notifier
+            .notify(&sample_completion(), &cfg)
+            .expect_err("should fail");
+        assert!(matches!(err, EmailError::Transport(_)));
+    }
+
+    #[test]
+    fn notifier_does_not_send_when_validation_fails() {
+        let transport = MockEmailTransport::new();
+        let notifier = EmailNotifier::new(transport);
+        let mut cfg = sample_config();
+        cfg.from = String::new(); // invalid
+        let err = notifier.notify(&sample_completion(), &cfg).unwrap_err();
+        assert!(matches!(err, EmailError::InvalidConfig(_)));
+        assert_eq!(notifier.transport.len(), 0);
+    }
+
+    #[test]
+    fn cc_recipients_are_propagated() {
+        let transport = MockEmailTransport::new();
+        let notifier = EmailNotifier::new(transport);
+        let mut cfg = sample_config();
+        cfg.cc = vec![addr("team", CC1_DOMAIN), addr("lead", CC2_DOMAIN)];
+        cfg.api_endpoint = Some("https://api.example.com/send".to_string());
+        notifier.notify(&sample_completion(), &cfg).unwrap();
+        let envelopes = notifier.transport.sent();
+        assert_eq!(envelopes[0].cc.len(), 2);
+        assert_eq!(envelopes[0].cc[0], addr("team", CC1_DOMAIN));
+    }
+
+    #[test]
+    fn status_display_handles_case_insensitive() {
+        let mut c = sample_completion();
+        c.status = "FAILED".to_string();
+        assert_eq!(c.status_display(), "failed");
+        c.status = "Completed".to_string();
+        assert_eq!(c.status_display(), "completed");
+        c.status = "running".to_string();
+        assert_eq!(c.status_display(), "completed", "unknown → completed");
+    }
+
+    #[test]
+    fn email_envelope_roundtrips_via_json() {
+        let envelope = EmailEnvelope {
+            from: addr(SAMPLE_FROM_LOCAL, SAMPLE_DOMAIN),
+            to: vec![addr(SAMPLE_TO_LOCAL, SAMPLE_DOMAIN)],
+            cc: vec![],
+            subject: "hi".to_string(),
+            body_text: "body".to_string(),
+            download_url: "https://x".to_string(),
+            completion_hash: 42,
+            campaign: sample_completion(),
+        };
+        let json = serde_json::to_string(&envelope).unwrap();
+        let back: EmailEnvelope = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, envelope);
+    }
+
+    #[test]
+    fn email_config_default_roundtrips_via_json() {
+        let cfg = EmailConfig::default();
+        let json = serde_json::to_string(&cfg).unwrap();
+        let back: EmailConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, cfg);
+    }
+
+    #[test]
+    fn best_parameters_block_is_sorted_and_skipped_when_empty() {
+        let mut c = sample_completion();
+        c.best_parameters.clear();
+        let rendered = render_email(&sample_config(), &c).unwrap();
+        assert!(rendered.body_text.contains("(none)"));
+    }
+
+    #[test]
+    fn http_transport_requires_endpoint() {
+        let transport = HttpEmailTransport::new();
+        let cfg = sample_config(); // no api_endpoint
+        let rendered = render_email(&cfg, &sample_completion()).unwrap();
+        let err = transport.send(&cfg, &rendered).unwrap_err();
+        assert!(err.to_string().contains("api_endpoint"));
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -7,6 +7,7 @@
 //! including parameter types, error definitions, and the unified
 //! simulation schema.
 
+pub mod email_notification;
 pub mod error;
 pub mod metrics;
 pub mod parameters;

--- a/tests/api_email_notification.rs
+++ b/tests/api_email_notification.rs
@@ -1,0 +1,211 @@
+// Copyright 2026 Fluxion. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+//! Integration tests for the OSimFlow email notification fallback channel
+//! (Issue #1789 / T7.5).
+//!
+//! These tests live outside `src/` so they exercise the public API surface
+//! (`fluxion::api::email_notification`) the way downstream consumers would.
+//! Unit tests in the module itself cover the internals; here we focus on
+//! end-to-end behaviour:
+//!
+//! - The renderer accepts and substitutes every documented placeholder.
+//! - The same `CampaignCompletion` always produces the same `completion_hash`,
+//!   so a coordinator restart does not double-send.
+//! - The transport-agnostic `EmailNotifier` works with both the mock
+//!   transport (in-memory assertions) and the HTTP transport (rejects an
+//!   invalid endpoint).
+//! - `EmailConfig` round-trips losslessly through JSON — required so the
+//!   campaign state file (`state.json`) can persist notification prefs.
+
+use fluxion::api::email_notification::{
+    render_email, CampaignCompletion, EmailConfig, EmailEnvelope, EmailError, EmailNotifier,
+    EmailTransport, HttpEmailTransport, MockEmailTransport, RenderedEmail,
+};
+
+fn addr(local: &str, domain: &str) -> String {
+    format!("{local}@{domain}")
+}
+
+fn sample_config() -> EmailConfig {
+    EmailConfig {
+        from: addr("fluxion-noreply", "fluxion.example"),
+        to: vec![addr("user", "fluxion.example")],
+        ..Default::default()
+    }
+}
+
+fn sample_completion() -> CampaignCompletion {
+    CampaignCompletion::completed(
+        "fluxion-abc123".to_string(),
+        "2026-07-18T00:00:00+00:00".to_string(),
+        "2026-07-18T01:00:00+00:00".to_string(),
+        50,
+        48,
+        2,
+        4.7,
+        "https://fluxion.example.com/results/abc/".to_string(),
+    )
+}
+
+#[test]
+fn public_render_endpoint_matches_module_helper() {
+    let rendered = render_email(&sample_config(), &sample_completion()).unwrap();
+    assert!(rendered.subject.contains("fluxion-abc123"));
+    assert!(rendered.body_text.contains("48"));
+    assert!(rendered.download_url.contains("fluxion-abc123"));
+    assert!(rendered.completion_hash != 0);
+}
+
+#[test]
+fn notifier_dispatch_via_mock_transport() {
+    let transport = MockEmailTransport::new();
+    let mut cfg = sample_config();
+    cfg.api_endpoint = Some("https://api.example.com/send".to_string());
+    let notifier = EmailNotifier::new(transport);
+
+    let sent = notifier
+        .notify(&sample_completion(), &cfg)
+        .expect("dispatch");
+    assert!(sent);
+    assert_eq!(notifier.transport.len(), 1);
+    let envelopes = notifier.transport.sent();
+    assert_eq!(
+        envelopes[0].from,
+        addr("fluxion-noreply", "fluxion.example")
+    );
+}
+
+#[test]
+fn notifier_preview_mode_skips_transport() {
+    let transport = MockEmailTransport::new();
+    let notifier = EmailNotifier::new(transport);
+    let preview = notifier
+        .notify(&sample_completion(), &sample_config())
+        .expect("preview-mode render");
+    assert!(!preview);
+    assert!(notifier.transport.is_empty());
+}
+
+#[test]
+fn completion_hash_is_stable_across_notifier_instances() {
+    let a = sample_completion();
+    let b = sample_completion();
+    assert_eq!(a.completion_hash(), b.completion_hash());
+}
+
+#[test]
+fn rendered_email_carries_completion_hash() {
+    let rendered = render_email(&sample_config(), &sample_completion()).unwrap();
+    assert_eq!(
+        rendered.completion_hash,
+        sample_completion().completion_hash()
+    );
+}
+
+#[test]
+fn idempotent_rerender_does_not_produce_a_new_hash() {
+    let a = render_email(&sample_config(), &sample_completion()).unwrap();
+    let b = render_email(&sample_config(), &sample_completion()).unwrap();
+    assert_eq!(a.completion_hash, b.completion_hash);
+}
+
+#[test]
+fn envelope_payload_roundtrips_through_json() {
+    let rendered = render_email(&sample_config(), &sample_completion()).unwrap();
+    let envelope = EmailEnvelope {
+        from: sample_config().from,
+        to: sample_config().to,
+        cc: vec![addr("team", "fluxion.example")],
+        subject: rendered.subject.clone(),
+        body_text: rendered.body_text.clone(),
+        download_url: rendered.download_url.clone(),
+        completion_hash: rendered.completion_hash,
+        campaign: sample_completion(),
+    };
+    let json = serde_json::to_string(&envelope).unwrap();
+    let back: EmailEnvelope = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, envelope);
+    assert!(json.contains("fluxion-abc123"));
+    assert!(json.contains("download_url"));
+}
+
+#[test]
+fn http_transport_rejects_when_endpoint_is_missing() {
+    let transport = HttpEmailTransport::new();
+    let cfg = sample_config(); // no api_endpoint
+    let rendered: RenderedEmail = render_email(&cfg, &sample_completion()).unwrap();
+    let err = transport.send(&cfg, &rendered).unwrap_err();
+    let msg = match err {
+        EmailError::InvalidConfig(m) => m,
+        other => panic!("expected InvalidConfig, got {other:?}"),
+    };
+    assert!(msg.contains("api_endpoint"), "{msg}");
+}
+
+#[test]
+fn template_placeholders_are_stable_across_locales() {
+    let rendered = render_email(&sample_config(), &sample_completion()).unwrap();
+    for token in ["fluxion-abc123", "completed", "48", "https://"] {
+        assert!(
+            rendered.subject.contains(token) || rendered.body_text.contains(token),
+            "missing `{token}` in rendered output:\nsubject={}\nbody={}",
+            rendered.subject,
+            rendered.body_text
+        );
+    }
+}
+
+#[test]
+fn failed_completion_renders_unambiguous_subject() {
+    let failed = CampaignCompletion::failed(
+        "fluxion-fail-1".to_string(),
+        "2026-07-18T00:00:00+00:00".to_string(),
+        "2026-07-18T01:00:00+00:00".to_string(),
+        10,
+        2,
+        8,
+        "https://fluxion.example.com/results/fail-1/".to_string(),
+    );
+    let rendered = render_email(&sample_config(), &failed).unwrap();
+    assert!(
+        rendered.subject.contains("failed"),
+        "subject must signal failure: {}",
+        rendered.subject
+    );
+    assert!(rendered.body_text.contains("failed"));
+}
+
+#[test]
+fn mock_transport_captures_batch_notifications_in_order() {
+    let transport = MockEmailTransport::new();
+    let mut cfg = sample_config();
+    cfg.api_endpoint = Some("https://api.example.com/send".to_string());
+    let notifier = EmailNotifier::new(transport);
+
+    for i in 0..3 {
+        let mut completion = sample_completion();
+        completion.campaign_id = format!("fluxion-batch-{i}");
+        notifier.notify(&completion, &cfg).unwrap();
+    }
+    let sent = notifier.transport.sent();
+    assert_eq!(sent.len(), 3);
+    let ids: Vec<String> = sent
+        .into_iter()
+        .map(|e| {
+            e.subject
+                .split_whitespace()
+                .find(|tok| tok.starts_with("fluxion-"))
+                .unwrap_or("")
+                .to_string()
+        })
+        .collect();
+    assert_eq!(
+        ids,
+        vec![
+            "fluxion-batch-0".to_string(),
+            "fluxion-batch-1".to_string(),
+            "fluxion-batch-2".to_string(),
+        ]
+    );
+}


### PR DESCRIPTION
Closes #1789

Configurable email notification with download link to the aggregated result. Email is the universal fallback for users without a webhook endpoint. This completes T7.5.