### PR TITLE
test(hvac): resolve #1754 — scaffold HVAC-BESTEST test module + CI wiring

### DIFF
--- a/.github/workflows/hvac_bestest_validation.yml
+++ b/.github/workflows/hvac_bestest_validation.yml
@@ -44,6 +44,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
+      - name: Run HVAC BESTEST scaffold
+        run: cargo test --test hvac_bestest
+
       - name: Run HVAC BESTEST Validation Tests
         id: validation
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ cargo build --release                       # primary build (lto="thin", opt-lev
 cargo test                                  # all unit tests
 cargo test -p fluxion <test_name>           # single test (e.g. multi_zone_n_zone_network)
 cargo test --test ashrae_140_validation     # ASHRAE 140 validation suite
+cargo test --test hvac_bestest               # HVAC BESTEST RP-865 scaffold/suite
 cargo test --profile ci                     # FAST CI build (opt-level=1, codegen-units=256) — use for iteration
 LOOM=1 cargo test --features loom           # concurrency/race-condition tests (needs ~32GB; issue #1065)
 cargo test --features cuda --test surrogate_cuda_smoke  # GPU smoke (skips on CPU-only)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1011,6 +1011,15 @@ Each module tested independently against E+ reference data:
 Reconnect modules, run ASHRAE 140 system tests. Multi-node HVAC validation (Case 900) is in place; free-floating calibration landed in #1154 (CTF stability, EPW weather, ISO 13790 thermal mass). Empirical corrections removed in #1138.
 If a system test fails, the individual module tests pinpoint which module is wrong.
 
+#### HVAC BESTEST validation scaffold (#1754)
+
+`tests/validation/hvac_bestest/mod.rs` is the integration-test root for the
+RP-865-derived HVAC BESTEST track. It keeps analytical cases, comparative cases,
+and reference-data loading in separate test-only modules. The initial target is
+intentionally empty and runs with `cargo test --test hvac_bestest`; follow-on issues
+own all case definitions, reference bounds, and acceptance tolerances. This scaffold
+does not alter the production validation module or any physics dependency edge.
+
 ### Phase 3: ML Surrogate Drop-In
 Once physics is validated, train ML surrogates on physics outputs.
 Surrogates must match physics within 2% on held-out data. v3.0 surrogate training and ONNX export landed in #1139.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -419,6 +419,13 @@ name = "validation_night_ventilation_air_side"
 path = "tests/validation/night_ventilation_air_side.rs"
 harness = true
 
+# Issue #1754 / Plan T1.1 — HVAC BESTEST RP-865 validation scaffold.
+# Follow-on issues add analytical and comparative cases to this target.
+[[test]]
+name = "hvac_bestest"
+path = "tests/validation/hvac_bestest/mod.rs"
+harness = true
+
 [[test]]
 name = "validation_empirical"
 path = "tests/validation/empirical_validation_test.rs"

