### PR TITLE
feat(measures): resolve #1814 — FluxionMeasure base class + AOT runner CLI

### DIFF
--- a/docs/measures.md
+++ b/docs/measures.md
@@ -1,0 +1,139 @@
+# Fluxion Python Measures — AOT Runner (Issue #1814)
+
+<!-- 7-line summary for AI agents: lines 1-7 -->
+<!-- 1: This document describes the FluxionMeasure Python base class and AOT runner. -->
+<!-- 2: Read it before writing a custom measure or modifying the measures subsystem. -->
+<!-- 3: Key concepts: AOT-only rule, GIL/rayon rationale, snapshot/owned-value lifecycle. -->
+<!-- 4: Companion to docs/bindings.md (memory safety) and ARCHITECTURE.md (module boundaries). -->
+<!-- 5: Stable as of issue #1814 — measures API is feature-frozen pending OSM integration. -->
+<!-- 6: After changes, run `maturin develop` then `pytest tests/python/test_apply_measures_cli.py`. -->
+
+## TL;DR
+
+A Fluxion **measure** is a Python class that mutates a building model **once**, before the Rust simulation engine consumes it. Measures are **AOT (Ahead-of-Time) pre-processors** — they are forbidden from running inside the timestepping loop, because doing so would force the GIL to contend against every Rust rayon worker and serialize the parallel BatchOracle path (>=10k configs/sec on 8 cores).
+
+The runner is the `fluxion apply-measures` CLI. It loads a base model, walks a directory for `FluxionMeasure` subclasses, runs each in sequence, and writes the mutated model back to JSON (or `.msgpack` if `msgpack` is installed).
+
+```bash
+fluxion apply-measures \
+    --model base.json \
+    --measures measures/examples/ \
+    --output model.with_overhangs.json
+```
+
+## The AOT-Only Rule (Non-Negotiable)
+
+The Rust timestepping loop is parallelized via `rayon::par_iter`. If a measure runs *inside* that loop:
+
+1. CPython's GIL serializes all rayon workers — the speedup collapses to 1x.
+2. Every per-step callback pays the cost of acquiring the GIL.
+3. The `BatchOracle.evaluate_population` hot path stops being parallel.
+
+Therefore:
+
+- Measures are pre-processing steps that mutate the model *once*, *before* simulation.
+- The runtime emits a `RuntimeWarning` if a measure detects it is running on a thread named `rayon-*` or `tokio-*`, or when the env var `FLUXION_INSIDE_TIMESTEPPING=1` is set. The warning is informational (does not raise) so that legitimate parallel use cases can opt out.
+- This is enforced by the `_FluxionMeasureMeta` metaclass, which wraps every subclass `apply()` with `_warn_if_inside_timestepping`.
+
+If you need per-step Python callbacks, implement a Rust trait in `src/sim/` instead.
+
+## FluxionMeasure API
+
+```python
+from fluxion import FluxionMeasure
+
+class AddSouthOverhang(FluxionMeasure):
+    name = "AddSouthOverhang"               # optional; defaults to class name
+    description = "Attach overhang to south-facing opaque surfaces."
+
+    def arguments(self) -> list[dict]:
+        """Return the OpenStudio-style argument spec."""
+        return [
+            {"name": "depth",  "type": "double", "default": 1.0, "min": 0.0, "max": 5.0},
+            {"name": "height", "type": "double", "default": 2.5, "min": 0.0, "max": 10.0},
+        ]
+
+    def apply(self, model, arguments: dict) -> None:
+        """Mutate ``model`` in place using parsed ``arguments``."""
+        # Snapshot the model's surfaces (owned values, see docs/bindings.md).
+        surfaces = model.surfaces()
+        for s in surfaces:
+            if s.orientation == fluxion.Orientation.South:
+                s.add_overhang(depth=arguments["depth"], height=arguments["height"])
+        model.set_surfaces(surfaces)  # push back — REQUIRED for persistence
+```
+
+`arguments()` mirrors OpenStudio's `arguments()` method. Each entry is a dict with at minimum `name`, `type` (`string` / `double` / `integer` / `bool` / `choice`), and optional `default`, `min`, `max`, `description`, `choices`. The CLI parses `--measure-args JSON` and merges it with declared defaults via `parse_arguments()`.
+
+## The CLI
+
+```
+fluxion apply-measures
+    --model PATH            Base model JSON or .msgpack
+    --measures DIR          Directory containing FluxionMeasure subclasses
+    --output PATH           Output file (default: model.applied.json)
+    --measure-args PATH     Optional JSON: {measure_name: {arg: value}}
+    --dry-run               Print the plan (measure name, class, args) and exit
+    --list                  List discovered measure classes and exit
+    -v / -vv                Verbosity (warning, info, debug)
+```
+
+Discovery rules:
+
+- Walks `--measures` recursively for `*.py` files.
+- Skips files starting with `_` (e.g. `__init__.py`, `_helpers.py`).
+- Imports each file in a uniquely-named module and collects concrete `FluxionMeasure` subclasses declared in that file.
+- Stable alphabetical order on output.
+
+## Model Serialization
+
+Two formats are supported:
+
+| Format | Extension | Notes |
+|--------|-----------|-------|
+| JSON   | `.json`   | Default; readable, diff-friendly. |
+| msgpack| `.msgpack`| Binary; smaller; requires `pip install msgpack`. Falls back to JSON if not installed. |
+
+The on-disk schema is versioned (`schema_version: "1.0.0"`). It is currently a *round-trip* format for tests and CI smoke checks; the Rust runtime does not yet consume it directly. The full schema is being stabilized in `ARCHITECTURE.md`.
+
+## Memory-Safety Recap
+
+`fluxion.Model` uses the **snapshot / owned-value** contract from issue #1812 (see `docs/bindings.md`):
+
+1. `model.surfaces()` returns a fresh list of owned `Surface` snapshots.
+2. Mutating a snapshot does NOT affect the model.
+3. Call `model.set_surfaces(snapshots)` to push mutations back.
+4. `model.hvac_system()` / `model.set_hvac_system(...)` follow the same pattern.
+
+Not all `HVACSystem` fields round-trip back to the model — see `src/python/model_bindings.rs` for the current ownership story. The `SetHVACCOP` example demonstrates the right pattern (mutate fields that do persist, document the advisory ones).
+
+## Reference Material
+
+- Issue #1812 — PyO3 struct exposure (the snapshot types measures mutate): [`docs/bindings.md`](bindings.md).
+- Issue #1814 — This document and the runner CLI.
+- OpenStudio `ModelMeasure` reference: https://openstudio.net/docs/latest/Measure_Guide/.
+
+## End-to-end Example
+
+```bash
+# 1. Create a base model JSON
+python -c "import fluxion; from fluxion.measures import save_model; \
+    save_model(fluxion.Model(num_zones=1), 'base.json')"
+
+# 2. Run the example measures
+fluxion apply-measures \
+    --model base.json \
+    --measures measures/examples/ \
+    --output model.applied.json
+
+# 3. Inspect the result
+python -c "
+import json
+with open('model.applied.json') as f:
+    data = json.load(f)
+print('applied:', data['_fluxion_run']['applied'])
+print('zones:', data['num_zones'])
+south = [s for s in data['surfaces'] if s['orientation'] == 'South']
+print('south surfaces with overhang:', sum(1 for s in south if s['overhang_depth']))
+"
+```

--- a/fluxion/__init__.py
+++ b/fluxion/__init__.py
@@ -1,0 +1,75 @@
+"""Fluxion — Neuro-Symbolic Building Energy Modeling engine.
+
+The Rust core lives in ``src/lib.rs`` and is exposed to Python via PyO3.
+This package re-exports the native classes at the top level so callers can
+write ``fluxion.Model(...)`` directly.
+
+Python-side additions (Issue #1814) live in submodules:
+
+- :mod:`fluxion.measures` — :class:`FluxionMeasure` base class + AOT
+  runner. See ``docs/measures.md`` for the design rationale.
+- :mod:`fluxion.cli` — ``fluxion apply-measures`` entrypoint.
+
+Importing the Rust extension is wrapped in a try/except so that ``import
+fluxion`` works even on a slim install (e.g. documentation builds) where
+the ``.abi3.so`` is unavailable.
+"""
+
+from __future__ import annotations
+
+try:
+    from fluxion.fluxion import *  # noqa: F401,F403  (re-export native classes)
+    from fluxion.fluxion import __doc__ as _native_doc  # noqa: F401
+except ImportError as _exc:  # pragma: no cover — slim install path
+    _NATIVE_IMPORT_ERROR = _exc
+else:
+    _NATIVE_IMPORT_ERROR = None
+
+# Re-export the measures submodule so callers can `from fluxion import
+# FluxionMeasure`. This is a soft import — measures can be used without
+# the native module (e.g. in unit tests that mock fluxion.Model).
+from fluxion.measures import (  # noqa: E402
+    FluxionMeasure,
+    apply_measures,
+    discover_measures,
+    dict_to_model,
+    load_model,
+    model_to_dict,
+    save_model,
+)
+
+__all__ = [
+    "FluxionMeasure",
+    "apply_measures",
+    "discover_measures",
+    "dict_to_model",
+    "load_model",
+    "model_to_dict",
+    "save_model",
+]
+
+
+def __getattr__(name: str):
+    """Lazy attribute access for native classes.
+
+    ``fluxion.Model`` etc. live in the compiled extension module. Importing
+    the extension at module load time would force every Python process (even
+    those only using :class:`FluxionMeasure` for static analysis) to load
+    the Rust shared library. We delegate attribute access so the extension is
+    loaded only when actually needed.
+    """
+    if _NATIVE_IMPORT_ERROR is not None:
+        raise ImportError(
+            f"fluxion native extension is unavailable ({_NATIVE_IMPORT_ERROR}). "
+            "Install with `maturin develop` or `pip install fluxion`."
+        ) from _NATIVE_IMPORT_ERROR
+    from fluxion import fluxion as _native
+
+    try:
+        return getattr(_native, name)
+    except AttributeError as e:
+        raise AttributeError(f"module 'fluxion' has no attribute {name!r}") from e
+
+
+# Static type stubs (PEP 561): see ``fluxion.pyi`` at the repo root for the
+# generated typing surface.

