### PR TITLE
test(osimflow): resolve #1847 — pytest coverage for Python orchestration scripts

### DIFF
--- a/.agents/results/result-backend.md
+++ b/.agents/results/result-backend.md
@@ -1,137 +1,116 @@
-# Issue #1345 — HVAC predictive controller modulation propagation
+# Backend — Issue #1847 OSimFlow pytest coverage
 
-## Status
-
-- **Status**: COMPLETE
-- **Branch**: `fix/issue-1345-hvac-modulation`
-- **Worktree**: `/home/alex/Projects/worktrees/issue-1345-hvac-modulation`
-- **Base**: `main` @ `1dab4f3`
+**Status:** ✅ Complete
+**Date:** 2026-07-18
+**Branch:** `fix/issue-1847-establish-pytest-coverage`
+**PR (anchapin/fluxion#1847):** see `gh pr view` once the push completes.
 
 ## Summary
 
-The `PredictiveController::calculate_modulation` second tuple element
-(`modulation_factor`) was being discarded at `physics_impl.rs:2478` via
-`let (hvac_mode, _modulation) = ...`. Equipment therefore ran at 100% PLR
-regardless of predictive intent. The fix binds the modulation to a PLR
-update via `VariableCapacityEquipment::update_state` (the
-Chiller/Boiler/HeatPump/CAV/VAV path) in the 9R4C physics step, mirroring
-the wiring that already exists in the 5R1C path. The 24 h horizon constant
-in `thermal_model_core.rs:2295` was also replaced with the RFC-0001
-effective horizon (46 min = 2760 s) for dT/dt rate prediction.
+Established pytest infrastructure for the OSimFlow Python orchestration
+layer (`scripts/`) and added baseline unit tests for the three largest
+shipped-in-untested modules:
 
-## Files changed
+- `scripts/cloud_campaign_manager.py` (1,274 LoC; AWS/Nomad/DynamoDB)
+- `scripts/autonomous_parameter_sweep.py` (653 LoC; ASHRAE 140 divergence harness)
+- `scripts/ashrae_benchmark_harness.py` (551 LoC; benchmark runner + delta reporter)
 
-| File | Lines | Purpose |
-|------|-------|---------|
-| `src/sim/thermal_model_physics/physics_impl.rs` | +93 / -2 | Bind `_modulation` → `modulation`; add `equipment.update_state` block; wire economizer (mirrors 5R1C path) |
-| `src/sim/thermal_model_core.rs` | +11 / -5 | Replace 24 h horizon constant with RFC-0001 / Issue #1182 effective horizon (46 min × 60 s = 2760 s) |
-| `src/sim/hvac/equipment.rs` | +146 / -1 | Add 3 unit tests for modulation propagation (Chiller, AnyEquipment variants, PredictiveController contract) |
-| `tests/hvac_predictive_modulation.rs` | new (141 lines) | Integration test from the issue's verification path: 8760 h Case 800 simulation + 24-step 9R4C propagation check + RFC-0001 source guard |
+## Files Changed
 
-## Acceptance criteria status
-
-- [x] `let (hvac_mode, _modulation) = ...` at `physics_impl.rs:2478` replaced;
-      `_modulation` is now bound to `modulation` and forwarded to
-      `equipment.update_state` (Chiller/Boiler/HeatPump/CAV/VAV path)
-- [x] Effective prediction horizon constant equals 46 × 60 s (2760 s) per
-      RFC-0001; not 86400 s. The tracing span field changed from `24h_fixed`
-      to `rfc0001_46min`.
-- [x] Modulation factor ∈ [0, 1] asserted (lib unit tests + integration
-      test sweep)
-- [ ] Case 800 annual heating energy within ±5% of E+ reference — not
-      measured explicitly (pre-existing 800-series cases already exercise
-      the heat-pump path; the wiring fix is upstream of energy totals)
-- [ ] >5% of hours at PLR < 0.5 — depends on controller curve softening
-      (Plan 15-04 follow-up). Current controller is bang-bang (0 or 1.0
-      in steady state); this issue wires the propagation, not the curve.
-      See `.agents/results/issue-1345-python-verification.py` for the
-      controller behaviour analysis.
-
-## Verification
-
-```text
-$ cargo build --release --features ort
-Finished `release` profile [optimized] target(s) in 1m 03s
-
-$ cargo test --features ort --lib sim::hvac
-cargo test: 126 passed, 2467 filtered out (1 suite, 0.00s)
-  # 123 pre-existing + 3 new (issue-1345 propagation tests)
-
-$ cargo test --features ort --lib sim::thermal_model
-cargo test: 55 passed, 2538 filtered out (1 suite, 0.00s)
-
-$ cargo test --features ort --lib sim
-test result: FAILED. 913 passed; 2 failed; 0 ignored; 0 measured; 1678 filtered out
-  # 2 failures are pre-existing surface_flux_provider tests (verified on
-  # /tmp/fluxion-baseline clone of main, same 2 failures). Not caused by
-  # this fix.
-
-$ cargo test --features ort --test hvac_predictive_modulation
-cargo test: 3 passed (1 suite, 0.03s)
-  # 1. test_predictive_modulation_propagation_case_800
-  # 2. test_predictive_modulation_propagation_in_9r4c_step
-  # 3. test_rfc0001_prediction_horizon_constant
-
-$ cargo test --features ort --test issue_900_cooling_demand
-cargo test: 6 passed (1 suite, 0.13s)
-  # Re-validated after reverting an earlier q-modulation variant that
-  # caused a 1-test regression in the dead-band handling.
-
-$ cargo test --features ort --test test_hvac_load_calculation
-cargo test: 21 passed (1 suite, 0.00s)
-
-$ cargo test --features ort --test test_hvac_control_comprehensive
-cargo test: 41 passed (1 suite, 0.00s)
-
-$ cargo test --features ort --test test_engine_comprehensive
-cargo test: 8 passed (1 suite, 0.00s)
-
-$ cargo test --features ort --test hvac_equipment
-cargo test: 9 passed (1 suite, 0.00s)
-
-$ cargo test --features ort --test ashrae_140_cases_800_810
-test result: FAILED. 15 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out
-  # Same 2 failures on main (test_predictive_controller_integration,
-  # test_ashrae_810). Not caused by this fix.
-
-$ cargo clippy --lib --features ort -- -D warnings
-cargo clippy: No issues found
+```
+A  .github/workflows/python-tests.yml        # CI: py 3.10–3.13 matrix on Ubuntu, no cloud creds
+A  scripts/README.md                         # Documents the scripts/ci layout + fixtures
+A  scripts/ci/__init__.py                    # Test-package marker
+A  scripts/ci/test_ashrae_benchmark_harness.py
+A  scripts/ci/test_autonomous_parameter_sweep.py
+A  scripts/ci/test_cloud_campaign_manager.py
+A  scripts/conftest.py                       # Shared fixtures (fake_aws_clients, populated_state_store,
+                                            # fake_urlopen, fake_subprocess, temp_trace_dir, ...)
+A  scripts/pytest.ini                        # pytest-asyncio auto, coverage reporting, scripts/ci testpaths
+A  scripts/requirements-test.txt             # pytest>=8, pytest-asyncio, pytest-cov, boto3
+M  requirements-dev.txt                      # Added pytest>=8, pytest-asyncio, pytest-cov
+M  scripts/cloud_campaign_manager.py        # Resolved 11 unresolved git-merge-conflict markers
+                                            # (webhook HEAD vs email 1d0e1c8) so the file parses;
+                                            # both implementations now coexist.
 ```
 
-## Test coverage
+## Acceptance Criteria — checklist
 
-The fix is covered by three layers:
+- [x] **Task 1 — Pytest scaffolding**
+  - [x] `scripts/pytest.ini` configuring pytest, pytest-asyncio, pytest-cov
+  - [x] `scripts/conftest.py` with shared fixtures (temp campaign state, sample model spec, mocked subprocess)
+  - [x] `scripts/ci/` directory populated; layout documented in `scripts/README.md`
 
-1. **Lib unit tests** (`src/sim/hvac/equipment.rs` — added 3 tests):
-   - `test_predictive_modulation_propagates_to_update_state` — sweep
-     modulation ∈ {0, 0.25, 0.5, 1.0}; verify `equipment.current_plr()`
-     equals `modulated_load / capacity` for each.
-   - `test_predictive_modulation_propagates_through_any_equipment` —
-     verify the same propagation works through the `AnyEquipment` enum
-     wrapper (the type stored in `ThermalModel::hvac_equipment`) for
-     HeatPump, Boiler, and Chiller.
-   - `test_predictive_modulation_in_unit_interval` — the controller's
-     contract: `(HVACMode, f64)` second element is in `[0, 1]` for any
-     sane input.
+- [x] **Task 2 — Baseline unit tests**
+  - [x] `scripts/ci/test_cloud_campaign_manager.py` (51 tests):
+    - campaign-state serialization round-trip (dataclass + JSON)
+    - sweep-config validation (`generate_grid_points`, `generate_random_points`)
+    - mocked S3 / DynamoDB / Lambda job-spec generation (`create_campaign`, `trigger_aggregator`)
+    - state-store aggregation (`check_campaign_progress`)
+    - notification paths (webhook / email / SNS), idempotency, transport errors
+  - [x] `scripts/ci/test_autonomous_parameter_sweep.py` (23 tests):
+    - parameter-space enumeration (grid + random)
+    - early-termination logic (`tolerance_mae` abort)
+    - result aggregation (JSONL + CSV logs, sweep_state persistence)
+    - subprocess timeout / error handling
+    - divergence-report markdown rendering
+  - [x] `scripts/ci/test_ashrae_benchmark_harness.py` (30 tests):
+    - benchmark-config parsing (regex group: `TestParseValidationOutput`)
+    - **MAE + pass-rate edge cases**: `inf%`, leading whitespace, missing summary
+    - per-case ValidationCase construction (including ref-range `inf`)
+    - report rendering (`print_summary`, `print_delta`)
+    - GitHub-Actions step summary writer
 
-2. **Integration test** (`tests/hvac_predictive_modulation.rs` — new):
-   - `test_predictive_modulation_propagation_case_800` — 8760 h Case 800
-     simulation with heat pump attached; final PLR is in `[0, 1]`.
-   - `test_predictive_modulation_propagation_in_9r4c_step` — Case 900
-     (9R4C model), 24 hourly steps; verify the equipment received an
-     `update_state` call (PLR is bounded; was always 0 before the fix
-     because the 9R4C path never called `update_state`).
-   - `test_rfc0001_prediction_horizon_constant` — source-level guard
-     that the horizon constant is `46.0 * 60.0` (2760 s) and the
-     tracing field is `rfc0001_46min` (not the old `24h_fixed`).
+- [x] **Task 3 — CI wiring**
+  - [x] `.github/workflows/python-tests.yml` on Ubuntu
+  - [x] Python 3.10 / 3.11 / 3.12 / 3.13 matrix
+  - [x] No `DWAVE_API_TOKEN`, no Redis, no Kubernetes, no cloud credentials;
+        the workflow `unset`s them defensively and all externals are mocked via
+        `scripts/conftest.py` fixtures.
+  - [x] Enforces ≥60% line coverage on each of the three target files
+        via inline `coverage.xml` post-check.
 
-## Out-of-scope items (documented for next agent)
+## Coverage Achieved
 
-- The predictive controller's curve is bang-bang (0 or 1.0 in steady
-  state) because the dead-band eats intermediate errors before the
-  sensitivity scaling. The acceptance criterion `>5% of hours at PLR <
-  0.5` requires softening the controller (Plan 15-04 follow-up — see
-  the modes.rs TODO at line 15 and the controller's `calculate_modulation`
-  sensitivity of 10.0). This issue wires the propagation, not the curve.
-- The `hvac::zones::zone_control` controller is a separate staging
-  controller; not touched here.
+```
+scripts/ashrae_benchmark_harness.py       278     45    84%   ✅
+scripts/autonomous_parameter_sweep.py     263     43    84%   ✅
+scripts/cloud_campaign_manager.py         449    144    68%   ✅
+```
+
+All three target files exceed the 60% acceptance threshold.
+
+104 tests pass on Python 3.12 (local), pytest-asyncio in `auto` mode,
+`pytest-cov` configured with `--cov=scripts --cov-report=term-missing`.
+
+## How to run
+
+```bash
+pip install -r requirements-dev.txt -r scripts/requirements-test.txt
+pytest scripts/ci/ -c scripts/pytest.ini
+```
+
+Or directly via the workflow on a PR:
+`.github/workflows/python-tests.yml`.
+
+## Blockers / Notes
+
+- **`scripts/cloud_campaign_manager.py` had 11 unresolved git-merge-conflict
+  markers** (`<<<<<<< HEAD` / `=======` / `>>>>>>> 1d0e1c8`) at the time
+  this branch was created. The file was syntactically broken and could
+  not be imported at all. Resolved by keeping both webhook (HEAD) AND
+  email (1d0e1c8) implementations intact — `send_completion_notification`
+  now handles both channels. The `create_campaign` signature also accepts
+  `webhook_url` and `email_config` simultaneously.
+
+- Coverage on `cloud_campaign_manager.py` lands at 68% — well above the
+  60% requirement — but the `main()` argparse dispatcher (`if args.action
+  == "..."`) is intentionally untested because it requires end-to-end
+  fixture wiring beyond the issue scope. Future test expansions (CLI
+  parametrization, end-to-end flows) could push the file to 80%+ without
+  touching the merge resolution.
+
+- `get_campaign_state` only suppresses `ClientError` when `Error.Code == "404"`
+  (literal string match). Real S3 returns `"NoSuchKey"`. This is a latent bug
+  in the source but was left untouched per issue scope ("Do not modify files
+  outside the scope of this issue"). Tests use a `Code="404"` mock.

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,132 @@
+name: Python Tests (OSimFlow)
+
+# OSimFlow Python orchestration test suite (Issue #1847).
+#
+# Runs the pytest suite under `scripts/ci/` over a Python 3.10/3.11/3.12/3.13
+# matrix.  All AWS / D-Wave / Redis / Kubernetes integrations are mocked via
+# fixtures in `scripts/conftest.py` — this workflow requires **no** cloud
+# credentials.
+#
+# Triggers:
+#   * pull_request: fast gate on every PR
+#   * push to develop: integration check before the next release
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+    branches: [develop, main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  pytest-osimflow:
+    name: OSimFlow pytest (py ${{ matrix.python-version }})
+    runs-on: ${{ vars.FLUXION_LINUX_RUNNER || 'ubuntu-latest' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: pip-osimflow-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements-dev.txt', 'scripts/requirements-test.txt') }}
+          restore-keys: |
+            pip-osimflow-${{ runner.os }}-${{ matrix.python-version }}-
+            pip-osimflow-${{ runner.os }}-
+
+      - name: Install test dependencies
+        # Boto3/botocore are pulled in as optional deps so the conditional
+        # `import boto3` in cloud_campaign_manager.py resolves to a real
+        # module we can mock, instead of the `None` fallback path.
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          # requirements-dev.txt already lists pytest; install once and dedupe.
+          pip install -r requirements-dev.txt
+          pip install -r scripts/requirements-test.txt
+
+      - name: Run pytest scripts/ci/ with coverage
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Explicitly forbid any cloud credentials from leaking in.
+          unset DWAVE_API_TOKEN AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY \
+                AWS_SESSION_TOKEN FLUXION_REDIS_URL FLUXION_CAMPAIGN_TABLE
+          cd "$GITHUB_WORKSPACE"
+          pytest scripts/ci/ -c scripts/pytest.ini \
+            --cov-report=term-missing \
+            --cov-report=xml:scripts/ci/coverage.xml \
+            --junitxml=scripts/ci/junit.xml
+
+      - name: Enforce per-file coverage thresholds
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          """Fail the job if any of the three OSimFlow files drops below 60%."""
+          import xml.etree.ElementTree as ET
+
+          targets = {
+              "scripts/cloud_campaign_manager.py": 60.0,
+              "scripts/autonomous_parameter_sweep.py": 60.0,
+              "scripts/ashrae_benchmark_harness.py": 60.0,
+          }
+          root = ET.parse("scripts/ci/coverage.xml").getroot()
+
+          line_totals: dict[str, tuple[int, int]] = {}
+          for cls in root.findall(".//class"):
+              filename = cls.get("filename", "")
+              base = filename.split("site-packages/")[-1]
+              line_rate = float(cls.get("line-rate", "0"))
+              lines_valid = int(cls.get("lines-valid", "0"))
+              lines_covered = int(cls.get("lines-covered", "0"))
+              if base in targets:
+                  cur = line_totals.get(base, (0, 0))
+                  line_totals[base] = (cur[0] + lines_valid, cur[1] + lines_covered)
+
+          failures = []
+          for path, threshold in targets.items():
+              valid, covered = line_totals.get(path, (0, 0))
+              if valid == 0:
+                  failures.append((path, 0.0, threshold, "no coverage data"))
+                  continue
+              pct = (covered / valid) * 100
+              if pct < threshold:
+                  failures.append((path, pct, threshold, "below threshold"))
+              print(f"[coverage] {path}: {pct:.2f}% (threshold {threshold:.0f}%)")
+
+          if failures:
+              print("\n::error::OSimFlow coverage threshold failures:")
+              for path, pct, threshold, reason in failures:
+                  print(f"::error::  {path}: {pct:.2f}% < {threshold}% — {reason}")
+              raise SystemExit(1)
+          PY
+
+      - name: Upload coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: osimflow-coverage-${{ matrix.python-version }}
+          path: |
+            scripts/ci/coverage.xml
+            scripts/ci/junit.xml
+            .agents/coverage/python-osimflow
+          retention-days: 14
+          if-no-files-found: ignore

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,9 @@
 # Core tools
 maturin>=1.0,<2.0
 patchelf
-pytest
+pytest>=8.0.0
+pytest-asyncio>=0.23.0
+pytest-cov>=4.1.0
 
 # Core ML Framework
 torch>=2.0.0

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,81 @@
+# OSimFlow Python Orchestration
+
+> Cloud- and local-orchestration Python scripts that drive Fluxion
+> simulation campaigns. This README documents the test infrastructure
+> added in Issue #1847.
+
+## Layout
+
+```
+scripts/
+├── cloud_campaign_manager.py        # AWS/Nomad campaign manager (Issue #1192)
+├── autonomous_parameter_sweep.py    # Local MAE-divergence sweep (Issue #1450)
+├── ashrae_benchmark_harness.py      # ASHRAE 140 benchmark harness (Issue #1488)
+├── state_store.py                   # DynamoDB/Redis/in-memory backend (T7.3)
+├── conftest.py                      # Shared pytest fixtures (see below)
+├── pytest.ini                       # Pytest config scoped to this directory
+├── requirements-test.txt            # Test-only Python dependencies
+└── ci/
+    ├── __init__.py                  # Marker for the test package
+    ├── test_cloud_campaign_manager.py
+    ├── test_autonomous_parameter_sweep.py
+    └── test_ashrae_benchmark_harness.py
+```
+
+## Running the tests
+
+```bash
+# Install test dependencies (idempotent).
+pip install -r scripts/requirements-test.txt
+
+# Run the full OSimFlow test suite with coverage.
+pytest scripts/ci/ -c scripts/pytest.ini
+
+# Targeted runs.
+pytest scripts/ci/test_ashrae_benchmark_harness.py -c scripts/pytest.ini
+
+# Coverage report only (text + html under .agents/coverage/python-osimflow/)
+pytest scripts/ci/ -c scripts/pytest.ini --cov=scripts --cov-report=term-missing
+```
+
+Coverage targets (Issue #1847 acceptance criteria):
+
+| File                                       | Line coverage target |
+| ------------------------------------------ | -------------------- |
+| `scripts/cloud_campaign_manager.py`        | ≥ 60 %               |
+| `scripts/autonomous_parameter_sweep.py`    | ≥ 60 %               |
+| `scripts/ashrae_benchmark_harness.py`      | ≥ 60 %               |
+
+## Shared fixtures (`scripts/conftest.py`)
+
+* `_scrub_cloud_env` (autouse) — strips AWS / DWAVE / state-store env vars
+  so a stray credential never leaks into CI.
+* `fake_aws_clients` — in-memory S3 / SNS / DynamoDB / STS / Lambda fakes
+  keyed off `get_aws_clients()`.
+* `in_memory_state_store` and `populated_state_store` —
+  `state_store.InMemoryStateStore`, optionally pre-loaded with 5 work
+  units in varied `TaskStatus` states.
+* `fake_urlopen` — patches `urllib.request.urlopen` to return a fake
+  HTTP response, raise, or invoke a capture callback.
+* `fake_subprocess` — patches `subprocess.run` / `subprocess.check_output`
+  so the parameter-sweep and benchmark-harness scripts run hermetically.
+* `fluxion_model_spec` — deterministic `FluxionModel` parameter spec.
+* `temp_trace_dir`, `temp_campaign_db` — `tmp_path`-backed scratch dirs.
+
+## CI workflow
+
+`.github/workflows/python-tests.yml` runs the suite on Ubuntu for
+Python 3.10 / 3.11 / 3.12 / 3.13, requires no cloud credentials, no
+D-Wave token, no Redis, and no Kubernetes context.
+
+## Conventions
+
+* Tests use **plain `pytest` fixtures** — no class-based unittest unless
+  a group of tests needs shared state. (See
+  `test_ashrae_benchmark_harness.py::TestParseValidationOutput` for the
+  only class used here — it groups regex edge cases.)
+* `pytest-asyncio` runs in `auto` mode (`asyncio_mode = auto`); mark a
+  coroutine with `async def` only when the code under test is async.
+* AWS / SNS / webhook targets are always mocked. Never hit a real
+  endpoint from a test.
+* New helpers belong in `conftest.py`, not in individual test modules.

--- a/scripts/ci/__init__.py
+++ b/scripts/ci/__init__.py
@@ -1,0 +1,1 @@
+"""Marker module so pytest discovers ``scripts/ci/`` as a package."""

--- a/scripts/ci/test_ashrae_benchmark_harness.py
+++ b/scripts/ci/test_ashrae_benchmark_harness.py
@@ -1,0 +1,574 @@
+"""
+Tests for ``scripts/ashrae_benchmark_harness.py`` — Issue #1847.
+
+This module exercises the benchmark-config parsing, the regex-driven
+loaders, and the baseline-comparison delta calculations.  All
+``subprocess`` calls are mocked so no cargo invocation occurs.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+from contextlib import redirect_stdout
+from dataclasses import asdict
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+import ashrae_benchmark_harness as abh
+
+
+# ---------------------------------------------------------------------------
+# _parse_target_output — Rust-test-runner output.
+# ---------------------------------------------------------------------------
+
+
+def test_parse_target_output_extracts_passed_failed_and_names():
+    out = """
+running 47 tests
+test result: ok. 45 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out
+
+FAILED tests::test_one
+FAILED tests::test_two
+"""
+    passed, failed, names = abh._parse_target_output(out)
+    assert passed == 45
+    assert failed == 2
+    assert names == ["tests::test_one", "tests::test_two"]
+
+
+def test_parse_target_output_no_results_defaults_to_zero():
+    passed, failed, names = abh._parse_target_output("no rust output here")
+    assert (passed, failed, names) == (0, 0, [])
+
+
+# ---------------------------------------------------------------------------
+# _parse_validation_output — Cases / Pass Rate / MAE (bullet 3 of issue).
+# ---------------------------------------------------------------------------
+
+
+class TestParseValidationOutput:
+    """Grouped regex edge cases (issue: "MAE/pass-rate regex parsing highest-value")."""
+
+    def test_basic_case_is_parsed(self):
+        out = (
+            "Case 600 : Heating=2.00 (Ref: 1.00-3.00), "
+            "Cooling=1.20 (Ref: 0.80-1.60)\n"
+            "Pass Rate: 90.0% ... Passed: 9 ... Failed: 1\n"
+            "Mean Absolute Error: 2.50%\n"
+        )
+        cases, pass_rate, mae = abh._parse_validation_output(out)
+        assert len(cases) == 1
+        case = cases[0]
+        assert case.case_id == "600"
+        assert case.heating_pass is True
+        assert case.cooling_pass is True
+        assert case.overall_pass is True
+        assert pass_rate == 90.0
+        assert mae == 2.50
+
+    def test_inf_in_reference_range_always_passes(self):
+        """``inf`` as a reference bound means "no upper/lower limit" — must pass."""
+        out = "Case 600 : Heating=inf (Ref: 0.00-inf), Cooling=inf (Ref: 0.00-inf)"
+        cases, _, _ = abh._parse_validation_output(out)
+        assert cases[0].heating_pass is True
+        assert cases[0].cooling_pass is True
+        assert cases[0].overall_pass is True
+
+    def test_inf_pass_rate_and_mae_supported(self):
+        """``Pass Rate: inf%`` — the issue's headline edge case."""
+        out = (
+            "Case 600 : Heating=2.00 (Ref: 1.00-3.00), Cooling=1.00 (Ref: 0.50-1.50)\n"
+            "  Pass Rate: inf% ... Passed: 10 ... Failed: 0\n"
+            "  Mean Absolute Error: inf%\n"
+        )
+        cases, pass_rate, mae = abh._parse_validation_output(out)
+        assert pass_rate == float("inf")
+        assert mae == float("inf")
+
+    def test_leading_whitespace_in_summary_is_parsed(self):
+        """rust test output often prefixes 'Pass Rate' with indentation."""
+        out = (
+            "Case 600 : Heating=2.00 (Ref: 1.00-3.00), Cooling=1.00 (Ref: 0.50-1.50)\n"
+            "\n        Pass Rate: 80.0% ... Passed: 8 ... Failed: 2\n"
+            "        Mean Absolute Error: 4.20%\n"
+        )
+        _, pass_rate, mae = abh._parse_validation_output(out)
+        assert pass_rate == 80.0
+        assert mae == 4.20
+
+    def test_failing_case_marks_overall_pass_false(self):
+        out = "Case 600 : Heating=99.00 (Ref: 1.00-3.00), Cooling=1.00 (Ref: 0.50-1.50)"
+        cases, _, _ = abh._parse_validation_output(out)
+        assert cases[0].heating_pass is False
+        assert cases[0].overall_pass is False
+
+    def test_multiple_cases_track_each_independently(self):
+        out = (
+            "Case 600 : Heating=2.00 (Ref: 1.00-3.00), Cooling=1.00 (Ref: 0.50-1.50)\n"
+            "Case 900 : Heating=99.0 (Ref: 4.50-5.50), Cooling=8.0 (Ref: 7.50-8.50)\n"
+        )
+        cases, _, _ = abh._parse_validation_output(out)
+        assert [c.case_id for c in cases] == ["600", "900"]
+        assert cases[0].overall_pass is True
+        assert cases[1].overall_pass is False
+
+    def test_no_summary_falls_back_to_zero(self):
+        out = "Case 600 : Heating=2.00 (Ref: 1.00-3.00), Cooling=1.00 (Ref: 0.50-1.50)"
+        _, pass_rate, mae = abh._parse_validation_output(out)
+        assert pass_rate == 0.0
+        assert mae == 0.0
+
+    def test_no_cases_returns_empty_list(self):
+        cases, _, _ = abh._parse_validation_output("nothing here at all")
+        assert cases == []
+
+
+# ---------------------------------------------------------------------------
+# _git_info — both env fallback and exception fallback paths.
+# ---------------------------------------------------------------------------
+
+
+def test_git_info_uses_subprocess(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    def fake_check_output(cmd, **kwargs):
+        # Mirror real subprocess.check_output(text=True) shape: it returns str.
+        if "rev-parse" in cmd and "--short" in cmd:
+            return "abc1234\n"
+        if "rev-parse" in cmd and "--abbrev-ref" in cmd:
+            return "main\n"
+        raise subprocess.CalledProcessError(1, cmd)
+
+    monkeypatch.setattr("subprocess.check_output", fake_check_output)
+    sha, branch = abh._git_info()
+    assert sha == "abc1234"
+    assert branch == "main"
+
+
+def test_git_info_falls_back_to_env_on_subprocess_exception(monkeypatch):
+    """When ``git rev-parse`` fails (no .git dir), env vars drive the result."""
+    def fake_check_output(cmd, **kwargs):
+        raise FileNotFoundError("no git")
+
+    monkeypatch.setattr("subprocess.check_output", fake_check_output)
+    monkeypatch.setenv("GITHUB_SHA", "deadbeefcafe")
+    monkeypatch.setenv("GITHUB_REF_NAME", "feature/test")
+    sha, branch = abh._git_info()
+    assert sha == "deadbee"  # truncated to 7 chars
+    assert branch == "feature/test"
+
+
+def test_git_info_handles_subprocess_called_process(monkeypatch):
+    def fake_check_output(cmd, **kwargs):
+        raise subprocess.CalledProcessError(1, cmd)
+
+    monkeypatch.setattr("subprocess.check_output", fake_check_output)
+    # The production code is:
+    #   sha = os.environ.get("GITHUB_SHA", "unknown")[:7]
+    # An empty env value yields "" via .get(); we exercise that path here and
+    # separately exercise the "unknown" default via test_git_info_uses_env when
+    # the env var is unset.
+    monkeypatch.setenv("GITHUB_SHA", "")
+    sha, branch = abh._git_info()
+    assert sha == ""
+    # ``branch`` follows the same pattern with ``GITHUB_REF_NAME``.
+    monkeypatch.delenv("GITHUB_REF_NAME", raising=False)
+    sha, branch = abh._git_info()
+    assert branch == "unknown"
+
+
+def test_git_info_unknown_default_when_no_env(monkeypatch):
+    """When both subprocess and env are unusable, the literal ``"unknown"`` default applies."""
+
+    def fake_check_output(cmd, **kwargs):
+        raise FileNotFoundError("no git")
+
+    monkeypatch.setattr("subprocess.check_output", fake_check_output)
+    monkeypatch.delenv("GITHUB_SHA", raising=False)
+    monkeypatch.delenv("GITHUB_REF_NAME", raising=False)
+    sha, branch = abh._git_info()
+    assert sha == "unknown"
+    assert branch == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# _run_cargo_test — three return paths.
+# ---------------------------------------------------------------------------
+
+
+def test_run_cargo_test_success(monkeypatch):
+    fake_proc = MagicMock()
+    fake_proc.returncode = 0
+    fake_proc.stdout = "stdout content"
+    fake_proc.stderr = "stderr content"
+    monkeypatch.setattr("subprocess.run", lambda *a, **kw: fake_proc)
+
+    out, duration, code = abh._run_cargo_test("ashrae_140_validation")
+    assert code == 0
+    assert "stdout content" in out
+    assert "stderr content" in out
+    assert duration >= 0
+
+
+def test_run_cargo_test_timeout_returns_124(monkeypatch):
+    def fake_run(*a, **kw):
+        raise subprocess.TimeoutExpired("cargo", 5)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    out, duration, code = abh._run_cargo_test("ashrae_140_validation", timeout=5)
+    assert code == 124
+    assert "TIMEOUT" in out
+
+
+def test_run_cargo_test_missing_binary_returns_127(monkeypatch):
+    def fake_run(*a, **kw):
+        raise FileNotFoundError("cargo not found")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    out, duration, code = abh._run_cargo_test("ashrae_140_validation")
+    assert code == 127
+    assert "ERROR" in out
+
+
+# ---------------------------------------------------------------------------
+# run_harness — full pipeline with all subprocesses mocked (Issue bullet 4).
+# ---------------------------------------------------------------------------
+
+
+def _make_run(returncode=0, stdout="", stderr=""):
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.stdout = stdout
+    proc.stderr = stderr
+    return proc
+
+
+def test_run_harness_aggregates_per_target_data(monkeypatch):
+    # git_info is replaced with deterministic values.
+    monkeypatch.setattr(abh, "_git_info", lambda: ("abc1234", "develop"))
+
+    # Both cases are within tolerance so both pass.
+    summary_output = """
+Case 600 : Heating=2.00 (Ref: 1.00-3.00), Cooling=1.00 (Ref: 0.50-1.50)
+Case 900 : Heating=5.10 (Ref: 4.50-5.50), Cooling=8.10 (Ref: 7.50-8.50)
+Pass Rate: 100.0% ... Passed: 2 ... Failed: 0
+Mean Absolute Error: 1.50%
+test result: ok. 2 passed; 0 failed
+"""
+
+    def fake_run(cmd, **kwargs):
+        target = cmd[3] if len(cmd) > 3 else "?"
+        if target == "ashrae_140_validation":
+            return _make_run(0, stdout=summary_output, stderr="")
+        return _make_run(0, stdout="test result: ok. 5 passed; 0 failed", stderr="")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    report = abh.run_harness(release=False, timeout=60)
+    assert report.schema_version == abh.SCHEMA_VERSION
+    assert report.commit_sha == "abc1234"
+    assert report.branch == "develop"
+    assert len(report.test_targets) == len(abh.TEST_TARGETS)
+    # Comprehensive target parsed two validation cases.
+    assert len(report.validation_cases) == 2
+    # Both cases pass, so the harness reports 2/2.
+    assert report.summary.validation_cases_passed == 2
+    assert report.summary.validation_cases_failed == 0
+    # Summary pass_rate from the regex parser wins over the per-case fallback.
+    assert report.summary.pass_rate == 100.0
+    assert report.summary.mae_percent == pytest.approx(1.50)
+    # Aggregated rust-test counts: 2 from comprehensive + 5×N from the rest.
+    assert report.summary.total_tests_passed >= 2
+
+
+def test_run_harness_summary_pass_rate_fallback_when_no_match(monkeypatch):
+    """When the regex summary isn't in the output, derive pass_rate from per-case data."""
+    monkeypatch.setattr(abh, "_git_info", lambda: ("abc", "main"))
+    summary_output = """
+Case 600 : Heating=2.00 (Ref: 1.00-3.00), Cooling=1.00 (Ref: 0.50-1.50)
+Case 900 : Heating=99.0 (Ref: 4.50-5.50), Cooling=8.10 (Ref: 7.50-8.50)
+"""
+
+    def fake_run(cmd, **kwargs):
+        target = cmd[3] if len(cmd) > 3 else "?"
+        if target == "ashrae_140_validation":
+            return _make_run(0, stdout=summary_output, stderr="")
+        return _make_run(0, stdout="test result: ok. 1 passed; 0 failed", stderr="")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    report = abh.run_harness(release=False, timeout=60)
+    # 1 of 2 cases passes → 50.0%.
+    assert report.summary.pass_rate == pytest.approx(50.0)
+
+
+def test_run_harness_marks_target_not_found_when_cargo_missing(monkeypatch):
+    monkeypatch.setattr(abh, "_git_info", lambda: ("abc", "main"))
+
+    def fake_run(cmd, **kwargs):
+        raise FileNotFoundError("no cargo")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    report = abh.run_harness()
+    assert all(t.exit_code == 127 for t in report.test_targets)
+    assert all("NOT FOUND" in t.notes for t in report.test_targets)
+
+
+def test_run_harness_handles_per_target_timeouts(monkeypatch):
+    monkeypatch.setattr(abh, "_git_info", lambda: ("abc", "main"))
+
+    def fake_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd, 60)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    report = abh.run_harness(timeout=60)
+    assert all(t.exit_code == 124 for t in report.test_targets)
+
+
+# ---------------------------------------------------------------------------
+# compare_to_baseline — Delta computation.
+# ---------------------------------------------------------------------------
+
+
+def _make_report(
+    passed: int = 10,
+    failed: int = 5,
+    pass_rate: float = 66.7,
+    mae: float = 2.5,
+    duration: float = 100.0,
+    tests_passed: int = 30,
+    tests_failed: int = 5,
+) -> abh.BenchmarkReport:
+    summary = abh.BenchmarkSummary(
+        total_validation_cases=15,
+        validation_cases_passed=passed,
+        validation_cases_failed=failed,
+        pass_rate=pass_rate,
+        mae_percent=mae,
+        total_duration_s=duration,
+        total_tests_passed=tests_passed,
+        total_tests_failed=tests_failed,
+    )
+    return abh.BenchmarkReport(
+        schema_version=abh.SCHEMA_VERSION,
+        timestamp="2026-01-01T00:00:00Z",
+        commit_sha="abc",
+        branch="main",
+        summary=summary,
+        test_targets=[],
+        validation_cases=[],
+    )
+
+
+def test_compare_to_baseline_regression(tmp_path: Path):
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(json.dumps({
+        "summary": {
+            "validation_cases_passed": 12,
+            "validation_cases_failed": 3,
+            "pass_rate": 80.0,
+            "mae_percent": 2.0,
+            "total_duration_s": 90.0,
+        }
+    }))
+    cur = _make_report(passed=10, failed=5, pass_rate=66.7, mae=3.0, duration=110.0)
+    delta = abh.compare_to_baseline(cur, baseline)
+    assert delta is not None
+    assert delta.validation_cases_passed_delta == -2
+    assert delta.pass_rate_delta == pytest.approx(-13.3)
+    assert delta.mae_delta == pytest.approx(1.0)
+    assert delta.duration_delta_s == pytest.approx(20.0)
+    assert delta.regression is True
+    assert delta.improvement is False
+
+
+def test_compare_to_baseline_improvement(tmp_path: Path):
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(json.dumps({
+        "summary": {
+            "validation_cases_passed": 8,
+            "validation_cases_failed": 7,
+            "pass_rate": 53.3,
+            "mae_percent": 5.0,
+            "total_duration_s": 110.0,
+        }
+    }))
+    cur = _make_report(passed=12, failed=3, pass_rate=80.0, mae=2.5, duration=90.0)
+    delta = abh.compare_to_baseline(cur, baseline)
+    assert delta.validation_cases_passed_delta == 4
+    assert delta.improvement is True
+    assert delta.regression is False
+
+
+def test_compare_to_baseline_no_baseline_file(tmp_path: Path):
+    cur = _make_report()
+    assert abh.compare_to_baseline(cur, tmp_path / "missing.json") is None
+
+
+def test_compare_to_baseline_invalid_json(tmp_path: Path):
+    baseline = tmp_path / "broken.json"
+    baseline.write_text("not-json-{")
+    cur = _make_report()
+    assert abh.compare_to_baseline(cur, baseline) is None
+
+
+# ---------------------------------------------------------------------------
+# print_delta / print_summary — exercise without crashing.
+# ---------------------------------------------------------------------------
+
+
+def test_print_delta_smoke(tmp_path: Path, capsys):
+    cur = _make_report(passed=10)
+    delta = abh.Delta(
+        validation_cases_passed_delta=2,
+        validation_cases_failed_delta=-2,
+        pass_rate_delta=10.0, mae_delta=-0.5,
+        duration_delta_s=-5.0,
+        regression=False, improvement=True,
+    )
+    abh.print_delta(cur, delta)
+    out = capsys.readouterr().out
+    assert "DELTA" in out
+    assert "IMPROVEMENT" in out
+    assert "+2" in out
+
+
+def test_print_summary_with_cases(capsys):
+    report = abh.BenchmarkReport(
+        schema_version="1",
+        timestamp="t",
+        commit_sha="c",
+        branch="b",
+        summary=abh.BenchmarkSummary(
+            total_validation_cases=2,
+            validation_cases_passed=1,
+            validation_cases_failed=1,
+            pass_rate=50.0,
+            mae_percent=2.0,
+            total_duration_s=5.0,
+            total_tests_passed=10,
+            total_tests_failed=2,
+        ),
+        test_targets=[],
+        validation_cases=[
+            abh.ValidationCase(
+                case_id="600",
+                heating_actual=2.0, heating_ref_min=1.0, heating_ref_max=3.0,
+                heating_pass=True,
+                cooling_actual=1.0, cooling_ref_min=0.5, cooling_ref_max=1.5,
+                cooling_pass=True,
+                overall_pass=True,
+            ),
+            abh.ValidationCase(
+                case_id="900",
+                heating_actual=5.0, heating_ref_min=4.5, heating_ref_max=5.5,
+                heating_pass=True,
+                cooling_actual=8.0, cooling_ref_min=7.5, cooling_ref_max=8.5,
+                cooling_pass=True,
+                overall_pass=True,
+            ),
+        ],
+    )
+    abh.print_summary(report)
+    out = capsys.readouterr().out
+    assert "SUMMARY" in out
+    assert "Case" in out and "Pass?" in out
+    assert "600" in out and "900" in out
+
+
+# ---------------------------------------------------------------------------
+# write_github_step_summary — exercises summary + delta + per-target table.
+# ---------------------------------------------------------------------------
+
+
+def test_write_github_step_summary_appends_markdown(tmp_path: Path, monkeypatch):
+    summary_path = tmp_path / "step_summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_path))
+
+    report = abh.BenchmarkReport(
+        schema_version="1",
+        timestamp="t",
+        commit_sha="abc1234",
+        branch="main",
+        summary=abh.BenchmarkSummary(
+            total_validation_cases=3,
+            validation_cases_passed=3,
+            validation_cases_failed=0,
+            pass_rate=100.0,
+            mae_percent=1.5,
+            total_duration_s=42.0,
+            total_tests_passed=33,
+            total_tests_failed=0,
+        ),
+        test_targets=[
+            abh.TargetResult(
+                target="ashrae_140_validation",
+                duration_s=12.0, exit_code=0,
+                tests_passed=10, tests_failed=0,
+            ),
+            abh.TargetResult(
+                target="ashrae_140_case_900",
+                duration_s=8.0, exit_code=1,
+                tests_passed=5, tests_failed=1, failed_test_names=["x"],
+            ),
+        ],
+        validation_cases=[],
+    )
+    delta = abh.Delta(
+        validation_cases_passed_delta=1,
+        validation_cases_failed_delta=0,
+        pass_rate_delta=5.0, mae_delta=-0.5,
+        duration_delta_s=-3.0,
+        regression=False, improvement=True,
+    )
+    abh.write_github_step_summary(report, delta)
+    text = summary_path.read_text()
+    assert "ASHRAE 140 Benchmark Harness Results" in text
+    assert "ashrae_140_validation" in text
+    assert "Improvement" in text or "✅" in text
+    assert "Regression" not in text  # no regression block
+
+
+def test_write_github_step_summary_no_env_is_noop(monkeypatch, tmp_path):
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    report = _make_report()
+    # Should silently no-op without raising.
+    abh.write_github_step_summary(report, None)
+
+
+def test_write_github_step_summary_regression_block(tmp_path: Path, monkeypatch):
+    summary_path = tmp_path / "step_summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_path))
+
+    report = abh.BenchmarkReport(
+        schema_version="1",
+        timestamp="t",
+        commit_sha="c",
+        branch="b",
+        summary=abh.BenchmarkSummary(
+            total_validation_cases=4,
+            validation_cases_passed=2,
+            validation_cases_failed=2,
+            pass_rate=50.0,
+            mae_percent=4.0,
+            total_duration_s=10.0,
+            total_tests_passed=10,
+            total_tests_failed=2,
+        ),
+        test_targets=[],
+        validation_cases=[],
+    )
+    delta = abh.Delta(
+        validation_cases_passed_delta=-2,
+        validation_cases_failed_delta=2,
+        pass_rate_delta=-30.0,
+        mae_delta=2.0,
+        duration_delta_s=2.0,
+        regression=True, improvement=False,
+    )
+    abh.write_github_step_summary(report, delta)
+    text = summary_path.read_text()
+    assert "Regression" in text or "⏬" in text or "⬇️" in text

--- a/scripts/ci/test_autonomous_parameter_sweep.py
+++ b/scripts/ci/test_autonomous_parameter_sweep.py
@@ -1,0 +1,440 @@
+"""
+Tests for ``scripts/autonomous_parameter_sweep.py`` — Issue #1847.
+
+Targets the parameter-space enumeration, sweep-config persistence, and
+the high-value ``--dry-run`` path that is the most heavily-used CI
+smoke check.  ``subprocess.run`` is mocked so no real ``cargo test``
+invocation occurs.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+import autonomous_parameter_sweep as aps
+
+
+# ---------------------------------------------------------------------------
+# Fixtures.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sweep_config() -> aps.SweepConfig:
+    return aps.SweepConfig(
+        case_id="600",
+        sweep_type=aps.SweepType.GRID,
+        parameters=[
+            aps.ParameterSpec("R_value", default=2.0, min_val=1.0, max_val=2.0, step=1.0),
+            aps.ParameterSpec("wall_thickness", default=0.15, min_val=0.10, max_val=0.20, step=0.05),
+        ],
+        max_iterations=10,
+        samples_per_param=4,
+        trace_dir=None,
+    )
+
+
+def _fake_proc(returncode: int = 0, stdout: str = "", stderr: str = ""):
+    """Mimics the shape of ``subprocess.CompletedProcess``."""
+    obj = MagicMock()
+    obj.returncode = returncode
+    obj.stdout = stdout
+    obj.stderr = stderr
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# parse_cargo_output — MAE/Pass-Rate regex (Issue #1847 Task 2 bullet 2).
+# ---------------------------------------------------------------------------
+
+
+def test_parse_cargo_output_simple_mae_header():
+    out = """
+test result: ok.
+Mean Absolute Error: 4.21%
+Case 600 : Heating=2.00 (Ref: 1.00-3.00), Cooling=1.00 (Ref: 0.50-1.50)
+Pass Rate: 90.0% ... Passed: 18 ... Failed: 2
+"""
+    metrics = aps.parse_cargo_output(out)
+    assert metrics["heating_mae"] == pytest.approx(4.21)
+    assert metrics["overall_pass"] is True
+
+
+def test_parse_cargo_output_no_match_yields_zero_metrics():
+    metrics = aps.parse_cargo_output("nothing to see here")
+    assert metrics == {
+        "heating_mae": 0.0,
+        "cooling_mae": 0.0,
+        "peak_heating_mae": 0.0,
+        "peak_cooling_mae": 0.0,
+        "temperature_mae": 0.0,
+        "overall_pass": False,
+    }
+
+
+def test_parse_cargo_output_low_pass_rate_marks_failure():
+    out = "Mean Absolute Error: 5.0% Pass Rate: 60.0% Passed: 6 Failed: 4"
+    metrics = aps.parse_cargo_output(out)
+    assert metrics["overall_pass"] is False  # < 80% threshold
+
+
+def test_parse_cargo_output_extracts_per_case_errors():
+    out = """
+Case 600 : Heating=2.00 (Ref: 1.00-3.00), Cooling=1.20 (Ref: 0.80-1.60)
+Case 900 : Heating=5.10 (Ref: 4.50-5.50), Cooling=8.10 (Ref: 7.50-8.50)
+"""
+    metrics = aps.parse_cargo_output(out, case_filter="600")
+    # heating_errors = |2.00-2.00|/2.00 = 0 (ref avg = 2.00, sim = 2.00)
+    assert metrics["heating_mae"] == pytest.approx(0.0)
+    # cooling: ref avg (0.80+1.60)/2 = 1.20, sim = 1.20, error = 0
+    assert metrics["cooling_mae"] == pytest.approx(0.0)
+
+
+def test_parse_cargo_output_case_filter_skips_non_matching():
+    """``case_filter`` selects only the matching case; non-matching cases produce no errors."""
+    out = """
+Case 195 : Heating=0.50 (Ref: 0.00-1.00), Cooling=0.10 (Ref: -0.20-0.40)
+Case 470 : Heating=2.00 (Ref: 1.00-3.00), Cooling=1.00 (Ref: 0.50-1.50)
+"""
+    metrics_195 = aps.parse_cargo_output(out, case_filter="195")
+    metrics_470 = aps.parse_cargo_output(out, case_filter="470")
+    # Different filter selects different case — heating midpoint for 195.
+    assert metrics_195["heating_mae"] == pytest.approx(0.0)
+    assert metrics_470["heating_mae"] == pytest.approx(0.0)
+    assert metrics_195["cooling_mae"] == pytest.approx(0.0)
+    assert metrics_470["cooling_mae"] == pytest.approx(0.0)
+
+
+def test_parse_cargo_output_case_filter_only_counts_matching():
+    """Filtering by ``"195"`` must aggregate errors only for the matching case."""
+    out = """
+Case 195 : Heating=1.00 (Ref: 0.00-2.00), Cooling=1.00 (Ref: 0.00-2.00)
+Case 600 : Heating=5.00 (Ref: 1.00-3.00), Cooling=1.00 (Ref: 0.50-1.50)
+"""
+    metrics = aps.parse_cargo_output(out, case_filter="195")
+    # Heating: ref avg = (0+2)/2 = 1.0, sim = 1.0, error = 0
+    assert metrics["heating_mae"] == pytest.approx(0.0)
+    # 600 should NOT have been aggregated (it's outside the filter).
+    # Cooling for 195 also 0%. Total MAE stays 0.
+    assert metrics["cooling_mae"] == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Parameter-space enumeration.
+# ---------------------------------------------------------------------------
+
+
+def test_generate_grid_points_grid_two_params():
+    specs = [
+        aps.ParameterSpec("a", default=1.0, min_val=0.0, max_val=2.0, step=1.0),
+        aps.ParameterSpec("b", default=1.0, min_val=10.0, max_val=12.0, step=1.0),
+    ]
+    pts = aps.generate_grid_points(specs)
+    assert len(pts) == 9
+    assert pts[0] == {"a": 0.0, "b": 10.0}
+    assert pts[-1] == {"a": 2.0, "b": 12.0}
+
+
+def test_generate_random_points_respects_count_and_bounds():
+    specs = [aps.ParameterSpec("x", default=0.0, min_val=-1.0, max_val=1.0, step=0.5)]
+    points = aps.generate_random_points(specs, samples=128)
+    assert len(points) == 128
+    for p in points:
+        assert -1.0 <= p["x"] <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Sweep state persistence — load_sweep_state, save_sweep_state.
+# ---------------------------------------------------------------------------
+
+
+def test_save_sweep_state_round_trip(tmp_path: Path):
+    state = aps.SweepState(
+        config={"case_id": "600"},
+        results=[{"iteration": 1, "mae": 4.2}],
+        best_parameters={"R_value": 2.5},
+        best_mae=4.2,
+        start_time="2026-01-01T00:00:00Z",
+        status="running",
+        iteration=1,
+    )
+    aps.save_sweep_state(tmp_path, state)
+    loaded = aps.load_sweep_state(tmp_path)
+    assert loaded is not None
+    assert loaded.best_parameters == {"R_value": 2.5}
+    assert loaded.best_mae == pytest.approx(4.2)
+    assert loaded.iteration == 1
+    assert loaded.status == "running"
+
+
+def test_load_sweep_state_returns_none_when_missing(tmp_path: Path):
+    assert aps.load_sweep_state(tmp_path) is None
+
+
+def test_save_sweep_state_creates_directory(tmp_path: Path):
+    nested = tmp_path / "deep" / "nested"
+    state = aps.SweepState(
+        config={}, results=[], best_parameters={}, best_mae=999.0,
+        start_time="now", status="created", iteration=0,
+    )
+    aps.save_sweep_state(nested, state)
+    assert (nested / "sweep_state.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# run_sweep in --dry-run mode (avoids real cargo invocation).
+# ---------------------------------------------------------------------------
+
+
+def test_run_sweep_dry_run_writes_config_and_returns_state(
+    sweep_config, temp_trace_dir,
+):
+    sweep_config.trace_dir = temp_trace_dir
+    state = aps.run_sweep(sweep_config, dry_run=True)
+    assert state.status == "running"
+    assert state.iteration == 0
+    assert (temp_trace_dir / "sweep_config.json").exists()
+    cfg = json.loads((temp_trace_dir / "sweep_config.json").read_text())
+    assert cfg["case_id"] == "600"
+    assert cfg["max_iterations"] == 10
+
+
+def test_run_sweep_dry_run_does_not_invoke_cargo(
+    sweep_config, temp_trace_dir, fake_subprocess,
+):
+    sweep_config.trace_dir = temp_trace_dir
+    # Configure subprocess.run to fail loudly if invoked (proves dry-run doesn't call it).
+    fake_subprocess["install"](
+        run_return=_pytest_fail("dry-run must not invoke subprocess"),
+    )
+    state = aps.run_sweep(sweep_config, dry_run=True)
+    assert state is not None
+    assert fake_subprocess["run_calls"] == []
+
+
+# ---------------------------------------------------------------------------
+# run_sweep random mode: fake a single cargo run with non-zero metrics.
+# ---------------------------------------------------------------------------
+
+
+def test_run_sweep_random_with_mocked_cargo(
+    sweep_config, temp_trace_dir, fake_subprocess,
+):
+    sweep_config.sweep_type = aps.SweepType.RANDOM
+    sweep_config.samples_per_param = 2
+    sweep_config.max_iterations = 2
+    sweep_config.trace_dir = temp_trace_dir
+    # Tolerance far below the worst possible result (0% + 0% = 0%), so no early exit.
+    sweep_config.tolerance_mae = 0.0
+
+    fake_subprocess["install"](
+        run_return=_fake_proc(
+            0,
+            stdout="Mean Absolute Error: 3.10%\n"
+                   "Case 600 : Heating=2.00 (Ref: 1.00-3.00), "
+                   "Cooling=1.20 (Ref: 0.80-1.60)\n"
+                   "Pass Rate: 92.0% ... Passed: 9 ... Failed: 1",
+        )
+    )
+
+    state = aps.run_sweep(sweep_config, dry_run=False)
+    # Both iterations run; with tolerance=0.0 the early-abort never triggers.
+    assert state.iteration == 2
+    assert len(state.results) == 2
+    # log_result wrote JSONL
+    jsonl = (temp_trace_dir / "parameter_sweep_results.jsonl").read_text().strip().splitlines()
+    assert len(jsonl) == 2
+    first = json.loads(jsonl[0])
+    assert first["case_id"] == "600"
+    # convergence_log.csv exists
+    conv = (temp_trace_dir / "convergence_log.csv").read_text().strip().splitlines()
+    assert conv[0] == "iteration,mae,timestamp"
+    assert len(conv) == 3  # header + 2 rows
+
+
+def test_run_sweep_aborts_early_when_tolerance_met(
+    sweep_config, temp_trace_dir, fake_subprocess,
+):
+    sweep_config.sweep_type = aps.SweepType.GRID
+    sweep_config.max_iterations = 5
+    sweep_config.tolerance_mae = 1.0  # tight threshold
+    sweep_config.trace_dir = temp_trace_dir
+
+    fake_subprocess["install"](
+        run_return=_fake_proc(0, stdout="Mean Absolute Error: 0.50%\n")
+    )
+
+    state = aps.run_sweep(sweep_config, dry_run=False)
+    # First iteration's heating+cooling = 0.50 <= 1.0 tolerance → abort.
+    assert state.iteration == 1
+
+
+def test_run_sweep_handles_cargo_timeout(
+    sweep_config, temp_trace_dir, fake_subprocess,
+):
+    sweep_config.sweep_type = aps.SweepType.GRID
+    sweep_config.max_iterations = 2
+    sweep_config.tolerance_mae = 100.0
+    sweep_config.trace_dir = temp_trace_dir
+
+    fake_subprocess["install"](
+        run_return=_pytest_fail(""),
+    )
+    # Force a TimeoutExpired-style return for our run:
+    import subprocess as _subprocess
+
+    fake_subprocess["install"](
+        run_return=_raise_on_call(_subprocess.TimeoutExpired("cargo test", 60)),
+    )
+
+    state = aps.run_sweep(sweep_config, dry_run=False)
+    # Each iteration should record an error result.
+    assert all(r["error_message"] for r in state.results)
+    assert state.status == "completed"
+
+
+# ---------------------------------------------------------------------------
+# apply_parameters — used to set env overrides.
+# ---------------------------------------------------------------------------
+
+
+def test_apply_parameters_writes_uppercase_env():
+    env: dict[str, str] = {}
+    aps.apply_parameters({"R_value": 1.5, "wall_thickness": 0.20}, env)
+    assert env["FLUXION_PARAM_R_VALUE"] == "1.5"
+    assert env["FLUXION_PARAM_WALL_THICKNESS"] == "0.2"
+
+
+def test_apply_parameters_handles_empty_dict():
+    env: dict[str, str] = {"existing": "x"}
+    aps.apply_parameters({}, env)
+    assert env == {"existing": "x"}
+
+
+# ---------------------------------------------------------------------------
+# log_result writes JSONL with one record per call.
+# ---------------------------------------------------------------------------
+
+
+def test_log_result_appends_jsonl(tmp_path: Path):
+    trace = tmp_path / "trace"
+    result = aps.SweepResult(
+        run_id="abc12345",
+        case_id="600",
+        iteration=1,
+        parameters={"R_value": 2.0},
+        heating_mae=4.21,
+        cooling_mae=3.10,
+        peak_heating_mae=4.21,
+        peak_cooling_mae=3.10,
+        temperature_mae=4.21,
+        overall_pass=True,
+        timestamp="2026-01-01T00:00:00Z",
+        duration_ms=1200,
+    )
+    aps.log_result(trace, result)
+    aps.log_result(trace, result)
+    lines = (trace / "parameter_sweep_results.jsonl").read_text().strip().splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0])["run_id"] == "abc12345"
+
+
+# ---------------------------------------------------------------------------
+# log_convergence — CSV format with header creation on first call.
+# ---------------------------------------------------------------------------
+
+
+def test_log_convergence_writes_header_then_rows(tmp_path: Path):
+    trace = tmp_path / "trace"
+    aps.log_convergence(trace, 1, 4.21)
+    aps.log_convergence(trace, 2, 3.10)
+    rows = (trace / "convergence_log.csv").read_text().strip().splitlines()
+    assert rows[0] == "iteration,mae,timestamp"
+    assert rows[1].startswith("1,4.21,")
+    assert rows[2].startswith("2,3.1,")
+
+
+def test_log_convergence_does_not_duplicate_header(tmp_path: Path):
+    trace = tmp_path / "trace"
+    aps.log_convergence(trace, 1, 1.0)
+    aps.log_convergence(trace, 2, 2.0)
+    aps.log_convergence(trace, 3, 3.0)
+    rows = (trace / "convergence_log.csv").read_text().strip().splitlines()
+    assert sum(1 for r in rows if r.startswith("iteration")) == 1
+
+
+# ---------------------------------------------------------------------------
+# create_divergence_report renders best-pas markdown.
+# ---------------------------------------------------------------------------
+
+
+def test_create_divergence_report_emits_markdown(tmp_path: Path):
+    trace = tmp_path / "trace"
+    trace.mkdir(parents=True, exist_ok=True)  # ensure report can be written
+    config = aps.SweepConfig(
+        case_id="600",
+        sweep_type=aps.SweepType.RANDOM,
+        parameters=[aps.ParameterSpec("R_value", default=2.0, min_val=1.0,
+                                       max_val=5.0, step=0.5, unit="m²K/W")],
+    )
+    results = [
+        aps.SweepResult(
+            run_id="r1", case_id="600", iteration=1,
+            parameters={"R_value": 2.0},
+            heating_mae=4.0, cooling_mae=3.0,
+            peak_heating_mae=4.0, peak_cooling_mae=3.0,
+            temperature_mae=4.0, overall_pass=True,
+            timestamp="t0", duration_ms=10,
+        ),
+        aps.SweepResult(
+            run_id="r2", case_id="600", iteration=2,
+            parameters={"R_value": 3.0},
+            heating_mae=6.0, cooling_mae=5.0,
+            peak_heating_mae=6.0, peak_cooling_mae=5.0,
+            temperature_mae=6.0, overall_pass=False,
+            timestamp="t0", duration_ms=10,
+        ),
+    ]
+    aps.create_divergence_report(trace, config, results)
+    text = (trace / "divergence_report.md").read_text()
+    assert "Case:" in text and "600" in text
+    assert "Pass Rate" in text
+    assert "Best MAE" in text
+    assert "50.0%" in text  # 1 of 2 passed
+    assert "R_value" in text
+
+
+def test_create_divergence_report_no_results_writes_nothing(tmp_path: Path):
+    trace = tmp_path / "trace"
+    trace.mkdir(parents=True, exist_ok=True)
+    config = aps.SweepConfig(
+        case_id="600",
+        sweep_type=aps.SweepType.RANDOM,
+        parameters=[aps.ParameterSpec("x", default=1.0, min_val=0.0, max_val=1.0, step=0.1)],
+    )
+    aps.create_divergence_report(trace, config, [])
+    assert not (trace / "divergence_report.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# Helpers.
+# ---------------------------------------------------------------------------
+
+
+def _pytest_fail(msg: str):
+    """Wrap pytest.fail so the test process surfaces the assertion cleanly."""
+    def _fail(*a, **kw):
+        pytest.fail(msg)
+    return _fail
+
+
+def _raise_on_call(exc: BaseException):
+    def _runner(*args, **kwargs):
+        raise exc
+    return _runner

--- a/scripts/ci/test_cloud_campaign_manager.py
+++ b/scripts/ci/test_cloud_campaign_manager.py
@@ -1,0 +1,699 @@
+"""
+Tests for ``scripts/cloud_campaign_manager.py`` — Issue #1847.
+
+Coverage targets the public surface and the JSON dataclass round-trips
+that drive every consumer (workers, aggregator, SNS, webhook, email).
+The cloud module is intentionally mocked (see ``conftest.fake_aws_clients``).
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import uuid
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# Scripts/ is on sys.path via conftest.
+import cloud_campaign_manager as ccm
+
+
+# ---------------------------------------------------------------------------
+# Fixtures local to this file.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def campaign_config() -> ccm.CampaignConfig:
+    return ccm.CampaignConfig(
+        case_id="600",
+        sweep_type=ccm.SweepType.RANDOM,
+        parameters=[
+            ccm.ParameterSpec("R_value", default=2.0, min_val=1.0, max_val=2.5, step=0.5, unit="m²K/W"),
+            ccm.ParameterSpec("wall_thickness", default=0.15, min_val=0.10, max_val=0.20, step=0.05, unit="m"),
+        ],
+        max_iterations=4,
+        samples_per_param=4,
+    )
+
+
+@pytest.fixture
+def base_state(campaign_config) -> ccm.CampaignState:
+    return ccm.CampaignState(
+        campaign_id="fluxion-camp-abc1234567",
+        config={"case_id": campaign_config.case_id},
+        work_units=[{"work_unit_id": "wu-0000"}] * 4,
+        status="created",
+        start_time=datetime.now(timezone.utc).isoformat(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Data-class round-trip & serialization (Issue #1847 Task 2 bullet 1).
+# ---------------------------------------------------------------------------
+
+
+def test_campaign_state_round_trip_preserves_fields(base_state):
+    """``CampaignState(**asdict(state))`` must round-trip losslessly."""
+    base_state.best_mae = 1.234
+    base_state.best_parameters = {"R_value": 2.5, "wall_thickness": 0.15}
+    base_state.completed_units = 3
+    base_state.failed_units = 1
+    base_state.webhook_url = "https://example.test/hook"
+    base_state.sns_topic_arn = "arn:aws:sns:us-east-1:0:test"
+    base_state.email_config = {"from": "noreply@test", "to": ["ops@test"], "cc": []}
+
+    snapshot = asdict(base_state)
+    restored = ccm.CampaignState(**snapshot)
+
+    assert restored.campaign_id == base_state.campaign_id
+    assert restored.status == "created"
+    assert restored.best_mae == pytest.approx(1.234)
+    assert restored.best_parameters == {"R_value": 2.5, "wall_thickness": 0.15}
+    assert restored.completed_units == 3
+    assert restored.failed_units == 1
+    assert restored.webhook_url == "https://example.test/hook"
+    assert restored.sns_topic_arn == "arn:aws:sns:us-east-1:0:test"
+    assert restored.email_config["from"] == "noreply@test"
+    assert restored.notification_sent is False
+
+
+def test_campaign_state_json_round_trip(base_state):
+    """Real serialization through ``json.dumps`` / ``json.loads``."""
+    base_state.best_parameters = {"alpha": 0.1, "beta": 99.9}
+    payload = json.loads(json.dumps(asdict(base_state), default=str))
+    assert payload["best_parameters"]["alpha"] == 0.1
+    # notification_sent defaults to False and survives serialization.
+    assert payload["notification_sent"] is False
+    # Optional fields default to None.
+    assert payload["end_time"] is None
+
+
+def test_campaign_state_optional_fields_default_to_none():
+    state = ccm.CampaignState(
+        campaign_id="c",
+        config={},
+        work_units=[],
+        status="created",
+        start_time="t0",
+    )
+    assert state.end_time is None
+    assert state.error_message is None
+    assert state.webhook_url is None
+    assert state.sns_topic_arn is None
+    assert state.email_config is None
+    assert state.results_uri is None
+    assert state.best_parameters == {}
+    assert state.best_mae == 999.0
+
+
+# ---------------------------------------------------------------------------
+# Sweep-config validation (Issue #1847 Task 2 bullet 1).
+# ---------------------------------------------------------------------------
+
+
+def test_generate_grid_points_full_factorial():
+    specs = [
+        ccm.ParameterSpec("a", default=1.0, min_val=0.0, max_val=2.0, step=1.0),
+        ccm.ParameterSpec("b", default=1.0, min_val=10.0, max_val=12.0, step=1.0),
+    ]
+    points = ccm.generate_grid_points(specs)
+    # 3 a-values * 3 b-values = 9 combinations
+    assert len(points) == 9
+    seen_pairs = {(round(p["a"], 6), round(p["b"], 6)) for p in points}
+    assert seen_pairs == {
+        (0.0, 10.0), (0.0, 11.0), (0.0, 12.0),
+        (1.0, 10.0), (1.0, 11.0), (1.0, 12.0),
+        (2.0, 10.0), (2.0, 11.0), (2.0, 12.0),
+    }
+
+
+def test_generate_random_points_respects_bounds():
+    specs = [
+        ccm.ParameterSpec("low_high", default=0.5, min_val=0.0, max_val=1.0, step=0.1),
+    ]
+    points = ccm.generate_random_points(specs, samples=50)
+    assert len(points) == 50
+    for point in points:
+        assert 0.0 <= point["low_high"] <= 1.0
+
+
+def test_generate_grid_points_handles_floating_point_quantization():
+    """``0.1`` step accumulates ~ ``max_val`` exactly through epsilon tolerance."""
+    specs = [ccm.ParameterSpec("x", default=0.0, min_val=0.0, max_val=1.0, step=0.3)]
+    points = ccm.generate_grid_points(specs)
+    # 0.0, 0.3, 0.6, 0.9 → 4 stops (1.0 is not strictly <= 1.0+eps from 0.9+0.3=1.2)
+    assert len(points) == 4
+    assert all("x" in p for p in points)
+
+
+# ---------------------------------------------------------------------------
+# S3 URIs, env-var helpers, prefix plumbing (Issue #1847 Task 2 bullet 3).
+# ---------------------------------------------------------------------------
+
+
+def test_parse_s3_uri_valid():
+    bucket, key = ccm.parse_s3_uri("s3://my-bucket/foo/bar/baz.json")
+    assert bucket == "my-bucket"
+    assert key == "foo/bar/baz.json"
+
+
+def test_parse_s3_uri_no_key_returns_empty_string():
+    bucket, key = ccm.parse_s3_uri("s3://my-bucket")
+    assert bucket == "my-bucket"
+    assert key == ""
+
+
+def test_parse_s3_uri_rejects_non_s3_scheme():
+    with pytest.raises(ValueError, match="Invalid S3 URI"):
+        ccm.parse_s3_uri("https://example.com/foo")
+
+
+def test_get_required_env_returns_value(monkeypatch):
+    monkeypatch.setenv("FLUXION_REQUIRED", "secret-value")
+    assert ccm.get_required_env("FLUXION_REQUIRED") == "secret-value"
+
+
+def test_get_required_env_raises_when_unset(monkeypatch):
+    monkeypatch.delenv("FLUXION_REQUIRED", raising=False)
+    with pytest.raises(ValueError, match="FLUXION_REQUIRED"):
+        ccm.get_required_env("FLUXION_REQUIRED")
+
+
+def test_parse_email_recipients_handles_separators_and_whitespace():
+    assert ccm.parse_email_recipients("a@x,b@x ; c@x,,,d@x") == [
+        "a@x", "b@x", "c@x", "d@x",
+    ]
+
+
+def test_parse_email_recipients_empty_returns_empty_list():
+    assert ccm.parse_email_recipients("") == []
+    assert ccm.parse_email_recipients("   ") == []
+    assert ccm.parse_email_recipients(None) == []  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# create_campaign: mocked S3 work-unit + state persistence (bullet 3).
+# ---------------------------------------------------------------------------
+
+
+def test_create_campaign_generates_work_units_and_persists(monkeypatch, fake_aws_clients, campaign_config):
+    state = ccm.create_campaign(
+        campaign_config,
+        s3_bucket="fluxion-test-bucket",
+        s3_prefix="fluxion/test",
+        sns_topic_arn="arn:aws:sns:us-east-1:0:test",
+        webhook_url="https://example.test/hook",
+        email_config={"from": "noreply@test", "to": ["ops@test"], "cc": []},
+    )
+
+    # Campaign id is deterministic-format: "fluxion-" + 12 hex
+    assert state.campaign_id.startswith("fluxion-")
+    assert len(state.campaign_id.removeprefix("fluxion-")) == 12
+    # Up to max_iterations work units are emitted
+    assert len(state.work_units) == min(
+        campaign_config.max_iterations,
+        campaign_config.samples_per_param,
+    )
+    assert state.status == "created"
+    assert state.webhook_url == "https://example.test/hook"
+    assert state.sns_topic_arn == "arn:aws:sns:us-east-1:0:test"
+    assert state.email_config["from"] == "noreply@test"
+
+    # S3 mock got one put_object per work unit + one for the state.json blob.
+    s3_puts = fake_aws_clients["s3"].bucket_objects["fluxion-test-bucket"]
+    work_unit_keys = [k for k in s3_puts if "/work-units/" in k]
+    state_keys = [k for k in s3_puts if k.endswith("/state.json")]
+    assert len(work_unit_keys) == len(state.work_units)
+    assert len(state_keys) == 1
+    # Each work-unit body is valid JSON of the WorkUnit dataclass.
+    for key in work_unit_keys:
+        body = json.loads(s3_puts[key].decode("utf-8"))
+        assert body["campaign_id"] == state.campaign_id
+        assert body["case_id"] == "600"
+        assert isinstance(body["parameters"], dict)
+
+
+def test_create_campaign_grid_sweep_uses_grid_points(monkeypatch, fake_aws_clients):
+    config = ccm.CampaignConfig(
+        case_id="600",
+        sweep_type=ccm.SweepType.GRID,
+        parameters=[
+            ccm.ParameterSpec("R_value", default=2.0, min_val=1.0, max_val=2.0, step=1.0),
+            ccm.ParameterSpec("wall_thickness", default=0.15, min_val=0.10, max_val=0.20, step=0.05),
+        ],
+        max_iterations=10,
+    )
+    state = ccm.create_campaign(config, s3_bucket="b", s3_prefix="p")
+    # Grid: 2 R-values * 3 thickness-values = 6 combos, capped at max_iterations=10.
+    assert len(state.work_units) == 6
+
+
+def test_create_campaign_uses_max_iterations_when_no_random(campaign_config, fake_aws_clients):
+    """``BINARY`` falls into the default branch: ``generate_random_points(..., max_iterations)``."""
+    campaign_config.sweep_type = ccm.SweepType.BINARY
+    campaign_config.samples_per_param = 2
+    campaign_config.max_iterations = 5
+    state = ccm.create_campaign(campaign_config, s3_bucket="b", s3_prefix="p")
+    assert len(state.work_units) == 5
+
+
+# ---------------------------------------------------------------------------
+# update_campaign_state (delta-file application — Issue #1847 Task 2 bullet 3).
+# ---------------------------------------------------------------------------
+
+
+def test_update_campaign_state_overwrites_state_blob(fake_aws_clients, base_state):
+    base_state.completed_units = 2
+    base_state.failed_units = 1
+    base_state.status = "running"
+    ccm.update_campaign_state(base_state, "bucket-a", "prefix-a")
+
+    s3 = fake_aws_clients["s3"]
+    state_key = "prefix-a/campaigns/fluxion-camp-abc1234567/state.json"
+    assert state_key in s3.bucket_objects["bucket-a"]
+    body = json.loads(s3.bucket_objects["bucket-a"][state_key].decode("utf-8"))
+    assert body["completed_units"] == 2
+    assert body["failed_units"] == 1
+    assert body["status"] == "running"
+
+
+# ---------------------------------------------------------------------------
+# check_campaign_progress (state-store + S3 fallback paths).
+# ---------------------------------------------------------------------------
+
+
+def test_check_campaign_progress_via_in_memory_state_store(
+    in_memory_state_store, fake_aws_clients, base_state,
+):
+    """In-memory state-store path is authoritative when populated.
+
+    The test populates the store directly so the work units match
+    ``base_state.campaign_id`` and the aggregate query returns non-zero
+    counts.
+    """
+    from state_store import TaskState, TaskStatus
+
+    base_state.work_units = [{"work_unit_id": f"wu-{i:04d}"} for i in range(5)]
+    for i, status in enumerate(
+        [TaskStatus.COMPLETED, TaskStatus.COMPLETED, TaskStatus.COMPLETED,
+         TaskStatus.FAILED, TaskStatus.RUNNING]
+    ):
+        in_memory_state_store.set_state(
+            TaskState(
+                work_unit_id=f"wu-{i:04d}",
+                campaign_id=base_state.campaign_id,
+                status=status,
+                metrics={"heating_mae": 1.2 + i * 0.1} if status == TaskStatus.COMPLETED else {},
+                timestamp="2026-01-01T00:00:00Z",
+            )
+        )
+    after = ccm.check_campaign_progress(
+        base_state, "bucket", "prefix", state_store=in_memory_state_store
+    )
+    # 3 completed, 1 failed, 1 in-flight (running).
+    assert after.completed_units == 3
+    assert after.failed_units == 1
+    # status was "created", in_flight > 0 → "running"
+    assert after.status == "running"
+
+
+def test_check_campaign_progress_via_s3_listing(fake_aws_clients, base_state):
+    """Legacy S3-fallback counts ``results/*.json`` blobs."""
+    base_state.work_units = [{"work_unit_id": f"wu-{i:04d}"} for i in range(4)]
+    fake_aws_clients["s3"].listed_objects["bucket-a"] = [
+        {"Key": "prefix/results/wu-0000.json"},
+        {"Key": "prefix/results/wu-0001.json"},
+        {"Key": "prefix/results/wu-failed-0002.json"},
+        {"Key": "prefix/results/_placeholder"},  # ignored by filter
+    ]
+    after = ccm.check_campaign_progress(base_state, "bucket-a", "prefix")
+    assert after.completed_units == 2
+    assert after.failed_units == 1
+
+
+def test_check_campaign_progress_zero_work_units_no_division_error(
+    base_state, fake_aws_clients,
+):
+    """Zero work units should not divide-by-zero in the progress-pct calculation.
+
+    The S3-listing fallback is exercised when ``state_store`` is None, so we
+    need our mocked AWS clients available to avoid a real network call.
+    """
+    base_state.work_units = []
+    after = ccm.check_campaign_progress(base_state, "b", "p", state_store=None)
+    assert after.completed_units == 0
+    assert after.failed_units == 0
+    assert after.status == "created"
+
+
+def test_check_campaign_progress_marks_completed_when_state_store_reports_full(
+    in_memory_state_store, fake_aws_clients, base_state,
+):
+    from state_store import TaskState, TaskStatus
+
+    base_state.work_units = [{"work_unit_id": f"wu-{i:04d}"} for i in range(5)]
+    # Mark all 5 work units completed so the state-store reports full progress.
+    for i in range(5):
+        in_memory_state_store.set_state(
+            TaskState(
+                work_unit_id=f"wu-{i:04d}",
+                campaign_id=base_state.campaign_id,
+                status=TaskStatus.COMPLETED,
+                metrics={},
+                timestamp=f"2026-01-01T00:00:0{i}Z",
+            )
+        )
+    after = ccm.check_campaign_progress(
+        base_state, "b", "p", state_store=in_memory_state_store
+    )
+    assert after.status == "completed"
+
+
+# ---------------------------------------------------------------------------
+# build_completion_payload + email rendering.
+# ---------------------------------------------------------------------------
+
+
+def test_build_completion_payload_has_results_uri(base_state):
+    base_state.best_mae = 2.345
+    base_state.best_parameters = {"R_value": 2.5}
+    payload = ccm.build_completion_payload(base_state, "my-bucket", "my-prefix")
+    assert payload["campaign_id"] == base_state.campaign_id
+    assert payload["best_mae"] == 2.345
+    assert payload["best_parameters"] == {"R_value": 2.5}
+    assert payload["results_uri"].startswith("https://my-bucket.s3.")
+    assert payload["results_uri"].endswith(f"/campaigns/{base_state.campaign_id}/results/")
+
+
+def test_render_email_subject_uses_status(base_state):
+    payload = ccm.build_completion_payload(base_state, "b", "p")
+    assert "completed" in ccm.render_email_subject(payload)
+    payload["status"] = "failed"
+    assert "failed" in ccm.render_email_subject(payload)
+
+
+def test_render_email_body_includes_download_url(base_state):
+    payload = ccm.build_completion_payload(base_state, "b", "p")
+    body = ccm.render_email_body(payload, download_url="https://signed.example/r")
+    assert "https://signed.example/r" in body
+    assert "Fluxion campaign" in body
+    assert "Best MAE:" in body
+
+
+def test_render_email_body_empty_best_params_renders_placeholder(base_state):
+    base_state.best_parameters = {}
+    payload = ccm.build_completion_payload(base_state, "b", "p")
+    body = ccm.render_email_body(payload)
+    assert "(none)" in body
+
+
+# ---------------------------------------------------------------------------
+# send_webhook_notification / send_email_notification / send_completion_notification.
+# ---------------------------------------------------------------------------
+
+
+def test_send_webhook_2xx_returns_true(base_state, fake_urlopen):
+    fake_urlopen["install"](status=200)
+    ok = ccm.send_webhook_notification(base_state, "b", "p", "https://hook.test/x")
+    assert ok is True
+    assert len(fake_urlopen["calls"]) == 1
+    body = fake_urlopen["calls"][0].data.decode("utf-8")
+    payload = json.loads(body)
+    assert payload["campaign_id"] == base_state.campaign_id
+
+
+def test_send_webhook_5xx_returns_false(base_state, fake_urlopen):
+    fake_urlopen["install"](status=500)
+    assert ccm.send_webhook_notification(base_state, "b", "p", "https://hook.test/x") is False
+
+
+def test_send_webhook_url_error_returns_false(base_state, fake_urlopen):
+    fake_urlopen["install"](raises=urllib.error.URLError("nope"))
+    assert ccm.send_webhook_notification(base_state, "b", "p", "https://hook.test/x") is False
+
+
+def test_send_email_2xx_returns_true(base_state, fake_urlopen):
+    fake_urlopen["install"](status=202)
+    cfg = {
+        "from": "noreply@test",
+        "to": ["ops@test"],
+        "api_endpoint": "https://api.test/send",
+    }
+    assert ccm.send_email_notification(base_state, "b", "p", cfg) is True
+    # Envelope contains the rendered subject and body.
+    body = json.loads(fake_urlopen["calls"][0].data.decode("utf-8"))
+    assert body["to"] == ["ops@test"]
+    assert "started" in body["subject"].lower() or "completed" in body["subject"].lower()
+    assert "Fluxion campaign" in body["body_text"]
+
+
+def test_send_email_includes_x_fluxion_campaign_id_header(base_state, fake_urlopen):
+    fake_urlopen["install"](status=200)
+    cfg = {
+        "from": "noreply@test",
+        "to": ["ops@test"],
+        "api_endpoint": "https://api.test/send",
+    }
+    ccm.send_email_notification(base_state, "b", "p", cfg)
+    headers = fake_urlopen["calls"][0].headers
+    assert headers.get("X-fluxion-campaign-id") == base_state.campaign_id or \
+        headers.get("X-Fluxion-Campaign-Id") == base_state.campaign_id
+
+
+def test_send_email_5xx_returns_false(base_state, fake_urlopen):
+    fake_urlopen["install"](status=503)
+    cfg = {"from": "f@t", "to": ["x@t"], "api_endpoint": "https://api"}
+    assert ccm.send_email_notification(base_state, "b", "p", cfg) is False
+
+
+def test_send_email_missing_endpoint_does_not_raise(base_state, fake_urlopen):
+    """``KeyError`` on ``api_endpoint`` is swallowed and returns False."""
+    cfg = {"from": "f@t", "to": ["x@t"]}  # no api_endpoint
+    assert ccm.send_email_notification(base_state, "b", "p", cfg) is False
+
+
+def test_send_completion_notification_no_channels_logs_warning(base_state, fake_aws_clients, capsys):
+    base_state.notification_sent = False
+    ccm.send_completion_notification(base_state, "b", "p")
+    out = capsys.readouterr().err
+    assert "No notification channel" in out
+    # state untouched.
+    assert base_state.notification_sent is False
+
+
+def test_send_completion_notification_idempotent(base_state, fake_aws_clients, capsys, fake_urlopen):
+    base_state.notification_sent = True
+    ccm.send_completion_notification(base_state, "b", "p", webhook_url="https://hook")
+    assert "already sent" in capsys.readouterr().out
+    # URL was not called.
+    assert fake_urlopen["calls"] == []
+
+
+def test_send_completion_notification_webhook_failure_keeps_state_unflagged(
+    base_state, fake_urlopen, fake_aws_clients, capsys,
+):
+    fake_urlopen["install"](status=500)
+    ccm.send_completion_notification(
+        base_state, "b", "p", webhook_url="https://hook.test/x"
+    )
+    assert base_state.notification_sent is False
+    s3 = fake_aws_clients["s3"]
+    state_key = "p/campaigns/fluxion-camp-abc1234567/state.json"
+    assert state_key in s3.bucket_objects["b"]  # state blob re-persisted
+
+
+def test_send_completion_notification_sns_2xx_marks_success(
+    base_state, fake_aws_clients,
+):
+    base_state.notification_sent = False
+    ccm.send_completion_notification(
+        base_state, "b", "p", sns_topic_arn="arn:aws:sns:us-east-1:0:test"
+    )
+    sns = fake_aws_clients["sns"]
+    assert len(sns.published) == 1
+    assert sns.published[0]["TopicArn"] == "arn:aws:sns:us-east-1:0:test"
+    assert base_state.notification_sent is True
+
+
+def test_send_completion_notification_email_2xx_marks_success(
+    base_state, fake_urlopen, fake_aws_clients,
+):
+    fake_urlopen["install"](status=202)
+    cfg = {"from": "f@t", "to": ["x@t"], "api_endpoint": "https://api"}
+    ccm.send_completion_notification(base_state, "b", "p", email_config=cfg)
+    assert base_state.notification_sent is True
+
+
+# ---------------------------------------------------------------------------
+# build_email_config_from_args / build_default_params.
+# ---------------------------------------------------------------------------
+
+
+def test_build_email_config_from_args_returns_none_without_recipients():
+    args = MagicMock()
+    args.email_to = ""
+    args.email_cc = ""
+    args.email_from = ""
+    args.email_api_endpoint = None
+    args.email_api_auth = None
+    args.email_download_url = None
+    assert ccm.build_email_config_from_args(args) is None
+
+
+def test_build_email_config_from_args_populates_all_fields():
+    args = MagicMock()
+    args.email_to = "a@x, b@x"
+    args.email_cc = "c@x"
+    args.email_from = "fluxion@example"
+    args.email_api_endpoint = "https://api/send"
+    args.email_api_auth = "Bearer SG.x"
+    args.email_download_url = "https://signed/dl"
+    cfg = ccm.build_email_config_from_args(args)
+    assert cfg["to"] == ["a@x", "b@x"]
+    assert cfg["from"] == "fluxion@example"
+    assert cfg["cc"] == ["c@x"]
+    assert cfg["api_endpoint"] == "https://api/send"
+    assert cfg["api_auth_header"] == "Bearer SG.x"
+    assert cfg["download_url_override"] == "https://signed/dl"
+
+
+def test_build_default_params_contains_known_keys():
+    p = ccm.build_default_params()
+    assert set(p.keys()) == {"R_value", "wall_thickness", "thermal_mass", "h_tr_is"}
+    assert p["R_value"].unit == "m²K/W"
+    assert p["h_tr_is"].default == 8.29
+
+
+# ---------------------------------------------------------------------------
+# get_campaign_state: 404 → None, missing key → None.
+# ---------------------------------------------------------------------------
+
+
+def test_get_campaign_state_returns_none_on_missing(fake_aws_clients):
+    fake_aws_clients["s3"].bucket_objects.setdefault("b", {})  # empty bucket
+    assert ccm.get_campaign_state("missing", "b", "p") is None
+
+
+def test_get_campaign_state_round_trips_existing_state(fake_aws_clients, base_state):
+    serialized = json.dumps(asdict(base_state), default=str).encode("utf-8")
+    fake_aws_clients["s3"].bucket_objects["b"] = {
+        "p/campaigns/fluxion-camp-abc1234567/state.json": serialized
+    }
+    restored = ccm.get_campaign_state(base_state.campaign_id, "b", "p")
+    assert restored is not None
+    assert restored.campaign_id == base_state.campaign_id
+    assert restored.status == "created"
+
+
+def test_get_campaign_state_propagates_non_404_client_error(fake_aws_clients):
+    from botocore.exceptions import ClientError
+
+    s3 = fake_aws_clients["s3"]
+    # Override the S3 client to raise a non-404 ClientError.
+    s3.get_object = MagicMock(
+        side_effect=ClientError(
+            {"Error": {"Code": "AccessDenied", "Message": "no"},
+             "ResponseMetadata": {"HTTPStatusCode": 403}},
+            "GetObject",
+        )
+    )
+    with pytest.raises(ClientError):
+        ccm.get_campaign_state("x", "b", "p")
+
+
+# ---------------------------------------------------------------------------
+# ensure_s3_prefix creates a placeholder on miss, skips on hit.
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_s3_prefix_strips_trailing_slash(fake_aws_clients):
+    ccm.ensure_s3_prefix(fake_aws_clients["s3"], "b", "trailing/")
+    # We pass through ClientError path (head fails) → put fires for "trailing/_placeholder".
+    s3 = fake_aws_clients["s3"]
+    assert "trailing/_placeholder" in s3.bucket_objects["b"]
+
+
+def test_ensure_s3_prefix_skips_put_when_head_succeeds(fake_aws_clients):
+    fake_aws_clients["s3"].head_should_fail = False
+    fake_aws_clients["s3"].bucket_objects.setdefault("b", {})["p/_placeholder"] = b""
+    ccm.ensure_s3_prefix(fake_aws_clients["s3"], "b", "p")
+    # put not called (only the existing entry present, no size change tracked here, but
+    # we can prove no double-write by clearing first then calling with head success).
+    fake_aws_clients["s3"].bucket_objects["b"].clear()
+    fake_aws_clients["s3"].bucket_objects["b"]["p/_placeholder"] = b""
+    s3_put_count_before = len(fake_aws_clients["s3"].bucket_objects["b"])
+    ccm.ensure_s3_prefix(fake_aws_clients["s3"], "b", "p")
+    assert len(fake_aws_clients["s3"].bucket_objects["b"]) == s3_put_count_before
+
+
+# ---------------------------------------------------------------------------
+# trigger_aggregator — both branches.
+# ---------------------------------------------------------------------------
+
+
+def test_trigger_aggregator_lambda_branch(fake_aws_clients):
+    out = ccm.trigger_aggregator(
+        campaign_id="cid",
+        s3_bucket="bucket-x",
+        s3_prefix="prefix-x",
+        aggregator_function_name="agg-fn",
+    )
+    assert out == "s3://bucket-x/prefix-x/campaigns/cid/results/"
+    lambda_client = fake_aws_clients["lambda"]
+    lambda_client.invoke.assert_called_once()
+    kwargs = lambda_client.invoke.call_args.kwargs
+    assert kwargs["FunctionName"] == "agg-fn"
+
+
+def test_trigger_aggregator_no_function_returns_results_uri(fake_aws_clients):
+    out = ccm.trigger_aggregator(
+        campaign_id="cid", s3_bucket="b", s3_prefix="p"
+    )
+    assert out.startswith("s3://b/p/campaigns/cid/results/")
+
+
+# ---------------------------------------------------------------------------
+# _resolve_state_store — branches covering "auto / memory / dynamo / unknown".
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_state_store_memory(monkeypatch):
+    monkeypatch.setenv("FLUXION_STATE_STORE", "memory")
+    store = ccm._resolve_state_store("memory")
+    assert store is not None
+    # ``backend_name`` is exposed as a property/attribute, not a callable, on
+    # some StateStore implementations; the canonical interface is duck-typed,
+    # so just check the type.
+    assert store.__class__.__name__ in {"InMemoryStateStore", "MemoryStateStore"}
+
+
+def test_resolve_state_store_auto_falls_back_to_none(monkeypatch):
+    monkeypatch.delenv("FLUXION_STATE_STORE", raising=False)
+    monkeypatch.delenv("FLUXION_CAMPAIGN_TABLE", raising=False)
+    monkeypatch.delenv("FLUXION_REDIS_URL", raising=False)
+    assert ccm._resolve_state_store("auto") is None
+
+
+def test_resolve_state_store_unknown_returns_none(monkeypatch):
+    """An unrecognised selection yields None (the no-state-store fallback)."""
+    # Use a string the dispatcher doesn't know, regardless of env state.
+    monkeypatch.delenv("FLUXION_STATE_STORE", raising=False)
+    monkeypatch.delenv("FLUXION_CAMPAIGN_TABLE", raising=False)
+    monkeypatch.delenv("FLUXION_REDIS_URL", raising=False)
+    assert ccm._resolve_state_store("terraform") is None
+
+
+def test_resolve_state_store_auto_redis_when_redis_url(monkeypatch):
+    """Auto-dispatch should fall through to redis when ``FLUXION_REDIS_URL`` is set."""
+    monkeypatch.delenv("FLUXION_STATE_STORE", raising=False)
+    monkeypatch.delenv("FLUXION_CAMPAIGN_TABLE", raising=False)
+    monkeypatch.setenv("FLUXION_REDIS_URL", "redis://localhost:6379/0")
+    # The redis backend construction may fail without a server; the helper
+    # catches that and returns None — both outcomes prove the code path.
+    assert ccm._resolve_state_store("auto") is None or \
+        ccm._resolve_state_store("auto").__class__.__name__ == "RedisStateStore"

--- a/scripts/cloud_campaign_manager.py
+++ b/scripts/cloud_campaign_manager.py
@@ -322,13 +322,16 @@ def create_campaign(
     s3_bucket: str,
     s3_prefix: str,
     sns_topic_arn: Optional[str] = None,
-<<<<<<< HEAD
     webhook_url: Optional[str] = None,
-=======
     email_config: Optional[dict] = None,
->>>>>>> 1d0e1c8 (feat: resolve #1789 — email notification fallback for campaign completion)
 ) -> CampaignState:
-    """Create a new campaign and upload initial state to S3."""
+    """Create a new campaign and upload initial state to S3.
+
+    Notification channels (any combination, all optional):
+        - ``sns_topic_arn``: AWS SNS topic ARN
+        - ``webhook_url``:   generic webhook endpoint (Issue #1788 / T7.4)
+        - ``email_config``:  transactional email config (Issue #1789 / T7.5)
+    """
     clients = get_aws_clients()
 
     campaign_id = f"fluxion-{uuid.uuid4().hex[:12]}"
@@ -397,12 +400,9 @@ def create_campaign(
         work_units=work_units,
         status="created",
         start_time=datetime.now(timezone.utc).isoformat(),
-<<<<<<< HEAD
         webhook_url=webhook_url,
         sns_topic_arn=sns_topic_arn,
-=======
         email_config=email_config,
->>>>>>> 1d0e1c8 (feat: resolve #1789 — email notification fallback for campaign completion)
     )
 
     state_uri = f"s3://{s3_bucket}/{s3_prefix}/campaigns/{campaign_id}/state.json"
@@ -418,14 +418,11 @@ def create_campaign(
 
     if sns_topic_arn:
         print(f"[*] SNS notifications will be sent to: {sns_topic_arn}")
-<<<<<<< HEAD
     if webhook_url:
         print(f"[*] Webhook notifications will be sent to: {webhook_url}")
-=======
     if email_config and email_config.get("to"):
         recipients = ", ".join(email_config["to"])
         print(f"[*] Email notifications will be sent to: {recipients}")
->>>>>>> 1d0e1c8 (feat: resolve #1789 — email notification fallback for campaign completion)
 
     return state
 
@@ -578,35 +575,6 @@ def wait_for_completion(
         time.sleep(poll_interval)
 
 
-<<<<<<< HEAD
-def build_completion_payload(
-    state: CampaignState, s3_bucket: str, s3_prefix: str
-) -> dict[str, Any]:
-    """Build the JSON payload sent on completion (webhook + SNS body).
-
-    Includes the campaign ID and the result location so downstream
-    consumers (CI bots, dashboards, email fallback T7.5) can fetch the
-    aggregated output without inspecting S3 directly.
-    """
-    region = os.environ.get("AWS_REGION", "us-east-1")
-    results_uri = (
-        f"https://{s3_bucket}.s3.{region}.amazonaws.com/"
-        f"{s3_prefix}/campaigns/{state.campaign_id}/results/"
-    )
-    return {
-        "campaign_id": state.campaign_id,
-        "status": state.status,
-        "start_time": state.start_time,
-        "end_time": datetime.now(timezone.utc).isoformat(),
-        "total_runs": len(state.work_units),
-        "completed_runs": state.completed_units,
-        "failed_runs": state.failed_units,
-        "best_mae": state.best_mae,
-        "best_parameters": state.best_parameters,
-        "results_uri": results_uri,
-    }
-
-
 def send_webhook_notification(
     state: CampaignState,
     s3_bucket: str,
@@ -652,7 +620,8 @@ def send_webhook_notification(
             file=sys.stderr,
         )
         return False
-=======
+
+
 def send_email_notification(
     state: CampaignState,
     s3_bucket: str,
@@ -677,9 +646,6 @@ def send_email_notification(
     any transport / non-2xx failure. Failures are logged but never raised.
     """
     try:
-        import urllib.error
-        import urllib.request
-
         payload = build_completion_payload(state, s3_bucket, s3_prefix)
         subject = render_email_subject(payload)
         body = render_email_body(payload, email_config.get("download_url_override"))
@@ -725,11 +691,12 @@ def send_completion_notification(
     s3_bucket: str,
     s3_prefix: str,
     sns_topic_arn: Optional[str] = None,
+    webhook_url: Optional[str] = None,
     email_config: Optional[dict] = None,
 ) -> None:
-    """Send completion notification via SNS and/or email.
+    """Send completion notification via any combination of SNS, webhook, email.
 
-    Both channels are optional; at least one must be configured. The function
+    All channels are optional; at least one must be configured. The function
     is idempotent — repeated calls are no-ops once ``state.notification_sent``
     is set, mirroring the Rust coordinator (see
     ``src/api/email_notification.rs`` and Issue #1788 / T7.4 + #1789 / T7.5).
@@ -738,15 +705,21 @@ def send_completion_notification(
         print("[*] Notification already sent, skipping")
         return
 
-    if not sns_topic_arn and not email_config:
+    if not sns_topic_arn and not webhook_url and not email_config:
         print(
             "[WARN] No notification channel configured "
-            "(set --sns-topic or --email-to)",
+            "(set --sns-topic, --webhook-url, or --email-to)",
             file=sys.stderr,
         )
         return
 
     payload = build_completion_payload(state, s3_bucket, s3_prefix)
+
+    webhook_delivered = True
+    if webhook_url:
+        webhook_delivered = send_webhook_notification(
+            state, s3_bucket, s3_prefix, webhook_url
+        )
 
     if email_config:
         send_email_notification(state, s3_bucket, s3_prefix, email_config)
@@ -765,59 +738,11 @@ def send_completion_notification(
             print(f"[*] SNS notification sent to: {sns_topic_arn}")
         except Exception as exc:  # pragma: no cover - transport errors
             print(f"[WARN] SNS publish failed: {exc}", file=sys.stderr)
->>>>>>> 1d0e1c8 (feat: resolve #1789 — email notification fallback for campaign completion)
 
-
-def send_completion_notification(
-    state: CampaignState,
-    s3_bucket: str,
-    s3_prefix: str,
-    sns_topic_arn: Optional[str] = None,
-    webhook_url: Optional[str] = None,
-) -> None:
-    """Send completion notification via SNS and/or webhook.
-
-    At least one channel (sns_topic_arn or webhook_url) must be configured.
-    The function is idempotent — repeated calls are no-ops once
-    ``state.notification_sent`` is set.
-    """
-    if state.notification_sent:
-        print("[*] Notification already sent, skipping")
-        return
-
-    if not sns_topic_arn and not webhook_url:
-        print(
-            "[WARN] No notification channel configured "
-            "(set --sns-topic or --webhook-url)",
-            file=sys.stderr,
-        )
-        return
-
-    webhook_delivered = True
-    if webhook_url:
-        webhook_delivered = send_webhook_notification(
-            state, s3_bucket, s3_prefix, webhook_url
-        )
-
-    if sns_topic_arn:
-        try:
-            clients = get_aws_clients()
-            payload = build_completion_payload(state, s3_bucket, s3_prefix)
-            clients["sns"].publish(
-                TopicArn=sns_topic_arn,
-                Subject=(
-                    f"Fluxion Campaign {state.campaign_id} "
-                    f"{'Completed' if state.status == 'completed' else 'Failed'}"
-                ),
-                Message=json.dumps(payload, indent=2),
-            )
-            print(f"[*] SNS notification sent to: {sns_topic_arn}")
-        except Exception as exc:  # pragma: no cover - transport errors
-            print(f"[WARN] SNS publish failed: {exc}", file=sys.stderr)
-
-    # Mark notification as attempted once both configured channels have
-    # been tried. SNS failures are best-effort; webhook failure leaves
-    # notification_sent False so a follow-up ``--action notify`` retries.
+    # Mark notification as attempted once all configured channels have
+    # been tried. SNS/email failures are best-effort; webhook failure
+    # leaves notification_sent False so a follow-up ``--action notify``
+    # retries.
     state.notification_sent = webhook_delivered
     update_campaign_state(state, s3_bucket, s3_prefix)
 
@@ -865,11 +790,11 @@ def build_email_config_from_args(args) -> Optional[dict]:
         "to": recipients,
         "cc": cc,
     }
-    if args.email_api_endpoint:
+    if getattr(args, "email_api_endpoint", None):
         config["api_endpoint"] = args.email_api_endpoint
-    if args.email_api_auth:
+    if getattr(args, "email_api_auth", None):
         config["api_auth_header"] = args.email_api_auth
-    if args.email_download_url:
+    if getattr(args, "email_download_url", None):
         config["download_url_override"] = args.email_download_url
     return config
 
@@ -980,7 +905,6 @@ def main() -> int:
         help="Poll interval in seconds for wait action",
     )
     parser.add_argument(
-<<<<<<< HEAD
         "--state-store",
         type=str,
         choices=["dynamodb", "redis", "memory", "auto"],
@@ -989,7 +913,9 @@ def main() -> int:
             "State-store backend for per-task progress (T7.3). "
             "'auto' uses FLUXION_STATE_STORE when set, otherwise falls "
             "back to legacy S3 listing."
-=======
+        ),
+    )
+    parser.add_argument(
         "--email-from",
         type=str,
         default=os.environ.get("FLUXION_EMAIL_FROM"),
@@ -1033,7 +959,6 @@ def main() -> int:
         help=(
             "Optional pre-signed download URL that overrides the default "
             "S3 results URI in the email body. Useful for private buckets."
->>>>>>> 1d0e1c8 (feat: resolve #1789 — email notification fallback for campaign completion)
         ),
     )
     args = parser.parse_args()
@@ -1069,20 +994,14 @@ def main() -> int:
             samples_per_param=args.samples,
         )
 
-<<<<<<< HEAD
-=======
         email_config = build_email_config_from_args(args)
->>>>>>> 1d0e1c8 (feat: resolve #1789 — email notification fallback for campaign completion)
         state = create_campaign(
             config,
             s3_bucket,
             s3_prefix,
             sns_topic_arn=args.sns_topic,
-<<<<<<< HEAD
             webhook_url=args.webhook_url,
-=======
             email_config=email_config,
->>>>>>> 1d0e1c8 (feat: resolve #1789 — email notification fallback for campaign completion)
         )
 
         print(f"[*] Campaign created: {state.campaign_id}")
@@ -1187,27 +1106,17 @@ def main() -> int:
         print(f"    Failed: {state.failed_units}")
 
         if state.status in ("completed", "failed"):
-<<<<<<< HEAD
+            email_config = build_email_config_from_args(args) or state.email_config
             notify_sns = args.sns_topic or state.sns_topic_arn
             notify_webhook = args.webhook_url or state.webhook_url
-            if notify_sns or notify_webhook:
-=======
-            email_config = build_email_config_from_args(args) or state.email_config
-            if (args.sns_topic or state.notification_sent is False) and (
-                args.sns_topic or email_config
-            ):
->>>>>>> 1d0e1c8 (feat: resolve #1789 — email notification fallback for campaign completion)
+            if notify_sns or notify_webhook or email_config:
                 send_completion_notification(
                     state,
                     s3_bucket,
                     s3_prefix,
-<<<<<<< HEAD
                     sns_topic_arn=notify_sns,
                     webhook_url=notify_webhook,
-=======
-                    sns_topic_arn=args.sns_topic,
                     email_config=email_config,
->>>>>>> 1d0e1c8 (feat: resolve #1789 — email notification fallback for campaign completion)
                 )
 
         return 0
@@ -1235,34 +1144,23 @@ def main() -> int:
             print(f"[ERROR] Campaign {args.campaign_id} not found")
             return 1
 
-<<<<<<< HEAD
+        email_config = build_email_config_from_args(args) or state.email_config
         notify_sns = args.sns_topic or state.sns_topic_arn
         notify_webhook = args.webhook_url or state.webhook_url
-        if not notify_sns and not notify_webhook:
+        if not notify_sns and not notify_webhook and not email_config:
             parser.error(
                 "At least one notification channel is required: "
-                "pass --sns-topic or --webhook-url, or persist them in "
-=======
-        email_config = build_email_config_from_args(args) or state.email_config
-        if not args.sns_topic and not email_config:
-            parser.error(
-                "At least one notification channel is required: "
-                "pass --sns-topic or --email-to, or persist them in "
->>>>>>> 1d0e1c8 (feat: resolve #1789 — email notification fallback for campaign completion)
-                "the campaign state at creation time."
+                "pass --sns-topic, --webhook-url, or --email-to, "
+                "or persist them in the campaign state at creation time."
             )
 
         send_completion_notification(
             state,
             s3_bucket,
             s3_prefix,
-<<<<<<< HEAD
             sns_topic_arn=notify_sns,
             webhook_url=notify_webhook,
-=======
-            sns_topic_arn=args.sns_topic,
             email_config=email_config,
->>>>>>> 1d0e1c8 (feat: resolve #1789 — email notification fallback for campaign completion)
         )
 
         return 0

--- a/scripts/conftest.py
+++ b/scripts/conftest.py
@@ -1,0 +1,376 @@
+# scripts/conftest.py
+# -------------------
+# Shared pytest fixtures and path configuration for the OSimFlow Python
+# orchestration test suite (Issue #1847).
+#
+# Goals:
+#   * Make `scripts/` importable without per-test sys.path gymnastics.
+#   * Provide deterministic, no-I/O default parameter specs.
+#   * Provide hermetic fakes for the AWS / cloud modules so tests do not
+#     require credentials, network, DynamoDB, Redis, or K8s.
+#
+# Coverage must remain ≥60% line coverage on each of:
+#   - scripts/cloud_campaign_manager.py
+#   - scripts/autonomous_parameter_sweep.py
+#   - scripts/ashrae_benchmark_harness.py
+
+from __future__ import annotations
+
+import os
+import sys
+import urllib.error
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterator
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup: make `scripts/` importable.
+# ---------------------------------------------------------------------------
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Environment hygiene.
+# ---------------------------------------------------------------------------
+
+# Prevent any test from accidentally reaching the real cloud: clear every
+# Fluxion/Cloud env var that would trigger a live roundtrip.  Tests that
+# need to exercise env-driven code paths should set them locally via
+# `monkeypatch.setenv` so the cleanup is automatic.
+_CLOUD_ENV_VARS = (
+    "FLUXION_S3_BUCKET",
+    "FLUXION_S3_PREFIX",
+    "FLUXION_SNS_TOPIC_ARN",
+    "FLUXION_WEBHOOK_URL",
+    "FLUXION_EMAIL_FROM",
+    "FLUXION_EMAIL_TO",
+    "FLUXION_EMAIL_CC",
+    "FLUXION_EMAIL_API_ENDPOINT",
+    "FLUXION_EMAIL_API_AUTH",
+    "FLUXION_EMAIL_DOWNLOAD_URL",
+    "FLUXION_STATE_STORE",
+    "FLUXION_CAMPAIGN_TABLE",
+    "FLUXION_REDIS_URL",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "AWS_REGION",
+    "DWAVE_API_TOKEN",
+)
+
+
+@pytest.fixture(autouse=True)
+def _scrub_cloud_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure no test leaks real AWS / DWAVE / state-store credentials."""
+    for var in _CLOUD_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Stub AWS clients and S3/DynamoDB/Redis backends.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeS3Client:
+    """In-memory S3 mock covering the operations used by cloud_campaign_manager."""
+
+    bucket_objects: dict[str, dict[str, bytes]] = field(default_factory=dict)
+    listed_objects: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+    head_should_fail: bool = False
+
+    def put_object(self, Bucket: str, Key: str, Body: bytes = b"", **_: Any) -> dict[str, Any]:
+        self.bucket_objects.setdefault(Bucket, {})[Key] = (
+            Body if isinstance(Body, (bytes, bytearray)) else str(Body).encode("utf-8")
+        )
+        return {"ETag": "\"deadbeef\""}
+
+    def get_object(self, Bucket: str, Key: str, **_: Any) -> dict[str, Any]:
+        body = self.bucket_objects.get(Bucket, {}).get(Key)
+        if body is None:
+            # ``get_campaign_state`` only suppresses ClientError when the
+            # Error.Code is exactly the string ``"404"``.  Real S3 returns
+            # ``"NoSuchKey"``; we mirror the literal that the helper checks
+            # for.  Other tests can patch the bucket_objects to simulate
+            # real ``NoSuchKey`` propagation.
+            raise _make_client_error_for_get(404, "404", Key)
+        return {"Body": _FakeBody(body)}
+
+    def head_object(self, Bucket: str, Key: str, **_: Any) -> dict[str, Any]:
+        if self.head_should_fail:
+            raise _make_client_error(404, "NotFound", Key)
+        if Key not in self.bucket_objects.get(Bucket, {}):
+            raise _make_client_error(404, "NoSuchKey", Key)
+        return {}
+
+    def get_paginator(self, name: str) -> "_FakeS3Paginator":
+        assert name == "list_objects_v2"
+        return _FakeS3Paginator(self.listed_objects)
+
+
+@dataclass
+class _FakeBody:
+    data: bytes
+
+    def read(self) -> bytes:
+        return self.data
+
+
+@dataclass
+class _FakeS3Paginator:
+    listed_objects: dict[str, list[dict[str, Any]]]
+
+    def paginate(self, Bucket: str, Prefix: str, **_):  # noqa: A003  (boto3 kw)
+        objs = self.listed_objects.get(Bucket, [])
+        filtered = [o for o in objs if o.get("Key", "").startswith(Prefix)]
+        yield {"Contents": filtered}
+
+
+class _FakeSNSClient:
+    def __init__(self) -> None:
+        self.published: list[dict[str, Any]] = []
+
+    def publish(self, **kwargs: Any) -> dict[str, Any]:
+        self.published.append(kwargs)
+        return {"MessageId": "fake-message-id"}
+
+
+def _make_client_error(code: int, error_code: str, key: str) -> Exception:
+    from botocore.exceptions import ClientError
+
+    return ClientError(
+        {"Error": {"Code": error_code, "Message": f"missing {key}"}, "ResponseMetadata": {"HTTPStatusCode": code}},
+        "HeadObject",
+    )
+
+
+def _make_client_error_for_get(code: int, error_code: str, key: str) -> Exception:
+    """Like ``_make_client_error`` but stamps the operation as ``GetObject``."""
+    from botocore.exceptions import ClientError
+
+    return ClientError(
+        {"Error": {"Code": error_code, "Message": f"missing {key}"}, "ResponseMetadata": {"HTTPStatusCode": code}},
+        "GetObject",
+    )
+
+
+@pytest.fixture
+def fake_aws_clients(monkeypatch: pytest.MonkeyPatch):
+    """Return a dict of fake AWS clients and patch ``get_aws_clients`` to use them.
+
+    The cloud_campaign_manager code calls ``get_aws_clients()`` at the top
+    of every public function.  We override the helper to return our dict so
+    tests never touch the real boto3 session.
+    """
+    s3 = _FakeS3Client()
+    sns = _FakeSNSClient()
+    clients = {
+        "s3": s3,
+        "sns": sns,
+        "dynamodb": MagicMock(name="dynamodb"),
+        "sts": MagicMock(name="sts"),
+        "lambda": MagicMock(name="lambda"),
+    }
+
+    # `cloud_campaign_manager.py` is imported as a top-level module — there is
+    # no `scripts` package (no `scripts/__init__.py`).  Patch the symbol in
+    # the module's own namespace.
+    import cloud_campaign_manager as _ccm
+
+    monkeypatch.setattr(_ccm, "get_aws_clients", lambda: clients)
+    return clients
+
+
+# ---------------------------------------------------------------------------
+# state_store: in-memory backend reused across tests (no Redis / DynamoDB).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def in_memory_state_store():
+    """Construct an InMemoryStateStore.  Requires the local state_store module."""
+    from state_store import InMemoryStateStore
+
+    return InMemoryStateStore()
+
+
+@pytest.fixture
+def populated_state_store(in_memory_state_store):
+    """InMemoryStateStore pre-populated with 5 work units: 3 completed, 1 failed, 1 pending."""
+    from state_store import TaskState, TaskStatus
+
+    store = in_memory_state_store
+    for i, status in enumerate(
+        [TaskStatus.COMPLETED, TaskStatus.COMPLETED, TaskStatus.COMPLETED,
+         TaskStatus.FAILED, TaskStatus.PENDING]
+    ):
+        wu = f"wu-{i:04d}"
+        store.set_state(
+            TaskState(
+                work_unit_id=wu,
+                status=status,
+                campaign_id="fluxion-camp-test",
+                metrics={"heating_mae": 1.2 + i * 0.1} if status == TaskStatus.COMPLETED else {},
+                timestamp="2026-01-01T00:00:00Z",
+            )
+        )
+    return store
+
+
+# ---------------------------------------------------------------------------
+# urlopen stub (used by webhook + email notification paths).
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeHTTPResponse:
+    status: int = 200
+
+    def __enter__(self):  # noqa: D401 - context manager protocol
+        return self
+
+    def __exit__(self, *exc):  # noqa: D401 - context manager protocol
+        return False
+
+    def getcode(self) -> int:
+        return self.status
+
+
+@pytest.fixture
+def fake_urlopen(monkeypatch: pytest.MonkeyPatch):
+    """Patch ``urllib.request.urlopen`` with a callable factory.
+
+    Usage:
+        fake_urlopen(status=500)             # always returns 500
+        fake_urlopen(raises=urllib.error.URLError("boom"))  # raises
+        fake_urlopen(capture=callback)        # callback(request) -> response
+    """
+    state: dict[str, Any] = {"calls": []}
+
+    def _install(status: int = 200, raises: Exception | None = None,
+                 capture: Any | None = None) -> _FakeHTTPResponse:
+        if capture is not None:
+            def _factory(request, *args, **kwargs):
+                state["calls"].append(request)
+                return capture(request)
+        elif raises is not None:
+            def _factory(request, *args, **kwargs):
+                state["calls"].append(request)
+                raise raises
+        else:
+            def _factory(request, *args, **kwargs):
+                state["calls"].append(request)
+                return _FakeHTTPResponse(status=status)
+        monkeypatch.setattr("urllib.request.urlopen", _factory)
+        return _FakeHTTPResponse(status=status)
+
+    state["install"] = _install
+    state["calls"] = []
+    return state
+
+
+# ---------------------------------------------------------------------------
+# subprocess stub (used by sweep + harness scripts).
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeCompletedProcess:
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+
+
+@pytest.fixture
+def fake_subprocess(monkeypatch: pytest.MonkeyPatch):
+    """Patch ``subprocess.run`` / ``subprocess.check_output`` for OSimFlow scripts.
+
+    Usage:
+        fake_subprocess(run_return=_FakeCompletedProcess(0, stdout="...", stderr=""))
+        fake_subprocess(check_output_return="abc1234")
+    """
+    state: dict[str, Any] = {"run_calls": [], "check_output_calls": []}
+
+    def _install(
+        run_return: _FakeCompletedProcess | Exception | None = None,
+        check_output_return: str | bytes | Exception | None = None,
+    ) -> None:
+        def _fake_run(*args, **kwargs):
+            state["run_calls"].append((args, kwargs))
+            if isinstance(run_return, Exception):
+                raise run_return
+            return run_return if run_return is not None else _FakeCompletedProcess(0, "", "")
+
+        def _fake_check_output(*args, **kwargs):
+            state["check_output_calls"].append((args, kwargs))
+            if isinstance(check_output_return, Exception):
+                raise check_output_return
+            return check_output_return if check_output_return is not None else ""
+
+        monkeypatch.setattr("subprocess.run", _fake_run)
+        monkeypatch.setattr("subprocess.check_output", _fake_check_output)
+
+    state["install"] = _install
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Sweep / campaign spec fixtures.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fluxion_model_spec() -> dict[str, Any]:
+    """A deterministic FluxionModel spec dict for sweep/aggregation tests."""
+    return {
+        "case_id": "600",
+        "sweep_type": "random",
+        "parameters": [
+            {"name": "R_value", "default": 2.0, "min": 1.0, "max": 5.0, "step": 0.5, "unit": "m²K/W"},
+            {"name": "wall_thickness", "default": 0.15, "min": 0.05, "max": 0.30,
+             "step": 0.05, "unit": "m"},
+        ],
+        "max_iterations": 4,
+        "samples_per_param": 4,
+        "tolerance_mae": 5.0,
+    }
+
+
+@pytest.fixture
+def temp_trace_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A scratch trace directory; rerouted .sdd/traces/diagnostic to tmp via cwd."""
+    trace = tmp_path / ".sdd" / "traces" / "diagnostic"
+    trace.mkdir(parents=True, exist_ok=True)
+    monkeypatch.chdir(tmp_path)
+    return trace
+
+
+@pytest.fixture
+def temp_campaign_db(tmp_path: Path) -> Path:
+    """Scratch location to mimic a campaign-state DB file (we use JSON here)."""
+    db = tmp_path / "campaign_state.json"
+    db.write_text("{}")
+    return db
+
+
+# ---------------------------------------------------------------------------
+# Wrapper helpers for common assertion patterns.
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def raises_in_env(env_var: str) -> Iterator[None]:
+    """Assert that ``os.environ.get(env_var)`` returns falsy in the with-block."""
+    saved = os.environ.pop(env_var, None)
+    try:
+        yield
+    finally:
+        if saved is not None:
+            os.environ[env_var] = saved

--- a/scripts/pytest.ini
+++ b/scripts/pytest.ini
@@ -1,0 +1,21 @@
+[pytest]
+# OSimFlow Python orchestration pytest configuration (Issue #1847).
+# Sibling to the root pyproject.toml [tool.pytest.ini_options] which
+# points at the Rust integration tests under `tests/`.
+testpaths = scripts/ci
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function
+addopts =
+    -ra
+    --strict-markers
+    --strict-config
+    --tb=short
+    --cov=scripts
+    --cov-report=term-missing
+    --cov-report=html:.agents/coverage/python-osimflow
+filterwarnings =
+    ignore::DeprecationWarning:botocore.*
+    ignore::DeprecationWarning:state_store

--- a/scripts/requirements-test.txt
+++ b/scripts/requirements-test.txt
@@ -1,0 +1,13 @@
+# Test dependencies for OSimFlow Python orchestration scripts (Issue #1847).
+# Keep in sync with the root `requirements-dev.txt`.
+
+# Core test framework + plugins referenced by scripts/pytest.ini
+pytest>=8.0.0
+pytest-asyncio>=0.23.0
+pytest-cov>=4.1.0
+
+# State store imports `boto3` defensively (try-import) at module-load time.
+# Pull it in for CI so the conditional import resolves to a real client
+# that we can mock, instead of the `None` fallback.
+boto3>=1.34.0
+botocore>=1.34.0


### PR DESCRIPTION
Closes #1847

Establishes pytest infrastructure for `scripts/` orchestration Python and adds baseline unit tests for cloud_campaign_manager.py, autonomous_parameter_sweep.py, and ashrae_benchmark_harness.py. Adds CI workflow that gates on Python 3.10+ with all externals mocked.

Test coverage: ≥60% on each of the three target files. No new cloud/Redis/K8s dependencies.

### Coverage Achieved

| File | Coverage |
| ---- | -------- |
| scripts/ashrae_benchmark_harness.py | 84% |
| scripts/autonomous_parameter_sweep.py | 84% |
| scripts/cloud_campaign_manager.py | 68% |

104 pytest tests pass locally with `pytest scripts/ci/ -c scripts/pytest.ini`.

### What's in this PR

- **Pytest scaffolding**
  - `scripts/pytest.ini` — pytest-asyncio auto, pytest-cov on scripts/, scripts/ci testpaths
  - `scripts/conftest.py` — shared fixtures (`fake_aws_clients`, `populated_state_store`, `fake_urlopen`, `fake_subprocess`, `fluxion_model_spec`, `temp_trace_dir`, `_scrub_cloud_env`)
  - `scripts/README.md` — documents the layout + how to run
  - `scripts/requirements-test.txt` — pytest, pytest-asyncio, pytest-cov, boto3

- **Tests** (`scripts/ci/`)
  - `test_cloud_campaign_manager.py` — campaign-state round-trip, sweep-config validation, mocked S3/Nomad/aggregator flows, webhook/email/SNS notification paths, idempotency, transport errors, state-store aggregation.
  - `test_autonomous_parameter_sweep.py` — parameter-space enumeration (grid + random), early-termination logic, result aggregation (JSONL + CSV), divergence-report markdown, subprocess timeout / error handling.
  - `test_ashrae_benchmark_harness.py` — benchmark-config parsing, regex edge cases (**`inf%`, leading whitespace**, missing summary), report rendering, GitHub-Actions step-summary writer.

- **CI**
  - `.github/workflows/python-tests.yml` — Ubuntu matrix Python 3.10 / 3.11 / 3.12 / 3.13
  - pip cache keyed on `requirements-dev.txt + scripts/requirements-test.txt`
  - Defensive `unset DWAVE_API_TOKEN FLUXION_REDIS_URL FLUXION_CAMPAIGN_TABLE ...`
  - Inline `coverage.xml` post-check enforces ≥60% on each of the three target files
  - Uploads coverage + JUnit XML artifacts per matrix entry

### Notes

`scripts/cloud_campaign_manager.py` had 11 unresolved git-merge-conflict markers (`<<<<<<< HEAD` / `=======` / `>>>>>>> 1d0e1c8`) at branch-creation time. The file would not even parse. Resolved by keeping BOTH the webhook (HEAD) and email (1d0e1c8) implementations; `send_completion_notification` now handles both channels. `create_campaign` also accepts `webhook_url` and `email_config` simultaneously. The 68% coverage already exceeds the 60% threshold.