### PR TITLE
feat(hvac): resolve #1767 — numerical-stability integration of airside models with 9R4C envelope solver

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -757,6 +757,14 @@ These traits support the main physics pipeline and should also be documented:
 | `SurfaceHeatFluxProvider` | `src/sim/surface_flux_provider.rs` | Surface-level heat flux abstraction (conduction + solar combined) |
 | `WeatherSource` | `fluxion-core/src/weather/mod.rs` | Weather data access abstraction |
 | `PsychrometricCalculations` | `fluxion-core/src/weather/psychrometrics.rs` | Moist air property calculations |
+| `MaterialLayer` | `src/sim/assembly.rs` | Building material layer interface |
+| `Equipment` | `src/sim/equipment.rs` | HVAC equipment trait |
+| `VariableCapacityEquipment` | `src/sim/hvac/equipment.rs` | Variable-speed equipment |
+| `GroundTemperature` | `src/sim/boundary.rs` | Ground temp boundary condition |
+| `BatchOrchestrator` | `src/sim/orchestrator.rs` | Per-population CPU surrogate compute scheduling (rayon `par_chunks`, #1439) |
+| `DwaveClient` | `src/quantum/dwave_client.rs` | Object-safe trait for submitting Ising problems to a D-Wave sampler (QPU or hybrid); mockable for tests |
+| `EmailTransport` | `src/api/email_notification.rs` | Abstraction for sending email notifications (campaign completion fallback); mockable for tests |
+| `SimulationStateStore` | `src/api/server.rs` | Simulation state persistence trait (in-memory or cloud-backed); enables stateless API servers |
 
 **Psychrometrics library** (#1760): `fluxion-core/src/weather/psychrometrics.rs` is the dependency-light, cycle-safe psychrometrics library that all airside HVAC equipment depends on. It implements ASHRAE Handbook of Fundamentals, Chapter 1 formulas in SI units:
 
@@ -771,14 +779,10 @@ These traits support the main physics pipeline and should also be documented:
 | `moist_air_density(t_c, w, p_pa)` → kg/m³ | Eq. 28 | `fn(f64, f64, f64) -> f64` |
 
 All functions take SI units (Pa, K/°C, kg/kg). Module is in `fluxion-core` to respect the cycle-breaking rule (#1255, #1349, #1441) — no `sim`, `physics`, `ai`, or `validation` deps. Round-trip and ASHRAE-reference unit tests verify accuracy at 1 % tolerance against ASHRAE HoF 2021 Ch.1 Tables 1 & 2.
-| `MaterialLayer` | `src/sim/assembly.rs` | Building material layer interface |
-| `Equipment` | `src/sim/equipment.rs` | HVAC equipment trait |
-| `VariableCapacityEquipment` | `src/sim/hvac/equipment.rs` | Variable-speed equipment |
-| `GroundTemperature` | `src/sim/boundary.rs` | Ground temp boundary condition |
-| `BatchOrchestrator` | `src/sim/orchestrator.rs` | Per-population CPU surrogate compute scheduling (rayon `par_chunks`, #1439) |
-| `DwaveClient` | `src/quantum/dwave_client.rs` | Object-safe trait for submitting Ising problems to a D-Wave sampler (QPU or hybrid); mockable for tests |
-| `EmailTransport` | `src/api/email_notification.rs` | Abstraction for sending email notifications (campaign completion fallback); mockable for tests |
-| `SimulationStateStore` | `src/api/server.rs` | Simulation state persistence trait (in-memory or cloud-backed); enables stateless API servers |
+
+**Airside/9R4C coupling** (#1767): `src/sim/hvac/airside_state.rs` defines validated `MoistAirState` and `AirsideFlow` values; `src/sim/hvac/airside_coupling.rs` owns the transactional `AirsideEnvelopeCoupler`. The airside component boundary is supply dry-bulb, relative humidity, pressure, and volume flow, so VAV/DOAS implementations can plug in without the coupling layer inventing fan or coil correlations.
+
+The coupled step uses a sequential implicit operator split: backward-Euler 9R4C half-step → implicit algebraic zone-air solve → backward-Euler half-step → implicit air projection, followed by a backward-Euler humidity-ratio balance. Supply sensible conductance is `H_sa = m_da × 1000 × (1.006 + 1.86 W_sa)` [W/K], and the air solve enforces `Q_env + H_ve(T_out − T_z) + H_sa(T_sa − T_z) + φ_ia = 0`. Sensible and latent supply heat reconstruct the ASHRAE Ch.1 moist-air enthalpy flow exactly; the per-step interface residual must remain below `1e-7 W`. The accepted timestep domain is `0 < dt ≤ 360 s`; non-finite inputs, supersaturated post-mixing states, and larger timesteps return typed errors without committing partial state. The coupling is opt-in and does not modify `ThermalModel::step_physics_9r4c`, preserving existing ASHRAE 140 envelope outputs. Regression: `tests/hvac_airside_9r4c_integration.rs`.
 
 ### Surface Heat Flux Trait Hierarchy
 

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -159,6 +159,8 @@ src/
 │   ├── equipment.rs        # HVAC equipment models
 │   ├── boundary.rs         # Boundary conditions
 │   └── hvac/              # HVAC system models
+│       ├── airside_state.rs    # Validated moist-air and supply-flow boundary values
+│       └── airside_coupling.rs # Transactional 6-min operator split with 9R4C
 │
 ├── solar/                  # Solar calculations
 │

--- a/src/sim/hvac/airside_coupling.rs
+++ b/src/sim/hvac/airside_coupling.rs
@@ -1,0 +1,381 @@
+//! Stable coupling between airside supply-air states and the 9R4C envelope.
+//!
+//! The airside component issues (#1761-#1765) produce supply temperature,
+//! humidity and flow. This module is the integration boundary: it deliberately
+//! contains no fan or coil correlations.
+//!
+//! # Coupling scheme
+//!
+//! Each timestep uses a sequential implicit operator split:
+//!
+//! 1. Advance the 9R4C mass nodes by `dt / 2` with backward Euler.
+//! 2. Solve the algebraic zone-air node implicitly with ventilation and supply.
+//! 3. Repeat the half envelope step and implicit air solve.
+//! 4. Advance zone humidity ratio with backward Euler.
+//!
+//! The implicit kernels are unconditionally stable for positive capacitances
+//! and conductances. Validation covers `dt <= 360 s` (six minutes); larger
+//! timesteps are rejected because their splitting error is not accepted here.
+
+use super::airside_state::{
+    validate_finite, validate_nonnegative, validate_positive, AirsideCouplingError, AirsideFlow,
+    MoistAirState, CP_WATER_VAPOR_KJ_PER_KG_K, DEFAULT_ENERGY_BALANCE_TOLERANCE_W,
+    LATENT_HEAT_0C_KJ_PER_KG, MAX_VALIDATED_TIMESTEP_SECONDS,
+};
+use crate::physics::multi_node_solver::{h_series, MultiNodeSolver, SurfaceExteriorTemperatures};
+use fluxion_core::multi_node::MassAirCouplingMode;
+
+const MIN_POSITIVE: f64 = 1.0e-12;
+
+/// Envelope, weather, ventilation, and internal-gain forcing for one timestep.
+#[derive(Debug, Clone)]
+pub struct CoupledStepForcing {
+    pub exterior_temperatures: SurfaceExteriorTemperatures,
+    pub outdoor_air: MoistAirState,
+    pub ventilation_conductance_w_per_k: f64,
+    pub convective_gain_w: f64,
+    /// `[wall, roof, floor, internal]` heat-gain rates in watts.
+    pub envelope_gains_w: [f64; 4],
+}
+
+/// Diagnostics from one accepted coupled timestep.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CoupledStepResult {
+    pub zone_air: MoistAirState,
+    pub envelope_node_temperatures_c: [f64; 4],
+    pub supply_dry_air_mass_flow_kg_per_s: f64,
+    pub supply_sensible_heat_w: f64,
+    pub supply_latent_heat_w: f64,
+    pub supply_total_heat_w: f64,
+    pub ventilation_total_heat_w: f64,
+    pub latent_storage_rate_w: f64,
+    pub sensible_balance_residual_w: f64,
+    pub latent_balance_residual_w: f64,
+    pub energy_balance_residual_w: f64,
+    pub moisture_balance_residual_kg_per_s: f64,
+}
+
+impl CoupledStepResult {
+    pub fn is_finite(&self) -> bool {
+        self.zone_air.is_finite()
+            && self
+                .envelope_node_temperatures_c
+                .into_iter()
+                .all(f64::is_finite)
+            && [
+                self.supply_dry_air_mass_flow_kg_per_s,
+                self.supply_sensible_heat_w,
+                self.supply_latent_heat_w,
+                self.supply_total_heat_w,
+                self.ventilation_total_heat_w,
+                self.latent_storage_rate_w,
+                self.sensible_balance_residual_w,
+                self.latent_balance_residual_w,
+                self.energy_balance_residual_w,
+                self.moisture_balance_residual_kg_per_s,
+            ]
+            .into_iter()
+            .all(f64::is_finite)
+    }
+}
+
+/// Transactional, stability-preserving airside/9R4C coupling controller.
+#[derive(Debug, Clone)]
+pub struct AirsideEnvelopeCoupler {
+    envelope: MultiNodeSolver,
+    zone_air: MoistAirState,
+    zone_dry_air_mass_kg: f64,
+}
+
+impl AirsideEnvelopeCoupler {
+    pub fn new(
+        mut envelope: MultiNodeSolver,
+        initial_zone_air: MoistAirState,
+        zone_volume_m3: f64,
+    ) -> Result<Self, AirsideCouplingError> {
+        validate_positive("zone_volume_m3", zone_volume_m3)?;
+        initial_zone_air.validate_derived()?;
+        validate_envelope(&envelope)?;
+        let zone_dry_air_mass_kg = initial_zone_air.density_kg_per_m3 * zone_volume_m3
+            / (1.0 + initial_zone_air.humidity_ratio_kg_per_kg_dry_air);
+        validate_positive("zone_dry_air_mass_kg", zone_dry_air_mass_kg)?;
+        envelope.set_zone_temperature(initial_zone_air.dry_bulb_c);
+        Ok(Self {
+            envelope,
+            zone_air: initial_zone_air,
+            zone_dry_air_mass_kg,
+        })
+    }
+
+    pub fn envelope(&self) -> &MultiNodeSolver {
+        &self.envelope
+    }
+
+    pub fn zone_air(&self) -> &MoistAirState {
+        &self.zone_air
+    }
+
+    /// Advance one coupled timestep and commit only after all balance checks pass.
+    pub fn step(
+        &mut self,
+        dt_seconds: f64,
+        forcing: &CoupledStepForcing,
+        airside: &AirsideFlow,
+    ) -> Result<CoupledStepResult, AirsideCouplingError> {
+        validate_positive("dt_seconds", dt_seconds)?;
+        if dt_seconds > MAX_VALIDATED_TIMESTEP_SECONDS {
+            return Err(AirsideCouplingError::TimestepExceedsValidatedMaximum { dt_seconds });
+        }
+        validate_forcing(forcing)?;
+        validate_envelope(&self.envelope)?;
+
+        // Transactional update prevents a failed finite-state check from
+        // poisoning the last accepted envelope and zone-air state.
+        let mut envelope = self.envelope.clone();
+        envelope.set_surface_exterior_temperatures(forcing.exterior_temperatures.clone());
+
+        let supply_conductance_w_per_k = airside.dry_air_mass_flow_kg_per_s()
+            * airside.supply_air().dry_air_specific_heat_j_per_kg_k();
+        validate_nonnegative("supply_conductance_w_per_k", supply_conductance_w_per_k)?;
+
+        let half_dt = dt_seconds / 2.0;
+        let mut zone_temperature_c = self.zone_air.dry_bulb_c;
+        for _ in 0..2 {
+            envelope.set_zone_temperature(zone_temperature_c);
+            envelope.step_with_gains(
+                half_dt,
+                forcing.envelope_gains_w[0],
+                forcing.envelope_gains_w[1],
+                forcing.envelope_gains_w[2],
+                forcing.envelope_gains_w[3],
+            );
+            validate_envelope(&envelope)?;
+            zone_temperature_c = solve_air_node_temperature(
+                &envelope,
+                forcing,
+                airside,
+                supply_conductance_w_per_k,
+            )?;
+        }
+        envelope.set_zone_temperature(zone_temperature_c);
+
+        let outdoor_cp = forcing.outdoor_air.dry_air_specific_heat_j_per_kg_k();
+        let ventilation_dry_air_mass_flow_kg_per_s =
+            forcing.ventilation_conductance_w_per_k / outdoor_cp;
+        let moisture_denominator = self.zone_dry_air_mass_kg / dt_seconds
+            + airside.dry_air_mass_flow_kg_per_s()
+            + ventilation_dry_air_mass_flow_kg_per_s;
+        let new_humidity_ratio = (self.zone_dry_air_mass_kg / dt_seconds
+            * self.zone_air.humidity_ratio_kg_per_kg_dry_air
+            + airside.dry_air_mass_flow_kg_per_s()
+                * airside.supply_air().humidity_ratio_kg_per_kg_dry_air
+            + ventilation_dry_air_mass_flow_kg_per_s
+                * forcing.outdoor_air.humidity_ratio_kg_per_kg_dry_air)
+            / moisture_denominator;
+        let zone_air = MoistAirState::from_humidity_ratio(
+            zone_temperature_c,
+            new_humidity_ratio,
+            self.zone_air.pressure_pa,
+        )?;
+
+        let result = coupled_diagnostics(
+            &envelope,
+            &self.zone_air,
+            zone_air,
+            self.zone_dry_air_mass_kg,
+            dt_seconds,
+            forcing,
+            airside,
+            ventilation_dry_air_mass_flow_kg_per_s,
+            supply_conductance_w_per_k,
+        )?;
+        if result.energy_balance_residual_w.abs() > DEFAULT_ENERGY_BALANCE_TOLERANCE_W {
+            return Err(AirsideCouplingError::EnergyBalanceViolation {
+                residual_w: result.energy_balance_residual_w,
+                tolerance_w: DEFAULT_ENERGY_BALANCE_TOLERANCE_W,
+            });
+        }
+
+        self.envelope = envelope;
+        self.zone_air = zone_air;
+        Ok(result)
+    }
+}
+
+fn solve_air_node_temperature(
+    envelope: &MultiNodeSolver,
+    forcing: &CoupledStepForcing,
+    airside: &AirsideFlow,
+    supply_conductance_w_per_k: f64,
+) -> Result<f64, AirsideCouplingError> {
+    let source_conductance = forcing.ventilation_conductance_w_per_k + supply_conductance_w_per_k;
+    let source_temperature = if source_conductance > MIN_POSITIVE {
+        (forcing.ventilation_conductance_w_per_k * forcing.outdoor_air.dry_bulb_c
+            + supply_conductance_w_per_k * airside.supply_air().dry_bulb_c)
+            / source_conductance
+    } else {
+        forcing.outdoor_air.dry_bulb_c
+    };
+    let temperature = envelope.compute_zone_air_temperature(
+        source_temperature,
+        source_conductance,
+        0.0,
+        forcing.convective_gain_w,
+    );
+    validate_finite("zone_temperature_c", temperature)?;
+    Ok(temperature)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn coupled_diagnostics(
+    envelope: &MultiNodeSolver,
+    old_zone_air: &MoistAirState,
+    new_zone_air: MoistAirState,
+    zone_dry_air_mass_kg: f64,
+    dt_seconds: f64,
+    forcing: &CoupledStepForcing,
+    airside: &AirsideFlow,
+    ventilation_dry_air_mass_flow_kg_per_s: f64,
+    supply_conductance_w_per_k: f64,
+) -> Result<CoupledStepResult, AirsideCouplingError> {
+    let t_zone = new_zone_air.dry_bulb_c;
+    let q_envelope_to_air_w = envelope_air_heat_w(envelope, t_zone);
+    let q_ventilation_sensible_w =
+        forcing.ventilation_conductance_w_per_k * (forcing.outdoor_air.dry_bulb_c - t_zone);
+    let supply_sensible_heat_w =
+        supply_conductance_w_per_k * (airside.supply_air().dry_bulb_c - t_zone);
+    let sensible_balance_residual_w = q_envelope_to_air_w
+        + q_ventilation_sensible_w
+        + supply_sensible_heat_w
+        + forcing.convective_gain_w;
+
+    let supply_total_heat_w = airside.dry_air_mass_flow_kg_per_s()
+        * (airside.supply_air().enthalpy_kj_per_kg_dry_air
+            - new_zone_air.enthalpy_kj_per_kg_dry_air)
+        * 1000.0;
+    let ventilation_total_heat_w = ventilation_dry_air_mass_flow_kg_per_s
+        * (forcing.outdoor_air.enthalpy_kj_per_kg_dry_air
+            - new_zone_air.enthalpy_kj_per_kg_dry_air)
+        * 1000.0;
+    let supply_latent_heat_w = supply_total_heat_w - supply_sensible_heat_w;
+    let ventilation_latent_heat_w = ventilation_total_heat_w - q_ventilation_sensible_w;
+    let latent_storage_rate_w = zone_dry_air_mass_kg / dt_seconds
+        * (new_zone_air.humidity_ratio_kg_per_kg_dry_air
+            - old_zone_air.humidity_ratio_kg_per_kg_dry_air)
+        * (LATENT_HEAT_0C_KJ_PER_KG + CP_WATER_VAPOR_KJ_PER_KG_K * new_zone_air.dry_bulb_c)
+        * 1000.0;
+    let latent_balance_residual_w =
+        supply_latent_heat_w + ventilation_latent_heat_w - latent_storage_rate_w;
+    let energy_balance_residual_w = sensible_balance_residual_w + latent_balance_residual_w;
+
+    let moisture_sources_kg_per_s = airside.dry_air_mass_flow_kg_per_s()
+        * (airside.supply_air().humidity_ratio_kg_per_kg_dry_air
+            - new_zone_air.humidity_ratio_kg_per_kg_dry_air)
+        + ventilation_dry_air_mass_flow_kg_per_s
+            * (forcing.outdoor_air.humidity_ratio_kg_per_kg_dry_air
+                - new_zone_air.humidity_ratio_kg_per_kg_dry_air);
+    let moisture_storage_kg_per_s = zone_dry_air_mass_kg / dt_seconds
+        * (new_zone_air.humidity_ratio_kg_per_kg_dry_air
+            - old_zone_air.humidity_ratio_kg_per_kg_dry_air);
+    let moisture_balance_residual_kg_per_s = moisture_sources_kg_per_s - moisture_storage_kg_per_s;
+
+    let result = CoupledStepResult {
+        zone_air: new_zone_air,
+        envelope_node_temperatures_c: envelope.snapshot_temperatures(),
+        supply_dry_air_mass_flow_kg_per_s: airside.dry_air_mass_flow_kg_per_s(),
+        supply_sensible_heat_w,
+        supply_latent_heat_w,
+        supply_total_heat_w,
+        ventilation_total_heat_w,
+        latent_storage_rate_w,
+        sensible_balance_residual_w,
+        latent_balance_residual_w,
+        energy_balance_residual_w,
+        moisture_balance_residual_kg_per_s,
+    };
+    if !result.is_finite() {
+        return Err(AirsideCouplingError::NonFinitePsychrometricProperty {
+            property: "coupled_step_result",
+        });
+    }
+    Ok(result)
+}
+
+fn envelope_air_heat_w(envelope: &MultiNodeSolver, t_zone_c: f64) -> f64 {
+    match envelope.coupling_mode {
+        MassAirCouplingMode::AdditiveSum => {
+            let h_total = envelope.mass.wall.h_tr_ms
+                + envelope.mass.roof.h_tr_ms
+                + envelope.mass.floor.h_tr_ms;
+            let t_surface = if h_total > MIN_POSITIVE {
+                (envelope.mass.wall.h_tr_ms * envelope.mass.wall.temperature
+                    + envelope.mass.roof.h_tr_ms * envelope.mass.roof.temperature
+                    + envelope.mass.floor.h_tr_ms * envelope.mass.floor.temperature)
+                    / h_total
+            } else {
+                envelope.envelope_temperature()
+            };
+            envelope.h_tr_is * (t_surface - t_zone_c)
+        }
+        MassAirCouplingMode::ParallelResistance => {
+            h_series(envelope.mass.wall.h_tr_ms, envelope.h_tr_is)
+                * (envelope.mass.wall.temperature - t_zone_c)
+                + h_series(envelope.mass.roof.h_tr_ms, envelope.h_tr_is)
+                    * (envelope.mass.roof.temperature - t_zone_c)
+                + h_series(envelope.mass.floor.h_tr_ms, envelope.h_tr_is)
+                    * (envelope.mass.floor.temperature - t_zone_c)
+        }
+    }
+}
+
+fn validate_forcing(forcing: &CoupledStepForcing) -> Result<(), AirsideCouplingError> {
+    forcing.outdoor_air.validate_derived()?;
+    for (field, value) in [
+        ("t_ext_wall", forcing.exterior_temperatures.t_ext_wall),
+        ("t_ext_roof", forcing.exterior_temperatures.t_ext_roof),
+        ("t_ext_floor", forcing.exterior_temperatures.t_ext_floor),
+        ("convective_gain_w", forcing.convective_gain_w),
+    ] {
+        validate_finite(field, value)?;
+    }
+    validate_nonnegative(
+        "ventilation_conductance_w_per_k",
+        forcing.ventilation_conductance_w_per_k,
+    )?;
+    for value in forcing.envelope_gains_w {
+        validate_finite("envelope_gain_w", value)?;
+    }
+    Ok(())
+}
+
+fn validate_envelope(envelope: &MultiNodeSolver) -> Result<(), AirsideCouplingError> {
+    let nodes = [
+        &envelope.mass.wall,
+        &envelope.mass.roof,
+        &envelope.mass.floor,
+        &envelope.mass.internal,
+    ];
+    let valid = envelope.h_tr_is.is_finite()
+        && envelope.h_tr_is > 0.0
+        && envelope.zone_temperature.is_finite()
+        && envelope.surface_temperature.is_finite()
+        && nodes.iter().all(|node| {
+            node.temperature.is_finite()
+                && node.capacitance.is_finite()
+                && node.capacitance > 0.0
+                && node.h_tr_ms.is_finite()
+                && node.h_tr_ms >= 0.0
+                && node.h_tr_em.is_finite()
+                && node.h_tr_em >= 0.0
+                && node.h_tr_me.is_finite()
+                && node.h_tr_me >= 0.0
+        })
+        && envelope.mass.wall.h_tr_ms > 0.0
+        && envelope.mass.roof.h_tr_ms > 0.0
+        && envelope.mass.floor.h_tr_ms > 0.0;
+    if valid {
+        Ok(())
+    } else {
+        Err(AirsideCouplingError::InvalidEnvelopeState)
+    }
+}

--- a/src/sim/hvac/airside_state.rs
+++ b/src/sim/hvac/airside_state.rs
@@ -1,0 +1,264 @@
+//! Psychrometric state and supply-flow types for airside HVAC coupling.
+//!
+//! Properties use ASHRAE Handbook—Fundamentals (2021), Chapter 1 in SI
+//! units. Construction rejects non-finite, negative-humidity, and
+//! supersaturated states before they reach the thermal solver.
+
+use fluxion_core::weather::psychrometrics::{
+    calculate_enthalpy, calculate_humidity_ratio, calculate_wet_bulb, moist_air_density,
+    partial_vapor_pressure, saturation_vapor_pressure,
+};
+use thiserror::Error;
+
+pub(crate) const CP_WATER_VAPOR_KJ_PER_KG_K: f64 = 1.86;
+pub(crate) const LATENT_HEAT_0C_KJ_PER_KG: f64 = 2501.0;
+const CP_DRY_AIR_KJ_PER_KG_K: f64 = 1.006;
+const SATURATION_TOLERANCE_PERCENT: f64 = 1.0e-8;
+
+/// Maximum timestep covered by the issue #1767 annual stability validation.
+pub const MAX_VALIDATED_TIMESTEP_SECONDS: f64 = 360.0;
+
+/// Absolute First-Law tolerance at the airside/envelope interface.
+///
+/// This matches the `1e-7 W` tolerance used by `MultiNodeSolver` for its
+/// backward-Euler mass-node balance.
+pub const DEFAULT_ENERGY_BALANCE_TOLERANCE_W: f64 = 1.0e-7;
+
+/// Errors returned without committing a partially advanced coupled state.
+#[derive(Debug, Error, Clone, PartialEq)]
+pub enum AirsideCouplingError {
+    #[error("invalid airside coupling input `{field}`: {value}")]
+    InvalidInput { field: &'static str, value: f64 },
+    #[error("derived psychrometric property `{property}` is non-finite")]
+    NonFinitePsychrometricProperty { property: &'static str },
+    #[error(
+        "air state is supersaturated: relative humidity {relative_humidity_percent:.9}% exceeds 100%"
+    )]
+    SupersaturatedAirState { relative_humidity_percent: f64 },
+    #[error(
+        "timestep {dt_seconds} s exceeds the validated six-minute maximum of {MAX_VALIDATED_TIMESTEP_SECONDS} s"
+    )]
+    TimestepExceedsValidatedMaximum { dt_seconds: f64 },
+    #[error("9R4C envelope state is non-finite or has non-positive thermal coefficients")]
+    InvalidEnvelopeState,
+    #[error("coupled energy residual {residual_w:.6e} W exceeds tolerance {tolerance_w:.6e} W")]
+    EnergyBalanceViolation { residual_w: f64, tolerance_w: f64 },
+}
+
+/// Thermodynamically consistent moist-air state.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MoistAirState {
+    pub dry_bulb_c: f64,
+    pub relative_humidity_percent: f64,
+    pub pressure_pa: f64,
+    pub humidity_ratio_kg_per_kg_dry_air: f64,
+    pub enthalpy_kj_per_kg_dry_air: f64,
+    pub wet_bulb_c: f64,
+    pub density_kg_per_m3: f64,
+    pub partial_vapor_pressure_pa: f64,
+}
+
+impl MoistAirState {
+    /// Construct from dry-bulb temperature, relative humidity, and pressure.
+    pub fn try_new(
+        dry_bulb_c: f64,
+        relative_humidity_percent: f64,
+        pressure_pa: f64,
+    ) -> Result<Self, AirsideCouplingError> {
+        validate_finite("dry_bulb_c", dry_bulb_c)?;
+        validate_finite("relative_humidity_percent", relative_humidity_percent)?;
+        validate_finite("pressure_pa", pressure_pa)?;
+        if dry_bulb_c <= -273.15 {
+            return Err(AirsideCouplingError::InvalidInput {
+                field: "dry_bulb_c",
+                value: dry_bulb_c,
+            });
+        }
+        if !(0.0..=100.0).contains(&relative_humidity_percent) {
+            return Err(AirsideCouplingError::InvalidInput {
+                field: "relative_humidity_percent",
+                value: relative_humidity_percent,
+            });
+        }
+        if pressure_pa <= 0.0 {
+            return Err(AirsideCouplingError::InvalidInput {
+                field: "pressure_pa",
+                value: pressure_pa,
+            });
+        }
+
+        let humidity_ratio_kg_per_kg_dry_air =
+            calculate_humidity_ratio(dry_bulb_c, relative_humidity_percent, pressure_pa);
+        let enthalpy_kj_per_kg_dry_air =
+            calculate_enthalpy(dry_bulb_c, relative_humidity_percent, pressure_pa);
+        let wet_bulb_c = calculate_wet_bulb(dry_bulb_c, relative_humidity_percent, pressure_pa);
+        let density_kg_per_m3 =
+            moist_air_density(dry_bulb_c, humidity_ratio_kg_per_kg_dry_air, pressure_pa);
+        let partial_vapor_pressure_pa =
+            partial_vapor_pressure(humidity_ratio_kg_per_kg_dry_air, pressure_pa);
+
+        let state = Self {
+            dry_bulb_c,
+            relative_humidity_percent,
+            pressure_pa,
+            humidity_ratio_kg_per_kg_dry_air,
+            enthalpy_kj_per_kg_dry_air,
+            wet_bulb_c,
+            density_kg_per_m3,
+            partial_vapor_pressure_pa,
+        };
+        state.validate_derived()?;
+        Ok(state)
+    }
+
+    pub(crate) fn from_humidity_ratio(
+        dry_bulb_c: f64,
+        humidity_ratio_kg_per_kg_dry_air: f64,
+        pressure_pa: f64,
+    ) -> Result<Self, AirsideCouplingError> {
+        validate_nonnegative(
+            "humidity_ratio_kg_per_kg_dry_air",
+            humidity_ratio_kg_per_kg_dry_air,
+        )?;
+        let vapor_pressure_pa =
+            partial_vapor_pressure(humidity_ratio_kg_per_kg_dry_air, pressure_pa);
+        let saturation_pressure_pa = saturation_vapor_pressure(dry_bulb_c);
+        if !vapor_pressure_pa.is_finite()
+            || !saturation_pressure_pa.is_finite()
+            || saturation_pressure_pa <= 0.0
+        {
+            return Err(AirsideCouplingError::NonFinitePsychrometricProperty {
+                property: "relative_humidity",
+            });
+        }
+        let relative_humidity_percent = 100.0 * vapor_pressure_pa / saturation_pressure_pa;
+        if relative_humidity_percent > 100.0 + SATURATION_TOLERANCE_PERCENT {
+            return Err(AirsideCouplingError::SupersaturatedAirState {
+                relative_humidity_percent,
+            });
+        }
+        Self::try_new(
+            dry_bulb_c,
+            relative_humidity_percent.clamp(0.0, 100.0),
+            pressure_pa,
+        )
+    }
+
+    pub(crate) fn validate_derived(&self) -> Result<(), AirsideCouplingError> {
+        let properties = [
+            ("humidity_ratio", self.humidity_ratio_kg_per_kg_dry_air),
+            ("enthalpy", self.enthalpy_kj_per_kg_dry_air),
+            ("wet_bulb", self.wet_bulb_c),
+            ("density", self.density_kg_per_m3),
+            ("partial_vapor_pressure", self.partial_vapor_pressure_pa),
+        ];
+        for (property, value) in properties {
+            if !value.is_finite() {
+                return Err(AirsideCouplingError::NonFinitePsychrometricProperty { property });
+            }
+        }
+        if self.humidity_ratio_kg_per_kg_dry_air < 0.0
+            || self.density_kg_per_m3 <= 0.0
+            || self.partial_vapor_pressure_pa < 0.0
+            || self.partial_vapor_pressure_pa >= self.pressure_pa
+            || self.wet_bulb_c > self.dry_bulb_c + 1.0e-7
+        {
+            return Err(AirsideCouplingError::InvalidInput {
+                field: "derived_moist_air_state",
+                value: self.humidity_ratio_kg_per_kg_dry_air,
+            });
+        }
+        Ok(())
+    }
+
+    pub fn is_finite(&self) -> bool {
+        [
+            self.dry_bulb_c,
+            self.relative_humidity_percent,
+            self.pressure_pa,
+            self.humidity_ratio_kg_per_kg_dry_air,
+            self.enthalpy_kj_per_kg_dry_air,
+            self.wet_bulb_c,
+            self.density_kg_per_m3,
+            self.partial_vapor_pressure_pa,
+        ]
+        .into_iter()
+        .all(f64::is_finite)
+    }
+
+    pub(crate) fn dry_air_specific_heat_j_per_kg_k(&self) -> f64 {
+        1000.0
+            * (CP_DRY_AIR_KJ_PER_KG_K
+                + CP_WATER_VAPOR_KJ_PER_KG_K * self.humidity_ratio_kg_per_kg_dry_air)
+    }
+}
+
+/// Supply-air state produced by a VAV, DOAS, or other airside component.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct AirsideFlow {
+    supply_air: MoistAirState,
+    volumetric_flow_m3_per_s: f64,
+    dry_air_mass_flow_kg_per_s: f64,
+}
+
+impl AirsideFlow {
+    pub fn new(
+        supply_air: MoistAirState,
+        volumetric_flow_m3_per_s: f64,
+    ) -> Result<Self, AirsideCouplingError> {
+        supply_air.validate_derived()?;
+        validate_nonnegative("volumetric_flow_m3_per_s", volumetric_flow_m3_per_s)?;
+        let dry_air_mass_flow_kg_per_s = supply_air.density_kg_per_m3 * volumetric_flow_m3_per_s
+            / (1.0 + supply_air.humidity_ratio_kg_per_kg_dry_air);
+        validate_nonnegative("dry_air_mass_flow_kg_per_s", dry_air_mass_flow_kg_per_s)?;
+        Ok(Self {
+            supply_air,
+            volumetric_flow_m3_per_s,
+            dry_air_mass_flow_kg_per_s,
+        })
+    }
+
+    pub fn supply_air(&self) -> &MoistAirState {
+        &self.supply_air
+    }
+
+    pub fn volumetric_flow_m3_per_s(&self) -> f64 {
+        self.volumetric_flow_m3_per_s
+    }
+
+    pub fn dry_air_mass_flow_kg_per_s(&self) -> f64 {
+        self.dry_air_mass_flow_kg_per_s
+    }
+}
+
+pub(crate) fn validate_finite(field: &'static str, value: f64) -> Result<(), AirsideCouplingError> {
+    if value.is_finite() {
+        Ok(())
+    } else {
+        Err(AirsideCouplingError::InvalidInput { field, value })
+    }
+}
+
+pub(crate) fn validate_nonnegative(
+    field: &'static str,
+    value: f64,
+) -> Result<(), AirsideCouplingError> {
+    validate_finite(field, value)?;
+    if value >= 0.0 {
+        Ok(())
+    } else {
+        Err(AirsideCouplingError::InvalidInput { field, value })
+    }
+}
+
+pub(crate) fn validate_positive(
+    field: &'static str,
+    value: f64,
+) -> Result<(), AirsideCouplingError> {
+    validate_finite(field, value)?;
+    if value > 0.0 {
+        Ok(())
+    } else {
+        Err(AirsideCouplingError::InvalidInput { field, value })
+    }
+}

--- a/src/sim/hvac/mod.rs
+++ b/src/sim/hvac/mod.rs
@@ -3,6 +3,8 @@
 //! This module provides advanced HVAC system modeling capabilities including
 //! Variable Air Volume (VAV), Constant Air Volume (CAV), and heat pump systems.
 
+pub mod airside_coupling;
+pub mod airside_state;
 pub mod cycling;
 pub mod economizer;
 pub mod efficiency_curves;
@@ -12,6 +14,11 @@ pub mod modes;
 pub mod zones;
 
 // Re-export common types for convenience
+pub use airside_coupling::{AirsideEnvelopeCoupler, CoupledStepForcing, CoupledStepResult};
+pub use airside_state::{
+    AirsideCouplingError, AirsideFlow, MoistAirState, DEFAULT_ENERGY_BALANCE_TOLERANCE_W,
+    MAX_VALIDATED_TIMESTEP_SECONDS,
+};
 pub use cycling::CyclingTracker;
 pub use economizer::{calculate_free_cooling_capacity, is_economizer_active, EconomizerMode};
 pub use efficiency_curves::{

--- a/tests/hvac_airside_9r4c_integration.rs
+++ b/tests/hvac_airside_9r4c_integration.rs
@@ -1,0 +1,260 @@
+//! Coupled 9R4C envelope + airside integration tests (issue #1767).
+
+use fluxion::multi_node::{MassAirCouplingMode, ThermalMassNode};
+use fluxion::physics::cta::VectorField;
+use fluxion::physics::multi_node_solver::{MultiNodeSolver, SurfaceExteriorTemperatures};
+use fluxion::sim::engine::ThermalModel;
+use fluxion::sim::hvac::{
+    AirsideCouplingError, AirsideEnvelopeCoupler, AirsideFlow, CoupledStepForcing, MoistAirState,
+    DEFAULT_ENERGY_BALANCE_TOLERANCE_W,
+};
+use fluxion::validation::ashrae_140_cases::ASHRAE140Case;
+use fluxion::weather::denver::DenverTmyWeather;
+use fluxion::weather::WeatherSource;
+
+const PRESSURE_PA: f64 = 101_325.0;
+const TIMESTEP_SECONDS: f64 = 360.0;
+const TIMESTEPS_PER_YEAR: usize = 87_600;
+
+fn high_mass_coupler() -> AirsideEnvelopeCoupler {
+    high_mass_coupler_with_mode(MassAirCouplingMode::ParallelResistance)
+}
+
+fn high_mass_coupler_with_mode(mode: MassAirCouplingMode) -> AirsideEnvelopeCoupler {
+    let wall = ThermalMassNode::new(20.0, 5.0e6, 76.4, 25.0);
+    let roof = ThermalMassNode::new(20.0, 3.0e6, 32.9, 20.0);
+    let floor = ThermalMassNode::new(20.0, 2.0e6, 18.0, 10.0);
+    let internal = ThermalMassNode::new(20.0, 1.0e6, 0.0, 0.0).with_h_tr_me(100.0);
+    let solver = MultiNodeSolver::new_with_mode(165.6, wall, roof, floor, internal, mode);
+    let zone_air = MoistAirState::try_new(22.0, 50.0, PRESSURE_PA)
+        .expect("initial zone air state must be physical");
+
+    AirsideEnvelopeCoupler::new(solver, zone_air, 300.0)
+        .expect("representative high-mass zone must construct")
+}
+
+#[test]
+fn test_coupled_annual_run_no_nan() {
+    let mut coupled = high_mass_coupler();
+    let mut completed_steps = 0_usize;
+    let mut max_balance_residual_w = 0.0_f64;
+
+    for step in 0..TIMESTEPS_PER_YEAR {
+        let day = step as f64 / 240.0;
+        let hour = (step as f64 / 10.0) % 24.0;
+        let annual_phase = 2.0 * std::f64::consts::PI * (day - 30.0) / 365.0;
+        let daily_phase = 2.0 * std::f64::consts::PI * (hour - 8.0) / 24.0;
+        let outdoor_temperature_c = 10.0 + 18.0 * annual_phase.sin() + 7.0 * daily_phase.sin();
+        let outdoor_rh_percent = 50.0 + 20.0 * daily_phase.cos();
+        let outdoor_air =
+            MoistAirState::try_new(outdoor_temperature_c, outdoor_rh_percent, PRESSURE_PA)
+                .expect("annual outdoor state must remain physical");
+
+        let (supply_temperature_c, supply_rh_percent) = if outdoor_temperature_c > 18.0 {
+            (14.0, 55.0)
+        } else {
+            (32.0, 20.0)
+        };
+        let supply_air =
+            MoistAirState::try_new(supply_temperature_c, supply_rh_percent, PRESSURE_PA)
+                .expect("VAV/DOAS-equivalent supply state must remain physical");
+        let airside = AirsideFlow::new(supply_air, 0.55)
+            .expect("supply volume flow must produce a physical dry-air flow");
+
+        let occupied = (7.0..19.0).contains(&hour);
+        let convective_gain_w = if occupied { 500.0 } else { 50.0 };
+        let solar_gain_w = (std::f64::consts::PI * (hour - 6.0) / 12.0).sin().max(0.0) * 1_500.0;
+        let forcing = CoupledStepForcing {
+            exterior_temperatures: SurfaceExteriorTemperatures::uniform(outdoor_temperature_c),
+            outdoor_air,
+            ventilation_conductance_w_per_k: 20.0,
+            convective_gain_w,
+            envelope_gains_w: [
+                0.45 * solar_gain_w,
+                0.30 * solar_gain_w,
+                0.0,
+                0.25 * solar_gain_w,
+            ],
+        };
+
+        let result = coupled
+            .step(TIMESTEP_SECONDS, &forcing, &airside)
+            .unwrap_or_else(|error| panic!("coupled step {step} failed: {error}"));
+
+        assert!(
+            result.is_finite(),
+            "non-finite result at step {step}: {result:?}"
+        );
+        assert!(
+            coupled.zone_air().is_finite(),
+            "non-finite zone psychrometric state at step {step}: {:?}",
+            coupled.zone_air()
+        );
+        assert!(
+            coupled
+                .envelope()
+                .snapshot_temperatures()
+                .into_iter()
+                .all(f64::is_finite),
+            "non-finite 9R4C node at step {step}: {:?}",
+            coupled.envelope().snapshot_temperatures()
+        );
+
+        max_balance_residual_w = max_balance_residual_w.max(result.energy_balance_residual_w.abs());
+        completed_steps += 1;
+    }
+
+    assert_eq!(completed_steps, TIMESTEPS_PER_YEAR);
+    assert!(
+        max_balance_residual_w <= DEFAULT_ENERGY_BALANCE_TOLERANCE_W,
+        "maximum per-step residual {max_balance_residual_w:.3e} W exceeded tolerance {:.3e} W",
+        DEFAULT_ENERGY_BALANCE_TOLERANCE_W
+    );
+    println!(
+        "COUPLED_ANNUAL_RESULT|steps={completed_steps}|max_residual_w={max_balance_residual_w:.12e}"
+    );
+}
+
+#[test]
+fn test_energy_balance_closes() {
+    let outdoor_air =
+        MoistAirState::try_new(5.0, 80.0, PRESSURE_PA).expect("outdoor state must be physical");
+    let supply_air = MoistAirState::try_new(35.0, 20.0, PRESSURE_PA)
+        .expect("heating supply state must be physical");
+    let airside = AirsideFlow::new(supply_air, 0.55)
+        .expect("supply flow must produce a physical dry-air flow");
+    let forcing = CoupledStepForcing {
+        exterior_temperatures: SurfaceExteriorTemperatures::uniform(5.0),
+        outdoor_air,
+        ventilation_conductance_w_per_k: 20.0,
+        convective_gain_w: 350.0,
+        envelope_gains_w: [120.0, 80.0, 0.0, 100.0],
+    };
+
+    for mode in [
+        MassAirCouplingMode::AdditiveSum,
+        MassAirCouplingMode::ParallelResistance,
+    ] {
+        let mut coupled = high_mass_coupler_with_mode(mode);
+        let result = coupled
+            .step(TIMESTEP_SECONDS, &forcing, &airside)
+            .unwrap_or_else(|error| panic!("{mode:?} coupled step failed: {error}"));
+
+        assert!(
+            result.sensible_balance_residual_w.abs() <= DEFAULT_ENERGY_BALANCE_TOLERANCE_W,
+            "{mode:?} sensible residual {:.3e} W exceeds tolerance",
+            result.sensible_balance_residual_w
+        );
+        assert!(
+            result.latent_balance_residual_w.abs() <= DEFAULT_ENERGY_BALANCE_TOLERANCE_W,
+            "{mode:?} latent residual {:.3e} W exceeds tolerance",
+            result.latent_balance_residual_w
+        );
+        assert!(
+            result.energy_balance_residual_w.abs() <= DEFAULT_ENERGY_BALANCE_TOLERANCE_W,
+            "{mode:?} total residual {:.3e} W exceeds tolerance",
+            result.energy_balance_residual_w
+        );
+        assert!(
+            result.moisture_balance_residual_kg_per_s.abs() <= 1.0e-12,
+            "{mode:?} dry-air moisture residual {:.3e} kg/s exceeds tolerance",
+            result.moisture_balance_residual_kg_per_s
+        );
+        assert!(
+            (result.supply_total_heat_w
+                - result.supply_sensible_heat_w
+                - result.supply_latent_heat_w)
+                .abs()
+                <= DEFAULT_ENERGY_BALANCE_TOLERANCE_W,
+            "{mode:?} supply sensible + latent heat must reconstruct total enthalpy flow"
+        );
+    }
+}
+
+#[test]
+fn test_ashrae_140_envelope_unchanged() {
+    // Baseline captured from unmodified origin/develop before the issue #1767
+    // integration module was added. Case 900FF is envelope-only, so these
+    // deterministic annual temperatures detect any accidental production-path
+    // change independently of airside equipment behavior.
+    const BASELINE_MIN_C: f64 = 2.159_094;
+    const BASELINE_MAX_C: f64 = 48.030_329;
+    const BASELINE_AVERAGE_C: f64 = 26.532_328;
+    const BASELINE_TOLERANCE_C: f64 = 1.0e-6;
+
+    let spec = ASHRAE140Case::Case900FF.spec();
+    let mut model = ThermalModel::<VectorField>::from_spec(&spec);
+    let weather = DenverTmyWeather::new();
+    let mut minimum_c = f64::MAX;
+    let mut maximum_c = f64::MIN;
+    let mut sum_c = 0.0_f64;
+
+    for step in 0..8_760 {
+        let weather_data = weather
+            .get_hourly_data(step)
+            .expect("Denver TMY must contain every annual timestep");
+        model.weather = Some(weather_data.clone());
+        model.step_physics(step, weather_data.dry_bulb_temp, 3_600.0);
+        let zone_temperature_c = model.temperatures.as_slice()[0];
+        assert!(
+            zone_temperature_c.is_finite(),
+            "Case 900FF produced non-finite zone temperature at hour {step}"
+        );
+        minimum_c = minimum_c.min(zone_temperature_c);
+        maximum_c = maximum_c.max(zone_temperature_c);
+        sum_c += zone_temperature_c;
+    }
+
+    let average_c = sum_c / 8_760.0;
+    assert!(
+        (minimum_c - BASELINE_MIN_C).abs() <= BASELINE_TOLERANCE_C,
+        "Case 900FF minimum changed: baseline {BASELINE_MIN_C:.6}°C, actual {minimum_c:.6}°C"
+    );
+    assert!(
+        (maximum_c - BASELINE_MAX_C).abs() <= BASELINE_TOLERANCE_C,
+        "Case 900FF maximum changed: baseline {BASELINE_MAX_C:.6}°C, actual {maximum_c:.6}°C"
+    );
+    assert!(
+        (average_c - BASELINE_AVERAGE_C).abs() <= BASELINE_TOLERANCE_C,
+        "Case 900FF average changed: baseline {BASELINE_AVERAGE_C:.6}°C, actual {average_c:.6}°C"
+    );
+    println!(
+        "ASHRAE140_900FF_REGRESSION|min_c={minimum_c:.6}|max_c={maximum_c:.6}|avg_c={average_c:.6}"
+    );
+}
+
+#[test]
+fn test_non_finite_guard_is_transactional() {
+    let mut coupled = high_mass_coupler();
+    let initial_nodes = coupled.envelope().snapshot_temperatures();
+    let initial_zone_air = *coupled.zone_air();
+    let outdoor_air =
+        MoistAirState::try_new(5.0, 80.0, PRESSURE_PA).expect("outdoor state must be physical");
+    let supply_air =
+        MoistAirState::try_new(35.0, 20.0, PRESSURE_PA).expect("supply state must be physical");
+    let airside = AirsideFlow::new(supply_air, 0.55).expect("supply flow must be physical");
+    let forcing = CoupledStepForcing {
+        exterior_temperatures: SurfaceExteriorTemperatures::uniform(5.0),
+        outdoor_air,
+        ventilation_conductance_w_per_k: 20.0,
+        convective_gain_w: f64::NAN,
+        envelope_gains_w: [0.0; 4],
+    };
+
+    let error = coupled
+        .step(TIMESTEP_SECONDS, &forcing, &airside)
+        .expect_err("NaN forcing must be rejected");
+    assert!(matches!(
+        error,
+        AirsideCouplingError::InvalidInput {
+            field: "convective_gain_w",
+            ..
+        }
+    ));
+    assert_eq!(coupled.envelope().snapshot_temperatures(), initial_nodes);
+    assert_eq!(*coupled.zone_air(), initial_zone_air);
+    assert!(
+        AirsideFlow::new(supply_air, f64::MAX).is_err(),
+        "overflowing volume flow must not produce an infinite mass flow"
+    );
+}


### PR DESCRIPTION
Closes #1767

Integrates the airside equipment models (VAV/DOAS/coils/fans) with the 9R4C envelope solver using a stability-preserving coupling (operator split). Adds NaN/overflow guards and per-timestep energy-balance checks. ASHRAE 140 envelope results are unchanged (regression tested).