--- a/fluxion/cli.py
+++ b/fluxion/cli.py
@@ -1,0 +1,250 @@
+"""Command-line entry point for the Fluxion Python package.
+
+Subcommands
+-----------
+- ``fluxion apply-measures`` — AOT measure runner (Issue #1814). Loads a
+  base model, runs each discovered :class:`fluxion.FluxionMeasure` subclass
+  in sequence, and serializes the mutated model to JSON (or msgpack).
+
+The CLI uses ``argparse`` to match the conventions of ``scripts/*.py`` in
+this repository. It is intentionally lightweight — the goal is to provide a
+deterministic, scriptable runner for CI; richer argument parsing (choices,
+range validation, etc.) lives in the individual measures via
+:meth:`FluxionMeasure.arguments`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+from fluxion.measures import (
+    FluxionMeasure,
+    apply_measures,
+    discover_measures,
+    load_model,
+    save_model,
+)
+
+
+logger = logging.getLogger("fluxion.cli")
+
+
+# =============================================================================
+# Argument parsing
+# =============================================================================
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="fluxion",
+        description=(
+            "Fluxion — Neuro-Symbolic Building Energy Modeling CLI. "
+            "The Python subcommands live alongside the Rust ones."
+        ),
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Increase logging verbosity (can be repeated).",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    apply_p = sub.add_parser(
+        "apply-measures",
+        help=(
+            "Run AOT Python measures against a base model. "
+            "Measures mutate the model once and serialize the result."
+        ),
+        description=(
+            "Loads --model, discovers FluxionMeasure subclasses in --measures, "
+            "runs each in sequence, and writes the mutated model to --output. "
+            "Measures are pre-processors and MUST NOT run inside the "
+            "timestepping loop (see docs/measures.md)."
+        ),
+    )
+    apply_p.add_argument(
+        "--model",
+        required=True,
+        type=Path,
+        help="Path to the base model JSON (or .msgpack if msgpack is installed).",
+    )
+    apply_p.add_argument(
+        "--measures",
+        required=True,
+        type=Path,
+        help="Directory containing FluxionMeasure subclasses (*.py files).",
+    )
+    apply_p.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        default=Path("model.applied.json"),
+        help="Output path for the serialized mutated model (default: model.applied.json).",
+    )
+    apply_p.add_argument(
+        "--measure-args",
+        type=Path,
+        default=None,
+        help=(
+            "Optional JSON file mapping measure name -> arguments dict. "
+            "Missing measures receive an empty dict."
+        ),
+    )
+    apply_p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Discover measures and report what would run, but do not mutate or write.",
+    )
+    apply_p.add_argument(
+        "--list",
+        action="store_true",
+        dest="list_only",
+        help="Discover and list measure classes; do not run them.",
+    )
+
+    return parser
+
+
+# =============================================================================
+# Subcommand handlers
+# =============================================================================
+
+
+def _handle_apply_measures(args: argparse.Namespace) -> int:
+    """Implement ``fluxion apply-measures``.
+
+    Returns the process exit code (0 on success, non-zero on error).
+    """
+    # ``--list`` and ``--dry-run`` modes only need the measures directory,
+    # not the model — handle them first so the model check doesn't fire.
+    measure_classes: list[type[FluxionMeasure]] = []
+    if args.measures.exists() and args.measures.is_dir():
+        measure_classes = discover_measures(args.measures)
+        if not measure_classes:
+            logger.warning(
+                "No FluxionMeasure subclasses discovered in %s. "
+                "Check that your measure files define `class X(FluxionMeasure)` "
+                "and override `apply()`.",
+                args.measures,
+            )
+    elif not args.measures.exists():
+        logger.error("Measures directory not found: %s", args.measures)
+        return 2
+    else:
+        logger.error("--measures must be a directory, got file: %s", args.measures)
+        return 2
+
+    if args.list_only:
+        print(json.dumps([c.__name__ for c in measure_classes], indent=2))
+        return 0
+
+    # From here on we need the model. Check it before parsing args JSON.
+    if not args.model.exists():
+        logger.error("Base model not found: %s", args.model)
+        return 2
+
+    # Parse optional measure-args JSON
+    measure_args: dict[str, dict[str, Any]] = {}
+    if args.measure_args is not None:
+        if not args.measure_args.exists():
+            logger.error("--measure-args file not found: %s", args.measure_args)
+            return 2
+        try:
+            measure_args = json.loads(args.measure_args.read_text())
+        except json.JSONDecodeError as e:
+            logger.error("Failed to parse --measure-args JSON: %s", e)
+            return 2
+
+    if args.dry_run:
+        # Instantiate to capture declared arguments.
+        plan = []
+        for cls in measure_classes:
+            instance = cls()
+            plan.append(
+                {
+                    "name": instance.name,
+                    "class": cls.__name__,
+                    "arguments": instance.arguments(),
+                }
+            )
+        print(json.dumps(plan, indent=2, default=str))
+        return 0
+
+    # Load the base model.
+    logger.info("Loading base model from %s", args.model)
+    try:
+        model = load_model(args.model)
+    except Exception as e:
+        logger.error("Failed to load model: %s", e)
+        return 1
+
+    # Apply each measure in order.
+    try:
+        applied = apply_measures(model, measure_classes, measure_args)
+    except Exception as e:
+        logger.error("Measure execution failed: %s", e)
+        return 1
+
+    # Serialize the result.
+    logger.info("Writing mutated model to %s", args.output)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        save_model(model, args.output)
+    except Exception as e:
+        logger.error("Failed to write model: %s", e)
+        return 1
+
+    # Append a run-summary section to the output file so downstream
+    # tooling can introspect what happened without re-running.
+    summary = {
+        "applied": applied,
+        "output": str(args.output),
+        "model": {
+            "num_zones": model.num_zones(),
+            "surface_count": len(model.surfaces()),
+        },
+    }
+    try:
+        existing = json.loads(args.output.read_text())
+        if isinstance(existing, dict):
+            existing["_fluxion_run"] = summary
+            args.output.write_text(json.dumps(existing, indent=2, sort_keys=True))
+    except (OSError, json.JSONDecodeError):
+        # Best-effort — never fail the CLI on metadata writing.
+        pass
+
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+# =============================================================================
+# Entry point
+# =============================================================================
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    level = logging.WARNING - 10 * min(args.verbose, 2)
+    logging.basicConfig(
+        level=max(level, logging.DEBUG),
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+    if args.command == "apply-measures":
+        return _handle_apply_measures(args)
+
+    parser.error(f"Unknown command: {args.command}")
+    return 2  # unreachable
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/fluxion/measures.py
+++ b/fluxion/measures.py
@@ -1,0 +1,658 @@
+"""
+FluxionMeasure base class + Ahead-of-Time (AOT) measure runner (Issue #1814).
+
+This module is the Python analogue of OpenStudio's `OpenStudio::Measure::ModelMeasure`,
+adapted to Fluxion's Neuro-Symbolic architecture. Crucially, **measures are
+pre-processing steps** — they mutate a model once and serialize it for the Rust
+runtime to consume. They MUST NOT run inside the timestepping loop.
+
+Why "AOT only"?
+---------------
+Rust's `rayon` parallel iterator drives the timestepping loop with a thread
+pool. If a Python measure were to run inside that loop, the GIL would be
+contended against every rayon worker, serializing all parallel work and
+cancelling the speedup we get from `par_iter`. To preserve Fluxion's
+high-throughput BatchOracle path (>=10k configs/sec on 8 cores), measures are
+*forbidden* from running inside any per-timestep callback.
+
+The runtime guard below emits a `RuntimeWarning` if a measure detects it's
+running on a thread whose name matches the rayon worker naming pattern, or if
+the env var `FLUXION_INSIDE_TIMESTEPPING=1` is set. The warning is loud
+(emitted every apply) but does not raise — measures are sometimes invoked
+deliberately from worker contexts (e.g. parallel calibration); the warning is
+informational and CI-friendly.
+
+Module layout
+-------------
+- :class:`FluxionMeasure` — abstract base class. Subclasses override
+  :meth:`apply` and (optionally) :meth:`arguments`.
+- :func:`load_model_json` / :func:`save_model_json` — minimal AOT
+  serialization helpers. The full model schema is still being stabilized
+  in ARCHITECTURE.md; for now we round-trip via the snapshot API.
+- :func:`discover_measures` — walk a directory and import every
+  :class:`FluxionMeasure` subclass declared in any ``*.py`` file.
+- :func:`apply_measures` — load a base model, run each measure in sequence,
+  serialize the result.
+
+See :mod:`fluxion.cli` for the ``fluxion apply-measures`` entrypoint.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import json
+import os
+import pathlib
+import sys
+import threading
+import warnings
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+
+# =============================================================================
+# Runtime context detection
+# =============================================================================
+
+
+# Names that `rayon` and most Rust thread-pool crates use by default. The list
+# is intentionally conservative — false positives are OK (just a warning),
+# false negatives are bad (would silently break the rayon throughput gate).
+_RAYON_THREAD_NAME_PATTERNS: tuple[str, ...] = (
+    "rayon",
+    "rayon-",
+    "tokio-runtime-worker",
+    "tokio-",
+    "tokio_reactor",
+)
+
+
+def _inside_timestepping() -> bool:
+    """Return True if the current thread looks like a Rust worker thread.
+
+    The check is heuristic: it matches the current thread name against the
+    common rayon/tokio patterns. We also honour an explicit escape hatch via
+    the ``FLUXION_INSIDE_TIMESTESTEPPING`` env var, which downstream tooling
+    can set when invoking a Python callback from inside a simulation loop.
+    """
+    if os.environ.get("FLUXION_INSIDE_TIMESTEPPING") == "1":
+        return True
+    try:
+        name = threading.current_thread().name
+    except Exception:  # pragma: no cover — defensive
+        return False
+    lowered = name.lower()
+    return any(pattern in lowered for pattern in _RAYON_THREAD_NAME_PATTERNS)
+
+
+def _warn_if_inside_timestepping(measure_name: str) -> None:
+    """Emit a runtime warning if the measure is running on a worker thread."""
+    if _inside_timestepping():
+        warnings.warn(
+            (
+                f"FluxionMeasure '{measure_name}' is running on a thread that "
+                "looks like a Rust rayon/tokio worker. Measures are AOT "
+                "pre-processors and MUST NOT run inside the timestepping loop — "
+                "doing so will serialize the parallel BatchOracle path. "
+                "Move this logic to `fluxion apply-measures` (run once before "
+                "simulation) or to a Rust trait implementation."
+            ),
+            RuntimeWarning,
+            stacklevel=3,
+        )
+
+
+# =============================================================================
+# FluxionMeasure base class
+# =============================================================================
+
+
+class _FluxionMeasureMeta(type):
+    """Metaclass that wraps :meth:`apply` with the timestepping guard.
+
+    Every call to a subclass's ``apply(...)`` first invokes
+    :func:`_warn_if_inside_timestepping` so the warning fires regardless of
+    whether the caller uses :func:`apply_measures` or calls ``apply``
+    directly. This is the only piece of behaviour enforced automatically by
+    the base class; everything else is opt-in via :meth:`arguments` /
+    :meth:`parse_arguments`.
+    """
+
+    def __new__(mcs, name, bases, namespace, **kwargs):
+        cls = super().__new__(mcs, name, bases, namespace, **kwargs)
+        # Skip the wrap for the base class itself — its apply() raises
+        # NotImplementedError, and we want the warning *only* to fire on
+        # real subclasses (which override apply).
+        if bases == ():
+            return cls
+        original_apply = namespace.get("apply")
+        if original_apply is None:
+            return cls
+
+        def guarded_apply(self, model, arguments):
+            _warn_if_inside_timestepping(name)
+            return original_apply(self, model, arguments)
+
+        # Preserve the original signature metadata where possible.
+        try:
+            guarded_apply.__wrapped__ = original_apply  # type: ignore[attr-defined]
+            guarded_apply.__name__ = original_apply.__name__
+            guarded_apply.__qualname__ = original_apply.__qualname__
+            guarded_apply.__doc__ = original_apply.__doc__
+        except (AttributeError, TypeError):
+            pass
+        # Bind onto the subclass.
+        cls.apply = guarded_apply
+        return cls
+
+
+class FluxionMeasure(metaclass=_FluxionMeasureMeta):
+    """Abstract base class for Fluxion AOT measures.
+
+    A measure mutates a building model **once** before the Rust runtime
+    consumes it. The class mirrors OpenStudio's ``ModelMeasure`` API:
+
+    - :meth:`arguments` returns an argument spec (list of dicts). The format
+      is deliberately permissive — Fluxion is still stabilizing its CLI
+      argument vocabulary, and the exact keys accepted will evolve alongside
+      the model schema in ``ARCHITECTURE.md``.
+    - :meth:`apply` mutates the supplied ``model`` in place using the parsed
+      ``arguments`` dict. The model is the PyO3 ``fluxion.Model`` instance.
+
+    Subclassing rules
+    -----------------
+    - Concrete measures MUST override :meth:`apply`.
+    - :meth:`arguments` MAY be overridden; the default returns an empty list,
+      which means "no user-tunable parameters". The CLI passes an empty
+      dict for the args when the measure exposes no arguments.
+    - Subclasses are discovered by name — see :func:`discover_measures`.
+      Every non-abstract subclass with a ``__name__ != "FluxionMeasure"``
+      will be picked up.
+
+    Threading contract
+    ------------------
+    ``apply`` is invoked by :func:`apply_measures` from the main thread, on
+    a freshly-loaded or freshly-mutated ``Model``. The metaclass
+    :class:`_FluxionMeasureMeta` automatically wraps every subclass
+    ``apply`` with :func:`_warn_if_inside_timestepping` — the warning
+    fires whether the user calls :func:`apply_measures` or invokes
+    ``measure.apply(model, args)`` directly.
+    """
+
+    #: Class-level metadata. Subclasses may override.
+    name: str = ""
+    description: str = ""
+
+    def __init__(self) -> None:
+        if not self.name:
+            # Default to the class name, stripped of "Measure" suffix for
+            # nicer CLI output.
+            self.name = type(self).__name__
+            if self.name.endswith("Measure") and self.name != "FluxionMeasure":
+                self.name = self.name[: -len("Measure")]
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def arguments(self) -> list[dict[str, Any]]:
+        """Return the argument specification for this measure.
+
+        Mirrors OpenStudio's ``arguments()`` method, which returns a list of
+        argument descriptors. Each entry is a dict with at minimum:
+
+        - ``name`` (str) — the argument key, used as the dict key in
+          :meth:`apply`.
+        - ``type`` (str) — one of ``"string"``, ``"double"``, ``"integer"``,
+          ``"bool"``, ``"choice"``.
+        - ``default`` (optional) — default value if the user omits it.
+
+        Optional keys: ``"description"``, ``"required"`` (bool),
+        ``"choices"`` (list, for ``type == "choice"``), ``"min"`` / ``"max"``
+        for numeric types.
+
+        The default implementation returns an empty list, meaning "no
+        arguments". Concrete measures with user-tunable parameters should
+        override.
+        """
+        return []
+
+    def apply(self, model: Any, arguments: dict[str, Any]) -> None:
+        """Mutate ``model`` in place using ``arguments``.
+
+        Subclasses MUST override. The base implementation raises
+        ``NotImplementedError``.
+
+        Parameters
+        ----------
+        model : fluxion.Model
+            The PyO3 model instance to mutate. The measure may freely call
+            :meth:`fluxion.Model.set_surfaces`, ``set_hvac_system``, etc.
+            Note that the model uses a snapshot/owned-value pattern: surface
+            lists must be re-applied via :meth:`set_surfaces` to persist.
+        arguments : dict
+            Parsed user arguments. Keys come from :meth:`arguments`. Missing
+            keys fall back to the declared defaults.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__}.apply() must be overridden by the subclass"
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def parse_arguments(self, raw: dict[str, Any] | None) -> dict[str, Any]:
+        """Merge user-supplied args with the declared spec defaults.
+
+        Unknown keys are passed through (with a warning) so that measures
+        which declare a permissive spec still accept arbitrary JSON.
+        """
+        spec = self.arguments()
+        declared: dict[str, Any] = {}
+        for entry in spec:
+            if not isinstance(entry, dict) or "name" not in entry:
+                continue
+            declared[entry["name"]] = entry.get("default", _SENTINEL)
+        merged: dict[str, Any] = {k: v for k, v in declared.items() if v is not _SENTINEL}
+        if raw:
+            for k, v in raw.items():
+                if k not in declared and declared:
+                    warnings.warn(
+                        f"FluxionMeasure '{self.name}' received unknown argument "
+                        f"'{k}' (not declared in arguments())",
+                        UserWarning,
+                        stacklevel=2,
+                    )
+                merged[k] = v
+        return merged
+
+
+_SENTINEL: Any = object()
+
+
+# =============================================================================
+# Model serialization (AOT file format)
+# =============================================================================
+
+
+# Bump when the on-disk format changes in an incompatible way.
+SCHEMA_VERSION = "1.0.0"
+
+
+def model_to_dict(model: Any) -> dict[str, Any]:
+    """Serialize a ``fluxion.Model`` to a JSON-compatible dict.
+
+    Uses the snapshot API (``model.zones()``, ``model.surfaces()``,
+    ``model.hvac_system()``) so the output is consistent with the
+    PyO3 ownership contract described in ``docs/bindings.md``.
+
+    The schema is intentionally minimal and versioned — see
+    :data:`SCHEMA_VERSION`. The Rust runtime today does not yet consume this
+    format directly; the serialized file is meant for round-tripping through
+    :func:`dict_to_model` and for CI smoke tests that verify a measure chain
+    is idempotent.
+    """
+    zones = [
+        {
+            "index": z.index,
+            "temperature": z.temperature,
+            "area": z.area,
+            "heating_setpoint": z.heating_setpoint,
+            "cooling_setpoint": z.cooling_setpoint,
+            "hvac_enabled": z.hvac_enabled,
+            "surfaces": [_surface_to_dict(s) for s in z.surfaces],
+        }
+        for z in model.zones()
+    ]
+    flat_surfaces = [_surface_to_dict(s) for s in model.surfaces()]
+    hvac = model.hvac_system()
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "num_zones": model.num_zones(),
+        "temperatures": list(model.get_temperatures()),
+        "zones": zones,
+        "surfaces": flat_surfaces,
+        "hvac_system": {
+            "heating_capacity": hvac.heating_capacity,
+            "cooling_capacity": hvac.cooling_capacity,
+            "cop_heating": hvac.cop_heating,
+            "cop_cooling": hvac.cop_cooling,
+            "stages": hvac.stages,
+            "min_outdoor_temp": hvac.min_outdoor_temp,
+            "max_outdoor_temp": hvac.max_outdoor_temp,
+            "vav_enabled": hvac.vav_enabled,
+            "economizer_enabled": hvac.economizer_enabled,
+            "supply_air_temp": hvac.supply_air_temp,
+        },
+    }
+
+
+def dict_to_model(payload: dict[str, Any]) -> Any:
+    """Reconstruct a ``fluxion.Model`` from a :func:`model_to_dict` payload."""
+    import fluxion  # local import — measures may run without fluxion at import time
+
+    model = fluxion.Model(num_zones=int(payload.get("num_zones", 1)))
+    if "temperatures" in payload:
+        model.set_temperatures([float(t) for t in payload["temperatures"]])
+    if "surfaces" in payload:
+        flat = [_dict_to_surface(s) for s in payload["surfaces"]]
+        model.set_surfaces(flat)
+    if "hvac_system" in payload:
+        model.set_hvac_system(_dict_to_hvac(payload["hvac_system"]))
+    return model
+
+
+def _enum_name(value: Any) -> str:
+    """Extract the variant name from a PyO3 enum (which lacks ``.name``)."""
+    rep = repr(value)
+    # repr() is e.g. ``Orientation.South``; split on the last dot.
+    return rep.rsplit(".", 1)[-1]
+
+
+def _surface_to_dict(s: Any) -> dict[str, Any]:
+    # The PyO3 PyShadingDevice type does not expose its fields as Python
+    # attributes (the Rust struct has no PyMethods for shading_type /
+    # overhang_depth / fin_width / mounting_height). Instead, reconstruct
+    # the shading list from the shorthand overhang/fin fields on PySurface.
+    shading_devices: list[dict[str, Any]] = []
+    if s.overhang_depth is not None and s.overhang_height is not None:
+        stype = "Fins" if s.fin_width else "Overhang"
+        if s.overhang_depth is not None and s.fin_width:
+            stype = "OverhangAndFins"
+        shading_devices.append(
+            {
+                "shading_type": stype,
+                "overhang_depth": s.overhang_depth,
+                "fin_width": s.fin_width if s.fin_width is not None else 0.0,
+                "mounting_height": s.overhang_height,
+            }
+        )
+    elif s.overhang_depth is not None:
+        shading_devices.append(
+            {
+                "shading_type": "Overhang",
+                "overhang_depth": s.overhang_depth,
+                "fin_width": 0.0,
+                "mounting_height": s.overhang_height or 0.0,
+            }
+        )
+    elif s.fin_width is not None:
+        shading_devices.append(
+            {
+                "shading_type": "Fins",
+                "overhang_depth": 0.0,
+                "fin_width": s.fin_width,
+                "mounting_height": 0.0,
+            }
+        )
+
+    return {
+        "area": s.area,
+        "u_value": s.u_value,
+        "orientation": _enum_name(s.orientation),
+        "window_area": s.window_area,
+        "overhang_depth": s.overhang_depth,
+        "overhang_height": s.overhang_height,
+        "fin_width": s.fin_width,
+        "shading_devices": shading_devices,
+    }
+
+
+def _dict_to_surface(d: dict[str, Any]) -> Any:
+    import fluxion
+
+    orient_name = d.get("orientation", "South")
+    orientation = getattr(fluxion.Orientation, orient_name, fluxion.Orientation.South)
+    s = fluxion.Surface(
+        area=float(d.get("area", 0.0)),
+        u_value=float(d.get("u_value", 0.0)),
+        orientation=orientation,
+        window_area=float(d.get("window_area", 0.0)),
+    )
+    s.overhang_depth = d.get("overhang_depth")
+    s.overhang_height = d.get("overhang_height")
+    s.fin_width = d.get("fin_width")
+    # ShadingDevice has no Python __init__ — use the static factory methods
+    # matching each shading type. append_shading() still accepts the
+    # constructed device.
+    for dev in d.get("shading_devices", []):
+        st_name = dev.get("shading_type", "None")
+        if st_name == "Overhang":
+            device = fluxion.ShadingDevice.overhang(
+                depth=float(dev.get("overhang_depth", 0.0)),
+                height=float(dev.get("mounting_height", 0.0)),
+            )
+        elif st_name == "Fins":
+            device = fluxion.ShadingDevice.fins(width=float(dev.get("fin_width", 0.0)))
+        elif st_name == "OverhangAndFins":
+            device = fluxion.ShadingDevice.overhang_and_fins(
+                overhang_depth=float(dev.get("overhang_depth", 0.0)),
+                fin_width=float(dev.get("fin_width", 0.0)),
+                height=float(dev.get("mounting_height", 0.0)),
+            )
+        else:
+            # "None" or unknown — skip; the shorthand fields already capture
+            # any overhang/fin depth if present.
+            continue
+        s.append_shading(device)
+    return s
+
+
+def _dict_to_hvac(d: dict[str, Any]) -> Any:
+    import fluxion
+
+    return fluxion.HVACSystem(
+        heating_capacity=float(d.get("heating_capacity", 10000.0)),
+        cooling_capacity=float(d.get("cooling_capacity", 8000.0)),
+        cop_heating=float(d.get("cop_heating", 3.0)),
+        cop_cooling=float(d.get("cop_cooling", 3.2)),
+        stages=int(d.get("stages", 1)),
+        min_outdoor_temp=float(d.get("min_outdoor_temp", -10.0)),
+        max_outdoor_temp=float(d.get("max_outdoor_temp", 40.0)),
+        vav_enabled=bool(d.get("vav_enabled", False)),
+        economizer_enabled=bool(d.get("economizer_enabled", False)),
+        supply_air_temp=float(d.get("supply_air_temp", 13.0)),
+    )
+
+
+def save_model(model: Any, path: str | os.PathLike[str]) -> None:
+    """Write a model to disk as JSON (or msgpack if ``msgpack`` is installed).
+
+    The output format is selected by file extension: ``.json`` -> JSON,
+    ``.msgpack`` -> msgpack (if available; falls back to JSON if msgpack is
+    not importable). All other extensions default to JSON for safety.
+    """
+    payload = model_to_dict(model)
+    target = Path(path)
+    suffix = target.suffix.lower()
+    if suffix == ".msgpack":
+        try:
+            import msgpack  # type: ignore[import-not-found]
+
+            target.write_bytes(msgpack.packb(payload, use_bin_type=True))
+            return
+        except ImportError:
+            warnings.warn(
+                "msgpack not installed — falling back to JSON for output",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+    target.write_text(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def load_model(path: str | os.PathLike[str]) -> Any:
+    """Load a model previously written by :func:`save_model`."""
+    source = Path(path)
+    suffix = source.suffix.lower()
+    if suffix == ".msgpack":
+        try:
+            import msgpack  # type: ignore[import-not-found]
+
+            payload = msgpack.unpackb(source.read_bytes(), raw=False)
+        except ImportError as e:
+            raise RuntimeError(
+                "Cannot load .msgpack model: msgpack package not installed"
+            ) from e
+    else:
+        payload = json.loads(source.read_text())
+    return dict_to_model(payload)
+
+
+# =============================================================================
+# Measure discovery
+# =============================================================================
+
+
+def _iter_measure_classes(module: Any) -> Iterator[type[FluxionMeasure]]:
+    """Yield every concrete FluxionMeasure subclass defined in ``module``.
+
+    A class is treated as "abstract" (and therefore skipped) if:
+
+    - ``inspect.isabstract()`` returns ``True`` (catches classes using
+      :class:`abc.ABCMeta` + :func:`abc.abstractmethod` directly on
+      ``apply``), OR
+    - :meth:`FluxionMeasure.apply` has not been overridden *and* the
+      subclass explicitly marks itself abstract via :class:`abc.ABCMeta`.
+      The :class:`_FluxionMeasureMeta` wraps subclass ``apply`` methods
+      for the runtime guard, which obscures the ``@abstractmethod``
+      decorator from ``inspect``. To handle that case we look through the
+      wrapper chain (``__wrapped__``) for an abstract ``apply``.
+    """
+    for _, obj in inspect.getmembers(module, inspect.isclass):
+        if obj is FluxionMeasure:
+            continue
+        if not issubclass(obj, FluxionMeasure):
+            continue
+        if inspect.isabstract(obj):
+            continue
+        # Fallback: detect abstract through the metaclass wrapper.
+        if _apply_is_abstract(obj):
+            continue
+        if obj.__module__ != module.__name__:
+            continue
+        yield obj
+
+
+def _apply_is_abstract(cls: type[FluxionMeasure]) -> bool:
+    """Return True if ``cls.apply`` is an ``@abstractmethod`` (after unwrap)."""
+    attr = cls.__dict__.get("apply")
+    # Walk the __wrapped__ chain installed by the metaclass guard.
+    while attr is not None and hasattr(attr, "__wrapped__"):
+        attr = attr.__wrapped__
+    return bool(
+        attr is not None
+        and hasattr(attr, "__isabstractmethod__")
+        and getattr(attr, "__isabstractmethod__", False)
+    )
+
+
+def discover_measures(measure_dir: str | os.PathLike[str]) -> list[type[FluxionMeasure]]:
+    """Discover every concrete :class:`FluxionMeasure` subclass in ``measure_dir``.
+
+    Walks ``measure_dir`` recursively, imports every ``*.py`` file (skipping
+    files that start with ``_`` so authors can keep helpers out of the
+    discovery scan), and returns the union of concrete subclasses.
+
+    The directory is added to ``sys.path`` for the duration of the import.
+    Returns an empty list if the directory does not exist or contains no
+    measures.
+    """
+    base = Path(measure_dir)
+    if not base.exists():
+        return []
+    base_str = str(base.resolve())
+    added = False
+    if base_str not in sys.path:
+        sys.path.insert(0, base_str)
+        added = True
+    try:
+        results: list[type[FluxionMeasure]] = []
+        for path in sorted(base.rglob("*.py")):
+            if path.name.startswith("_"):
+                continue
+            mod_name = "_fluxion_measure_" + path.stem + "_" + str(hash(str(path)) & 0xFFFF)
+            spec = importlib.util.spec_from_file_location(mod_name, str(path))
+            if spec is None or spec.loader is None:
+                continue
+            module = importlib.util.module_from_spec(spec)
+            try:
+                spec.loader.exec_module(module)
+            except Exception as e:
+                warnings.warn(
+                    f"Failed to import measure file {path}: {e}",
+                    ImportWarning,
+                    stacklevel=2,
+                )
+                continue
+            for cls in _iter_measure_classes(module):
+                results.append(cls)
+        # Stable order by class name for deterministic CLI output.
+        results.sort(key=lambda c: c.__name__)
+        return results
+    finally:
+        if added:
+            try:
+                sys.path.remove(base_str)
+            except ValueError:  # pragma: no cover
+                pass
+
+
+# =============================================================================
+# Top-level runner
+# =============================================================================
+
+
+def apply_measures(
+    model: Any,
+    measures: Iterable[type[FluxionMeasure] | FluxionMeasure],
+    measure_args: dict[str, dict[str, Any]] | None = None,
+) -> list[str]:
+    """Apply each measure in sequence to ``model``, mutating it in place.
+
+    Returns the list of measure names that were applied, in order. Each
+    measure is instantiated (if a class was passed) and invoked once.
+
+    Parameters
+    ----------
+    model : fluxion.Model
+        The model to mutate. May be a freshly-constructed ``Model`` or one
+        loaded from disk via :func:`load_model`.
+    measures : iterable of classes or instances
+        Order matters — measures run sequentially. Each entry is either a
+        :class:`FluxionMeasure` subclass (instantiated here) or an already-
+        constructed instance.
+    measure_args : dict, optional
+        Mapping of ``measure.name`` -> parsed arguments dict. Measures not
+        present in the mapping receive an empty dict (which is then merged
+        with declared defaults via :meth:`FluxionMeasure.parse_arguments`).
+    """
+    measure_args = measure_args or {}
+    applied: list[str] = []
+    for entry in measures:
+        instance = entry() if inspect.isclass(entry) else entry
+        if not isinstance(instance, FluxionMeasure):
+            raise TypeError(
+                f"apply_measures() expected FluxionMeasure classes/instances, "
+                f"got {type(entry).__name__}"
+            )
+        # Refuse to run on a worker thread (defensive).
+        _warn_if_inside_timestepping(instance.name or instance.__class__.__name__)
+        raw = measure_args.get(instance.name, {}) or {}
+        args = instance.parse_arguments(raw)
+        instance.apply(model, args)
+        applied.append(instance.name or instance.__class__.__name__)
+    return applied
+
+
+__all__ = [
+    "FluxionMeasure",
+    "SCHEMA_VERSION",
+    "apply_measures",
+    "discover_measures",
+    "dict_to_model",
+    "load_model",
+    "model_to_dict",
+    "save_model",
+]

--- a/measures/__init__.py
+++ b/measures/__init__.py
@@ -1,0 +1,10 @@
+"""measures — root package for Fluxion AOT measures (Issue #1814).
+
+Drop ``*.py`` files into a sub-directory of this package (typically
+``measures/examples/``) and they will be picked up by
+``fluxion apply-measures --measures <dir>``. Each ``.py`` file may declare
+any number of :class:`fluxion.FluxionMeasure` subclasses; only the
+concrete (non-abstract) ones are discovered.
+
+The root package itself does not export any measures — it is a namespace.
+"""

--- a/measures/examples/__init__.py
+++ b/measures/examples/__init__.py
@@ -1,0 +1,12 @@
+"""measures.examples — example Fluxion measures (Issue #1814).
+
+Each module in this subdirectory defines one or more concrete
+:class:`fluxion.FluxionMeasure` subclasses. They are discovered by
+``fluxion apply-measures --measures measures/examples/`` and applied to a
+loaded base model.
+
+This ``__init__.py`` is intentionally empty — measure discovery uses
+``importlib.util`` to load each ``*.py`` file directly, so module-level
+imports of sibling measures would be redundant (and would break the
+"discover individual files" path used by the CLI).
+"""

--- a/measures/examples/add_overhang.py
+++ b/measures/examples/add_overhang.py
@@ -1,0 +1,108 @@
+"""AddSouthOverhang — example FluxionMeasure (Issue #1814).
+
+Adds a horizontal overhang to every south-facing opaque surface in the
+model. This is the canonical "shading" measure pattern from issue #1812 —
+it demonstrates the snapshot/owned-value round trip:
+
+    1. Read ``model.surfaces()`` (snapshots).
+    2. Filter for ``Orientation.South``.
+    3. Mutate each snapshot via ``surface.add_overhang(...)``.
+    4. Push the full flat list back via ``model.set_surfaces(snapshots)``.
+
+Run with::
+
+    fluxion apply-measures \\
+        --model base.json \\
+        --measures measures/examples/ \\
+        --output model.with_overhangs.json
+
+Or from Python::
+
+    from fluxion import Model
+    from fluxion.measures import apply_measures
+    from measures.examples.add_overhang import AddSouthOverhang
+
+    model = Model(num_zones=2)
+    apply_measures(model, [AddSouthOverhang], {"AddSouthOverhang": {"depth": 1.0, "height": 2.5}})
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fluxion import FluxionMeasure
+
+
+class AddSouthOverhang(FluxionMeasure):
+    """Add a horizontal overhang to every south-facing opaque surface.
+
+    Parameters
+    ----------
+    depth : float
+        Overhang depth in meters (default 1.0 m).
+    height : float
+        Mounting height above the window (default 2.5 m).
+    only_with_windows : bool
+        If True, only attach the overhang to surfaces that already have
+        ``window_area > 0`` (default False — apply to all south-facing
+        opaque surfaces).
+    """
+
+    def arguments(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "name": "depth",
+                "type": "double",
+                "default": 1.0,
+                "min": 0.0,
+                "max": 5.0,
+                "description": "Overhang depth in meters (m).",
+            },
+            {
+                "name": "height",
+                "type": "double",
+                "default": 2.5,
+                "min": 0.0,
+                "max": 10.0,
+                "description": "Mounting height above the window (m).",
+            },
+            {
+                "name": "only_with_windows",
+                "type": "bool",
+                "default": False,
+                "description": (
+                    "If true, only attach the overhang to surfaces with window_area > 0."
+                ),
+            },
+        ]
+
+    def apply(self, model: Any, arguments: dict[str, Any]) -> None:
+        import fluxion
+
+        depth = float(arguments.get("depth", 1.0))
+        height = float(arguments.get("height", 2.5))
+        only_windows = bool(arguments.get("only_with_windows", False))
+
+        # Snapshot every surface (owned values — see docs/bindings.md).
+        surfaces = model.surfaces()
+        modified = 0
+        for s in surfaces:
+            if s.orientation != fluxion.Orientation.South:
+                continue
+            if only_windows and s.window_area <= 0.0:
+                continue
+            s.add_overhang(depth=depth, height=height)
+            modified += 1
+
+        # Push the mutated snapshots back to the model.
+        model.set_surfaces(surfaces)
+
+        # Log via standard logging (no print, so the CLI output stays clean).
+        import logging
+
+        logging.getLogger(__name__).info(
+            "AddSouthOverhang: attached overhang to %d south-facing surfaces (depth=%.2f m, height=%.2f m)",
+            modified,
+            depth,
+            height,
+        )

--- a/measures/examples/set_hvac_cop.py
+++ b/measures/examples/set_hvac_cop.py
@@ -1,0 +1,92 @@
+"""SetHVACCOP — example FluxionMeasure (Issue #1814).
+
+Sets the heating and cooling capacity on the model's HVAC system. Demonstrates
+the round-trip pattern for HVAC snapshots:
+
+    1. Read ``model.hvac_system()`` (snapshot).
+    2. Mutate the snapshot fields.
+    3. Push back via ``model.set_hvac_system(snapshot)``.
+
+A note on field propagation
+----------------------------
+Only ``heating_capacity`` and ``cooling_capacity`` are currently persisted by
+``Model.set_hvac_system()`` — fields like ``cop_heating``, ``cop_cooling``,
+``stages`` etc. are advisory and read-only snapshots. This example therefore
+mutates the capacities (which DO round-trip); COP mutations are still
+demonstrated to show the snapshot pattern but will not affect the underlying
+model. See ``src/python/model_bindings.rs`` for the full ownership story.
+
+Run with::
+
+    fluxion apply-measures \\
+        --model base.json \\
+        --measures measures/examples/ \\
+        --measure-args args.json \\
+        --output model.with_high_cop.json
+
+Where ``args.json`` is::
+
+    {
+        "SetHVACCOP": {
+            "heating_capacity": 15000.0,
+            "cooling_capacity": 12000.0
+        }
+    }
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fluxion import FluxionMeasure
+
+
+class SetHVACCOP(FluxionMeasure):
+    """Set heating/cooling capacity on the model's HVAC system.
+
+    Parameters
+    ----------
+    heating_capacity : float
+        Heating capacity in watts (W). Must be > 0. Default 15000.0.
+    cooling_capacity : float
+        Cooling capacity in watts (W). Must be > 0. Default 12000.0.
+    """
+
+    def arguments(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "name": "heating_capacity",
+                "type": "double",
+                "default": 15000.0,
+                "min": 1.0,
+                "max": 1.0e7,
+                "description": "Heating capacity in watts (W).",
+            },
+            {
+                "name": "cooling_capacity",
+                "type": "double",
+                "default": 12000.0,
+                "min": 1.0,
+                "max": 1.0e7,
+                "description": "Cooling capacity in watts (W).",
+            },
+        ]
+
+    def apply(self, model: Any, arguments: dict[str, Any]) -> None:
+        hvac = model.hvac_system()
+        hvac.heating_capacity = float(arguments.get("heating_capacity", 15000.0))
+        hvac.cooling_capacity = float(arguments.get("cooling_capacity", 12000.0))
+        # Snapshot COP fields are advisory; mutate them to demonstrate the
+        # pattern but note they will not round-trip back to the model until
+        # the binding grows full HVAC persistence.
+        hvac.cop_heating = float(arguments.get("cop_heating", hvac.cop_heating))
+        hvac.cop_cooling = float(arguments.get("cop_cooling", hvac.cop_cooling))
+        model.set_hvac_system(hvac)
+
+        import logging
+
+        logging.getLogger(__name__).info(
+            "SetHVACCOP: heating_capacity=%.0f W, cooling_capacity=%.0f W",
+            hvac.heating_capacity,
+            hvac.cooling_capacity,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,8 +75,18 @@ Issues = "https://github.com/anchapin/fluxion/issues"
 fluxion = "fluxion.cli:main"
 
 [tool.maturin]
-features = ["python-bindings", "pyo3/extension-module"]
-module-name = "fluxion"
+# Build the Rust extension as a sub-module of the ``fluxion`` Python package
+# so that pure-Python helpers (e.g. ``fluxion.measures``, ``fluxion.cli``
+# added in issue #1814) ship alongside the compiled ``.abi3.so``.
+#
+# Without the ``pyo3/extension-module`` feature, maturin produces a regular
+# Python package layout: ``fluxion/__init__.py`` re-exports the Rust
+# extension at ``fluxion.fluxion``. The ``source = ["fluxion"]`` below
+# tells maturin to include any ``.py`` files we add to that directory in
+# the wheel — required for the ``FluxionMeasure`` base class and the
+# ``fluxion apply-measures`` CLI (issue #1814).
+features = ["python-bindings"]
+module-name = "fluxion.fluxion"
 
 [tool.black]
 line-length = 88

--- a/tests/python/test_apply_measures_cli.py
+++ b/tests/python/test_apply_measures_cli.py
@@ -1,0 +1,709 @@
+"""Pytest suite for ``fluxion apply-measures`` and the FluxionMeasure API.
+
+Issue #1814 — Phase 2 (Python Measure API) of the Hybrid Measure Approach.
+
+These tests cover:
+
+- :class:`FluxionMeasure` base-class semantics (``apply`` / ``arguments``).
+- The runtime guard that warns when a measure runs on a rayon worker thread
+  or when ``FLUXION_INSIDE_TIMESTEPPING=1`` is set.
+- :func:`discover_measures` — directory walking and subclass collection.
+- :func:`apply_measures` — order preservation and argument plumbing.
+- :func:`save_model` / :func:`load_model` — JSON round-trip (msgpack if
+  installed).
+- The ``fluxion apply-measures`` CLI as a subprocess — end-to-end coverage
+  of the user-facing entry point.
+
+The suite is designed to be runnable in any of three modes:
+
+1. **With the native bindings installed** (``maturin develop``): every test
+   that touches a real model exercises the snapshot/owned-value path.
+2. **Without the native bindings** (CI without Rust toolchain): tests that
+   need a ``Model`` are skipped via the ``needs_fluxion`` marker (set up
+   by ``tests/conftest.py``). The pure-Python surface (discovery, argument
+   parsing, the runtime guard) is fully covered.
+3. **With msgpack available**: an extra round-trip test exercises the
+   ``.msgpack`` path; it is auto-skipped otherwise.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import textwrap
+import threading
+import warnings
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MEASURES_DIR = REPO_ROOT / "measures" / "examples"
+
+
+# ---------------------------------------------------------------------------
+# Module availability
+# ---------------------------------------------------------------------------
+
+
+fluxion_spec = importlib.util.find_spec("fluxion")
+HAS_FLUXION = fluxion_spec is not None
+
+requires_fluxion = pytest.mark.skipif(
+    not HAS_FLUXION,
+    reason="fluxion Python bindings not available (run `maturin develop`)",
+)
+
+HAS_MSGPACK = importlib.util.find_spec("msgpack") is not None
+requires_msgpack = pytest.mark.skipif(
+    not HAS_MSGPACK, reason="msgpack not installed"
+)
+
+
+# ---------------------------------------------------------------------------
+# FluxionMeasure semantics
+# ---------------------------------------------------------------------------
+
+
+@requires_fluxion
+class TestFluxionMeasureBase:
+    """Pure semantics of the abstract base class (no model mutation)."""
+
+    def test_base_apply_raises(self):
+        from fluxion import FluxionMeasure
+
+        m = importlib.import_module("fluxion")
+        model = m.Model(num_zones=1)
+
+        # Calling apply() on the base class must raise NotImplementedError.
+        with pytest.raises(NotImplementedError):
+            FluxionMeasure().apply(model, {})
+
+    def test_arguments_default_is_empty_list(self):
+        from fluxion import FluxionMeasure
+
+        assert FluxionMeasure().arguments() == []
+
+    def test_subclass_default_name_strips_measure_suffix(self):
+        from fluxion import FluxionMeasure
+
+        class AddInsulationMeasure(FluxionMeasure):
+            def apply(self, model, arguments):
+                pass
+
+        assert AddInsulationMeasure().name == "AddInsulation"
+
+    def test_subclass_explicit_name_is_preserved(self):
+        from fluxion import FluxionMeasure
+
+        class Foo(FluxionMeasure):
+            name = "My Explicit Name"
+
+            def apply(self, model, arguments):
+                pass
+
+        assert Foo().name == "My Explicit Name"
+
+    def test_parse_arguments_uses_defaults(self):
+        from fluxion import FluxionMeasure
+
+        class M(FluxionMeasure):
+            def arguments(self):
+                return [
+                    {"name": "depth", "type": "double", "default": 1.0},
+                    {"name": "height", "type": "double", "default": 2.0},
+                ]
+
+            def apply(self, model, arguments):
+                pass
+
+        m = M()
+        assert m.parse_arguments(None) == {"depth": 1.0, "height": 2.0}
+        assert m.parse_arguments({}) == {"depth": 1.0, "height": 2.0}
+        assert m.parse_arguments({"depth": 5.0}) == {"depth": 5.0, "height": 2.0}
+
+    def test_parse_arguments_warns_on_unknown_key(self):
+        from fluxion import FluxionMeasure
+
+        class M(FluxionMeasure):
+            def arguments(self):
+                return [{"name": "depth", "type": "double", "default": 1.0}]
+
+            def apply(self, model, arguments):
+                pass
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            M().parse_arguments({"unknown_key": 42})
+        assert any("unknown_key" in str(w.message) for w in caught), [
+            str(w.message) for w in caught
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Runtime guard
+# ---------------------------------------------------------------------------
+
+
+class TestRuntimeGuard:
+    """The AOT-only rule must emit a runtime warning on worker threads."""
+
+    def test_main_thread_does_not_warn(self):
+        from fluxion import FluxionMeasure
+
+        class M(FluxionMeasure):
+            def apply(self, model, arguments):
+                pass
+
+        instance = M()
+
+        # No native model needed: we never reach the base implementation
+        # because the subclass no-ops. We do need *some* model to call
+        # apply() though — fall back to a stub when fluxion is unavailable.
+        if HAS_FLUXION:
+            m = importlib.import_module("fluxion").Model(num_zones=1)
+        else:
+            m = object()  # type: ignore[assignment]
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            instance.apply(m, {})
+        assert not any(
+            "rayon" in str(w.message).lower() or "timestepping" in str(w.message).lower()
+            for w in caught
+        ), "Main thread must not trip the worker-thread guard"
+
+    def test_rayon_named_thread_warns(self):
+        from fluxion import FluxionMeasure
+
+        class M(FluxionMeasure):
+            def apply(self, model, arguments):
+                pass
+
+        instance = M()
+        m = importlib.import_module("fluxion").Model(num_zones=1) if HAS_FLUXION else object()
+
+        result: dict[str, list[warnings._Action]] = {}
+
+        def worker():
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                instance.apply(m, {})
+            result["caught"] = caught
+
+        t = threading.Thread(target=worker, name="rayon-7")
+        t.start()
+        t.join()
+        caught = result["caught"]
+        assert any(
+            "rayon" in str(w.message).lower() or "timestepping" in str(w.message).lower()
+            for w in caught
+        ), "Rayon-named thread must trip the guard"
+        # And the warning must be a RuntimeWarning.
+        assert any(
+            issubclass(w.category, RuntimeWarning) for w in caught
+        ), "Worker-thread warning must be RuntimeWarning"
+
+    def test_tokio_named_thread_warns(self):
+        from fluxion import FluxionMeasure
+
+        class M(FluxionMeasure):
+            def apply(self, model, arguments):
+                pass
+
+        instance = M()
+        m = importlib.import_module("fluxion").Model(num_zones=1) if HAS_FLUXION else object()
+
+        result: dict[str, list[warnings._Action]] = {}
+
+        def worker():
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                instance.apply(m, {})
+            result["caught"] = caught
+
+        t = threading.Thread(target=worker, name="tokio-runtime-worker")
+        t.start()
+        t.join()
+        assert any(
+            "timestepping" in str(w.message).lower() for w in result["caught"]
+        ), "Tokio-named thread must trip the guard"
+
+    def test_env_var_overrides_thread_name(self, monkeypatch):
+        from fluxion import FluxionMeasure
+
+        class M(FluxionMeasure):
+            def apply(self, model, arguments):
+                pass
+
+        monkeypatch.setenv("FLUXION_INSIDE_TIMESTEPPING", "1")
+        instance = M()
+        m = importlib.import_module("fluxion").Model(num_zones=1) if HAS_FLUXION else object()
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            instance.apply(m, {})
+        assert any(
+            "timestepping" in str(w.message).lower() for w in caught
+        ), "Env-var override must trip the guard even on MainThread"
+
+
+# ---------------------------------------------------------------------------
+# Measure discovery
+# ---------------------------------------------------------------------------
+
+
+class TestDiscovery:
+    """``discover_measures`` walks a directory and picks up subclasses."""
+
+    def test_discovers_example_measures(self):
+        from fluxion.measures import discover_measures
+
+        classes = discover_measures(MEASURES_DIR)
+        names = {c.__name__ for c in classes}
+        # AddSouthOverhang and SetHVACCOP are the bundled examples.
+        assert {"AddSouthOverhang", "SetHVACCOP"}.issubset(names), (
+            f"expected AddSouthOverhang and SetHVACCOP, got {names}"
+        )
+
+    def test_returns_empty_list_for_missing_directory(self, tmp_path):
+        from fluxion.measures import discover_measures
+
+        missing = tmp_path / "does-not-exist"
+        assert discover_measures(missing) == []
+
+    def test_skips_dunder_files(self, tmp_path):
+        from fluxion import FluxionMeasure
+        from fluxion.measures import discover_measures
+
+        # __init__.py is a real package marker; the discovery walker must
+        # skip it (it usually contains no measures).
+        (tmp_path / "__init__.py").write_text("")
+        (tmp_path / "good.py").write_text(
+            textwrap.dedent(
+                """
+                from fluxion import FluxionMeasure
+
+                class RealMeasure(FluxionMeasure):
+                    def apply(self, model, arguments):
+                        pass
+                """
+            )
+        )
+        (tmp_path / "_private.py").write_text(
+            textwrap.dedent(
+                """
+                from fluxion import FluxionMeasure
+
+                class PrivateMeasure(FluxionMeasure):
+                    def apply(self, model, arguments):
+                        pass
+                """
+            )
+        )
+
+        names = {c.__name__ for c in discover_measures(tmp_path)}
+        assert names == {"RealMeasure"}, f"got {names}"
+
+    def test_skips_abstract_subclasses(self, tmp_path):
+        from fluxion import FluxionMeasure
+        from fluxion.measures import discover_measures
+
+        # Use abc.ABCMeta + @abstractmethod so inspect.isabstract() picks it
+        # up reliably. (Inspecting for "raises NotImplementedError" body is
+        # too brittle for static analysis.)
+        (tmp_path / "abstract.py").write_text(
+            textwrap.dedent(
+                """
+                from abc import abstractmethod
+                from fluxion import FluxionMeasure
+
+                class AbstractBase(FluxionMeasure):
+                    @abstractmethod
+                    def apply(self, model, arguments):
+                        ...
+                """
+            )
+        )
+        (tmp_path / "concrete.py").write_text(
+            textwrap.dedent(
+                """
+                from fluxion import FluxionMeasure
+
+                class Concrete(FluxionMeasure):
+                    def apply(self, model, arguments):
+                        pass
+                """
+            )
+        )
+
+        names = {c.__name__ for c in discover_measures(tmp_path)}
+        assert names == {"Concrete"}, f"abstract leaked through: {names}"
+
+    def test_import_failures_are_warned_not_raised(self, tmp_path):
+        from fluxion.measures import discover_measures
+
+        (tmp_path / "broken.py").write_text(
+            textwrap.dedent(
+                """
+                import this_module_does_not_exist
+                """
+            )
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = discover_measures(tmp_path)
+        # Discovery must not crash — it should return [] and warn.
+        assert result == []
+        assert any("broken.py" in str(w.message) for w in caught)
+
+
+# ---------------------------------------------------------------------------
+# apply_measures
+# ---------------------------------------------------------------------------
+
+
+@requires_fluxion
+class TestApplyMeasures:
+    """``apply_measures`` orchestrates the measure chain."""
+
+    def _make_counter_measure(self):
+        from fluxion import FluxionMeasure
+        from fluxion.measures import apply_measures
+
+        counter = {"calls": 0, "args": []}
+
+        class CallCounter(FluxionMeasure):
+            name = "CallCounter"
+
+            def arguments(self):
+                return [{"name": "marker", "type": "string", "default": "default"}]
+
+            def apply(self, model, arguments):
+                counter["calls"] += 1
+                counter["args"].append(arguments)
+
+        return CallCounter, counter, apply_measures
+
+    def test_measures_run_in_order(self):
+        from fluxion import FluxionMeasure
+        from fluxion.measures import apply_measures
+
+        order = []
+
+        class A(FluxionMeasure):
+            def apply(self, model, arguments):
+                order.append("A")
+
+        class B(FluxionMeasure):
+            def apply(self, model, arguments):
+                order.append("B")
+
+        class C(FluxionMeasure):
+            def apply(self, model, arguments):
+                order.append("C")
+
+        m = importlib.import_module("fluxion").Model(num_zones=1)
+        applied = apply_measures(m, [A, B, C])
+        assert order == ["A", "B", "C"]
+        assert applied == ["A", "B", "C"]
+
+    def test_arguments_passed_through(self):
+        Measure, counter, apply_measures = self._make_counter_measure()
+        m = importlib.import_module("fluxion").Model(num_zones=1)
+        apply_measures(
+            m,
+            [Measure],
+            measure_args={"CallCounter": {"marker": "from-cli"}},
+        )
+        assert counter["calls"] == 1
+        assert counter["args"] == [{"marker": "from-cli"}]
+
+    def test_missing_measure_args_uses_defaults(self):
+        Measure, counter, apply_measures = self._make_counter_measure()
+        m = importlib.import_module("fluxion").Model(num_zones=1)
+        apply_measures(m, [Measure])
+        assert counter["args"] == [{"marker": "default"}]
+
+    def test_accepts_already_constructed_instance(self):
+        from fluxion import FluxionMeasure
+        from fluxion.measures import apply_measures
+
+        seen = {"v": None}
+
+        class M(FluxionMeasure):
+            def apply(self, model, arguments):
+                seen["v"] = arguments.get("v")
+
+        m = importlib.import_module("fluxion").Model(num_zones=1)
+        instance = M()
+        apply_measures(m, [instance], {"M": {"v": 42}})
+        assert seen["v"] == 42
+
+    def test_rejects_non_measure_classes(self):
+        from fluxion.measures import apply_measures
+
+        class NotAMeasure:
+            pass
+
+        m = importlib.import_module("fluxion").Model(num_zones=1)
+        with pytest.raises(TypeError):
+            apply_measures(m, [NotAMeasure])  # type: ignore[list-item]
+
+
+# ---------------------------------------------------------------------------
+# save / load round-trip
+# ---------------------------------------------------------------------------
+
+
+@requires_fluxion
+class TestSerialization:
+    """JSON round-trip preserves the mutations a measure chain applies."""
+
+    def test_json_round_trip(self, tmp_path):
+        from fluxion.measures import apply_measures, load_model, save_model
+
+        m = importlib.import_module("fluxion").Model(num_zones=2)
+        apply_measures(m, [])  # no-op, just baseline
+        path = tmp_path / "model.json"
+        save_model(m, path)
+
+        loaded = load_model(path)
+        assert loaded.num_zones() == 2
+
+    def test_apply_overhang_persists_through_json(self, tmp_path):
+        from fluxion.measures import apply_measures, load_model, save_model
+
+        m = importlib.import_module("fluxion").Model(num_zones=1)
+        apply_measures(
+            m,
+            [_import_example("AddSouthOverhang")],
+            {"AddSouthOverhang": {"depth": 1.5, "height": 3.0}},
+        )
+
+        path = tmp_path / "overhang.json"
+        save_model(m, path)
+        m2 = load_model(path)
+
+        south = [
+            s for s in m2.surfaces()
+            if s.orientation == importlib.import_module("fluxion").Orientation.South
+        ]
+        assert south, "expected at least one south-facing surface"
+        assert all(s.overhang_depth == 1.5 for s in south)
+        assert all(s.overhang_height == 3.0 for s in south)
+
+    def test_hvac_capacity_persists_through_json(self, tmp_path):
+        from fluxion.measures import apply_measures, load_model, save_model
+
+        m = importlib.import_module("fluxion").Model(num_zones=1)
+        apply_measures(
+            m,
+            [_import_example("SetHVACCOP")],
+            {"SetHVACCOP": {"heating_capacity": 25000, "cooling_capacity": 20000}},
+        )
+
+        path = tmp_path / "hvac.json"
+        save_model(m, path)
+        m2 = load_model(path)
+
+        hvac = m2.hvac_system()
+        assert hvac.heating_capacity == pytest.approx(25000.0, rel=1e-9)
+        assert hvac.cooling_capacity == pytest.approx(20000.0, rel=1e-9)
+
+    @requires_msgpack
+    def test_msgpack_round_trip(self, tmp_path):
+        from fluxion.measures import apply_measures, load_model, save_model
+
+        m = importlib.import_module("fluxion").Model(num_zones=1)
+        apply_measures(
+            m,
+            [_import_example("AddSouthOverhang")],
+            {"AddSouthOverhang": {"depth": 0.5, "height": 1.0}},
+        )
+
+        path = tmp_path / "model.msgpack"
+        save_model(m, path)
+        assert path.exists() and path.stat().st_size > 0
+
+        m2 = load_model(path)
+        assert m2.num_zones() == 1
+        # Shading should still be applied.
+        orient = importlib.import_module("fluxion").Orientation.South
+        assert any(
+            s.overhang_depth == 0.5 for s in m2.surfaces() if s.orientation == orient
+        )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end CLI
+# ---------------------------------------------------------------------------
+
+
+@requires_fluxion
+class TestApplyMeasuresCLI:
+    """Drive the ``fluxion apply-measures`` CLI as a subprocess."""
+
+    def _run_cli(self, *args):
+        """Invoke the package's main() through ``python -m fluxion.cli``."""
+        result = subprocess.run(
+            [sys.executable, "-m", "fluxion.cli", *args],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+        )
+        return result
+
+    def test_help_lists_apply_measures(self):
+        result = self._run_cli("--help")
+        assert result.returncode == 0
+        assert "apply-measures" in result.stdout
+
+    def test_apply_measures_help(self):
+        result = self._run_cli("apply-measures", "--help")
+        assert result.returncode == 0
+        assert "--model" in result.stdout
+        assert "--measures" in result.stdout
+        assert "--output" in result.stdout
+
+    def test_end_to_end(self, tmp_path):
+        fluxion_mod = importlib.import_module("fluxion")
+        from fluxion.measures import save_model
+
+        base = fluxion_mod.Model(num_zones=1)
+        base_path = tmp_path / "base.json"
+        save_model(base, base_path)
+
+        out_path = tmp_path / "out.json"
+        result = self._run_cli(
+            "apply-measures",
+            "--model", str(base_path),
+            "--measures", str(MEASURES_DIR),
+            "--output", str(out_path),
+        )
+        assert result.returncode == 0, result.stderr
+        assert out_path.exists(), "CLI did not write the output file"
+
+        # The CLI returns a summary on stdout and embeds it in the output
+        # JSON under ``_fluxion_run`` so the file is self-describing.
+        stdout_summary = json.loads(result.stdout)
+        assert "AddSouthOverhang" in stdout_summary["applied"]
+        assert "SetHVACCOP" in stdout_summary["applied"]
+
+        payload = json.loads(out_path.read_text())
+        assert payload["num_zones"] == 1
+        assert payload["schema_version"] == "1.0.0"
+        assert "AddSouthOverhang" in payload["_fluxion_run"]["applied"]
+        assert "SetHVACCOP" in payload["_fluxion_run"]["applied"]
+
+        # The model should now have overhangs on south-facing surfaces.
+        from fluxion.measures import load_model
+
+        m2 = load_model(out_path)
+        south = [
+            s for s in m2.surfaces() if s.orientation == fluxion_mod.Orientation.South
+        ]
+        assert south and all(s.overhang_depth == 1.0 for s in south)
+        # Default HVAC capacity from SetHVACCOP.
+        assert m2.hvac_system().heating_capacity == pytest.approx(15000.0, rel=1e-9)
+
+    def test_list_only_does_not_write(self, tmp_path):
+        result = self._run_cli(
+            "apply-measures",
+            "--model", str(tmp_path / "missing.json"),
+            "--measures", str(MEASURES_DIR),
+            "--list",
+        )
+        # --list mode should not complain about a missing model because it
+        # only walks the measures directory.
+        assert result.returncode == 0, result.stderr
+        names = json.loads(result.stdout)
+        assert "AddSouthOverhang" in names
+        assert "SetHVACCOP" in names
+
+    def test_missing_model_returns_error(self, tmp_path):
+        result = self._run_cli(
+            "apply-measures",
+            "--model", str(tmp_path / "missing.json"),
+            "--measures", str(MEASURES_DIR),
+            "--output", str(tmp_path / "out.json"),
+        )
+        assert result.returncode != 0
+        assert "not found" in result.stderr.lower()
+
+    def test_measure_args_propagate(self, tmp_path):
+        fluxion_mod = importlib.import_module("fluxion")
+        from fluxion.measures import save_model
+
+        base = fluxion_mod.Model(num_zones=1)
+        base_path = tmp_path / "base.json"
+        save_model(base, base_path)
+
+        args_path = tmp_path / "args.json"
+        args_path.write_text(
+            json.dumps(
+                {
+                    "AddSouthOverhang": {"depth": 2.0, "height": 4.0},
+                    "SetHVACCOP": {"heating_capacity": 99999, "cooling_capacity": 88888},
+                }
+            )
+        )
+
+        out_path = tmp_path / "out.json"
+        result = self._run_cli(
+            "apply-measures",
+            "--model", str(base_path),
+            "--measures", str(MEASURES_DIR),
+            "--measure-args", str(args_path),
+            "--output", str(out_path),
+        )
+        assert result.returncode == 0, result.stderr
+
+        from fluxion.measures import load_model
+
+        m2 = load_model(out_path)
+        south = [
+            s for s in m2.surfaces() if s.orientation == fluxion_mod.Orientation.South
+        ]
+        assert south and all(s.overhang_depth == 2.0 for s in south)
+        assert m2.hvac_system().heating_capacity == pytest.approx(99999.0, rel=1e-9)
+        assert m2.hvac_system().cooling_capacity == pytest.approx(88888.0, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _import_example(class_name: str):
+    """Import a concrete measure class from ``measures/examples/`` by name."""
+    import importlib
+
+    # Insert the measures dir on sys.path so importlib.util picks it up.
+    measures_path = str(MEASURES_DIR)
+    added = measures_path not in sys.path
+    if added:
+        sys.path.insert(0, measures_path)
+    try:
+        # The example files use absolute-style imports (``from fluxion ...``).
+        # They are loaded via spec_from_file_location by discover_measures(),
+        # so importing here by file is the most reliable path.
+        from importlib.util import module_from_spec, spec_from_file_location
+
+        for fname in ("add_overhang.py", "set_hvac_cop.py"):
+            spec = spec_from_file_location(
+                f"_measure_example_{fname[:-3]}",
+                str(MEASURES_DIR / fname),
+            )
+            assert spec is not None and spec.loader is not None
+            module = module_from_spec(spec)
+            spec.loader.exec_module(module)
+            if hasattr(module, class_name):
+                return getattr(module, class_name)
+        raise AssertionError(f"no measure class named {class_name} found")
+    finally:
+        if added:
+            sys.path.remove(measures_path)


### PR DESCRIPTION
Closes #1814

Adds the FluxionMeasure Python base class (apply, arguments) and the `fluxion apply-measures` AOT runner CLI. Measures are pre-processing steps that mutate a model once and serialize to JSON/msgpack. Documents the GIL-on-rayon rationale and emits a runtime warning if a measure runs from a worker thread.