--- a/tests/validation/hvac_bestest/README.md
+++ b/tests/validation/hvac_bestest/README.md
@@ -1,0 +1,61 @@
+# HVAC BESTEST validation scaffold
+
+This directory is the integration-test home for Fluxion's HVAC BESTEST work. Issue
+#1754 provides module and CI wiring only: no case inputs, reference bounds,
+acceptance tolerances, or equipment calculations are implemented here.
+
+## Taxonomy
+
+HVAC BESTEST distinguishes validation methods by the source of truth:
+
+- **Analytical verification** compares a program with a known analytical or
+  generally accepted numerical solution under tightly controlled boundary
+  conditions. For HVAC BESTEST, these are not free-floating envelope tests: the
+  HVAC equipment or air-distribution system is active and the solution checks
+  mass and energy balances, coil loads, fan heat, and related state points.
+- **Comparative testing** compares a program with itself or with qualified,
+  independently implemented reference programs when no analytical truth standard
+  is available. Comparative ranges are evidence, not physical constants, and must
+  retain source/version provenance.
+
+Envelope-only and free-floating cases remain in the ASHRAE Standard 140 harness;
+they validate the building loads presented to HVAC models but are not RP-865 HVAC
+case identifiers.
+
+## Case families
+
+| Family | Method | Scope | Planned module |
+|---|---|---|---|
+| `AE101`–`AE445` | Analytical / quasi-analytical | RP-865-derived airside HVAC equipment and distribution-system configurations | `analytical.rs` |
+| `E100`–`E200` | Analytical | Companion HVAC BESTEST unitary space-cooling equipment cases; dry-coil cases `E100`–`E140` and wet-coil cases `E150`–`E200` | `analytical.rs` |
+| Future dynamic cases | Comparative | Cases whose dynamic boundary conditions prevent a closed-form truth solution | `comparative.rs` |
+
+ASHRAE Standard 140 building-fabric identifiers such as Cases 600 and 900 are
+intentionally excluded from this taxonomy; they remain under the existing envelope
+validation suite.
+
+## Module responsibilities
+
+- `analytical.rs`: analytical and quasi-analytical case runners and assertions.
+- `comparative.rs`: cross-program comparative cases and qualified comparison bands.
+- `reference_data.rs`: typed loaders with publication, version, units, and checksum
+  provenance for RP-865/HVAC BESTEST reference data.
+- `mod.rs`: integration-test target root only.
+
+Follow-on issues must add tests before implementation, preserve moist-air and dry-air
+mass balances, close the sensible/latent energy balance, and avoid invented bounds
+or placeholder correlations.
+
+## Sources
+
+- Neymark et al., *Airside HVAC BESTEST: Adaptation of ASHRAE RP 865 Airside HVAC
+  Equipment Modeling Test Cases for ASHRAE Standard 140, Volume 1: Cases
+  AE101–AE445*, NREL/TP-5500-66000 (2016), DOI 10.2172/1244668.
+- IEA SHC Task 22, *HVAC BESTEST, Volume 1: Cases E100–E200*, Section 1.3
+  (fundamental unitary space-cooling equipment tests and case summary tables).
+
+Run the scaffold with:
+
+```bash
+cargo test --test hvac_bestest
+```

--- a/tests/validation/hvac_bestest/analytical.rs
+++ b/tests/validation/hvac_bestest/analytical.rs
@@ -1,0 +1,5 @@
+//! Analytical HVAC BESTEST case scaffold.
+//!
+//! Future cases belong here when they compare Fluxion outputs with a documented
+//! analytical or quasi-analytical solution. Issue #1754 intentionally registers no
+//! cases and defines no provisional tolerances.

--- a/tests/validation/hvac_bestest/comparative.rs
+++ b/tests/validation/hvac_bestest/comparative.rs
@@ -1,0 +1,5 @@
+//! Comparative HVAC BESTEST case scaffold.
+//!
+//! Future cases belong here when they compare Fluxion with qualified reference
+//! programs for conditions without an analytical truth standard. Issue #1754
+//! intentionally registers no cases and defines no provisional acceptance bounds.

--- a/tests/validation/hvac_bestest/mod.rs
+++ b/tests/validation/hvac_bestest/mod.rs
@@ -1,0 +1,9 @@
+//! HVAC BESTEST RP-865 validation scaffold.
+//!
+//! This integration-test target is intentionally empty for issue #1754. Follow-on
+//! issues will add analytical and comparative cases without coupling reference-data
+//! parsing to the simulation runners.
+
+mod analytical;
+mod comparative;
+mod reference_data;

--- a/tests/validation/hvac_bestest/reference_data.rs
+++ b/tests/validation/hvac_bestest/reference_data.rs
@@ -1,0 +1,4 @@
+//! RP-865 reference-data loader scaffold.
+//!
+//! Follow-on work will add typed, provenance-checked loaders for published bounds
+//! and reference outputs. This scaffold deliberately contains no placeholder data.


### PR DESCRIPTION
Closes #1754

Creates tests/validation/hvac_bestest/ as the home for HVAC BESTEST RP-865 validation. Includes module root, README describing the case taxonomy, and stubs for analytical + comparative sub-modules. Wires a CI no-op job so the pipeline is green from day one. Documents the cargo invocation in AGENTS.md.

## Summary by Sourcery

Introduce an HVAC BESTEST RP-865 validation scaffold and wire it into the test suite and CI without adding any actual validation cases yet.

Enhancements:
- Document the new HVAC BESTEST validation phase and scaffold in the project architecture and testing guidance.

CI:
- Update the HVAC BESTEST CI workflow to run the new scaffold test target so the pipeline remains green.

Documentation:
- Document the HVAC BESTEST validation scaffold layout, taxonomy, and usage, including how to run it via cargo.

Tests:
- Add an empty HVAC BESTEST integration test target with analytical, comparative, and reference-data submodules to host future RP-865 validation cases.