### PR TITLE
docs: enforce develop as default branch — update docs, add branch protection workflow

### DIFF
--- a/.github/workflows/protect-main-branch.yml
+++ b/.github/workflows/protect-main-branch.yml
@@ -1,0 +1,36 @@
+# Protect main branch — only accept PRs from develop
+#
+# This workflow enforces the repository policy that PRs targeting `main`
+# may only come from the `develop` branch. Feature branches must target
+# `develop`; releases are cut by merging `develop` → `main`.
+#
+# See AGENTS.md → "Branch & PR Conventions" for the full policy.
+
+name: Protect Main Branch
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  enforce-develop-only:
+    name: Verify PR is from develop
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check head branch
+        if: github.head_ref != 'develop'
+        run: |
+          echo "::error::PRs targeting 'main' are only permitted from the 'develop' branch."
+          echo "::error::Head branch is '${{ github.head_ref }}'."
+          echo "::error::Please target 'develop' instead, or merge your changes into 'develop' first."
+          exit 1
+
+      - name: Pass
+        if: github.head_ref == 'develop'
+        run: |
+          echo "✓ PR is from 'develop' — proceeding."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,11 +164,17 @@ Heavy Linux jobs honour `vars.FLUXION_LINUX_RUNNER` (self-hosted Hetzner fallbac
 
 ## Branch & PR Conventions
 
-- **`develop`** is the default integration branch. All PRs target it (`gh pr create --base develop`).
-- **`main`** is release-only — no direct PRs except release merges.
+- **`develop`** is the default branch and integration branch.
+  - All new feature branches must be created from `develop`: `git checkout develop && git pull && git checkout -b fix/issue-123`.
+  - All PRs must target `develop`: `gh pr create --base develop`.
+  - Direct pushes to `develop` are prohibited — all changes go through PR review.
+- **`main`** is release-only.
+  - No direct pushes to `main` — branch protection enforces PR-only flow.
+  - PRs targeting `main` are **only permitted from the `develop` branch** (enforced by the `protect-main-branch.yml` workflow). Hotfixes targeting `main` directly from a feature branch will be automatically rejected by CI.
+  - Releases are cut by merging `develop` → `main` via a release PR.
 - `--no-ff` merges preserve history (CONTRIBUTING.md).
 - Conventional commit messages: `fix(scope): …`, `feat(scope): …`, `refactor(scope): …`, `perf(scope): …`, `test(scope): …`, `docs(scope): …`.
-- Never force-push `main`. Hotfixes still go through PR review.
+- Never force-push `main` or `develop`. Hotfixes still go through PR review.
 
 ## Key Files
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,43 +5,46 @@ Read this before submitting PRs or branching strategies.
 Covers: PR workflow, hotfix process, merge strategy, branch conventions.
 Companion to RULES.md (coding rules) and CODEBASE_MAP.md (code navigation).
 Status: Active — follows --no-ff merge policy and expedited hotfix process.
-Action: Use `gh pr create` for all changes; never push directly to main.
+Action: Use `gh pr create --base develop` for all changes; never push directly to main or develop.
 
 ## Quick Rules
 
-1. **Never force-push `main`**
-2. **All changes go through PR** - even hotfixes
-3. **CI must pass** before merging
-4. **Use `--no-ff` merges** to preserve history
+1. **Never force-push `main` or `develop`**
+2. **`develop` is the default branch** — create all feature branches from `develop` and target all PRs to `develop`
+3. **All changes go through PR** - even hotfixes
+4. **CI must pass** before merging
+5. **Use `--no-ff` merges** to preserve history
 
 ## Workflow
 
 ### Normal Changes
-1. Create a feature branch: `git checkout -b fix/issue-123`
+1. Update from develop and create a feature branch: `git checkout develop && git pull && git checkout -b fix/issue-123`
 2. Make changes, commit
-3. Push and create PR: `gh pr create`
+3. Push and create PR targeting develop: `gh pr create --base develop`
 4. Get review approval
 5. Merge via PR (not squash-merge)
 
 ### Hotfixes (Unblocked CI)
-1. Create branch: `git checkout -b hotfix/urgent-fix`
+1. Create branch from develop: `git checkout develop && git pull && git checkout -b hotfix/urgent-fix`
 2. Make minimal fix
-3. Create PR immediately
+3. Create PR targeting develop: `gh pr create --base develop`
 4. Request expedited review
 5. Merge after approval
 
 ### When `main` is Broken
 1. **Do NOT force-push to fix it**
-2. Create a `hotfix/broken-main` branch
+2. Create a `hotfix/broken-main` branch from `develop`
 3. Apply minimal fix (revert broken commits or restore working versions)
-4. Create PR with clear explanation
+4. Create PR targeting `develop` with clear explanation
 5. Get emergency review approval
-6. Merge via PR
+6. Merge via PR to `develop`, then fast-forward `develop` → `main` via release PR
 
 ## Branch Protection
 
-- `main` requires PR review and passing CI
-- Protected branches cannot be force-pushed
+- **`develop`** (default branch): requires PR review; direct pushes are blocked.
+- **`main`** (release branch): requires PR review and passing CI; PRs to `main` are only accepted from the `develop` branch.
+- Protected branches cannot be force-pushed.
+- Branch protection and the `protect-main-branch.yml` workflow enforce these rules automatically.
 
 ## Commit Messages
 
@@ -69,12 +72,12 @@ Use conventional commits:
   pub const FIXTURE_DATA: [f64; 1000] = [/* ... */];
   ```
   See `tests/per_tilt_per_azimuth_fixture_data.rs` for a working example.
-- If `cargo fmt --check` fails on your PR with many unrelated drift items, the drift is pre-existing on `main`. Rebase onto `main` first; if the drift persists after rebase, file a follow-up issue — do NOT auto-fix 200 files of mechanical drift as part of a feature PR.
+- If `cargo fmt --check` fails on your PR with many unrelated drift items, the drift is pre-existing on `develop`. Rebase onto `develop` first; if the drift persists after rebase, file a follow-up issue — do NOT auto-fix 200 files of mechanical drift as part of a feature PR.
 
 ### Avoid scope creep on CI failures
 
 If your PR's CI fails on a check that is not in scope for your change (e.g., `ASHRAE 140 Strict Energy Gate`, `MultiZoneValidator` lib tests, `Cargo Audit` advisories in dependencies you didn't touch):
-1. **First** verify the failure is pre-existing on `main` HEAD without your changes (`git stash && cargo ...` or check out `main` and reproduce).
+1. **First** verify the failure is pre-existing on `develop` HEAD without your changes (`git stash && cargo ...` or check out `develop` and reproduce).
 2. **If pre-existing**: file a separate follow-up issue (label `bug`, link your PR in the body). Do NOT bloat your PR diff with the unrelated fix.
 3. **If introduced by your PR**: fix it in scope or STOP and report.
 

--- a/agent-orchestrator.yaml
+++ b/agent-orchestrator.yaml
@@ -11,7 +11,7 @@ projects:
     sessionPrefix: flu
     repo: anchapin/fluxion
     path: /home/alex/Projects/fluxion
-    defaultBranch: main
+    defaultBranch: develop
     agentRules: |-
       Always run tests before pushing.
       Use conventional commits (feat:, fix:, chore:, docs:, refactor:, test:).

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -15,7 +15,7 @@ Understand the issue before writing any code.
 
 ### Entry Criteria
 - Issue is assigned and triaged
-- Branch created from `main`
+- Branch created from `develop`
 
 ### Checklist
 - [ ] Read `ARCHITECTURE.md` — understand module boundaries and data flow
@@ -136,10 +136,10 @@ Finalize and prepare for merge.
 ### Worktree Management
 ```bash
 # Create worktree
-git worktree add ../worktrees/issue-{N}-{slug} -b fix/issue-{N}-{slug} main
+git worktree add ../worktrees/issue-{N}-{slug} -b fix/issue-{N}-{slug} develop
 
 # Sync before starting
-git pull origin main
+git pull origin develop
 
 # Commit and push
 git add . && git commit -m "docs: resolve #{N} — {title}"

--- a/docs/orchestration/pr-body-conventions.md
+++ b/docs/orchestration/pr-body-conventions.md
@@ -30,7 +30,7 @@ GaugeSolver Phase 1/2/3 issues) just because the PR body mentions
 `Closes #N` line.
 
 ```bash
-gh pr create --base main \
+gh pr create --base develop \
   --title "fix: resolve #N — <title>" \
   --body "$(cat <<'EOF'
 Closes #N


### PR DESCRIPTION
Closes N/A — infrastructure/policy change

## Summary

Updates all developer-facing documentation to consistently enforce `develop` as the default and integration branch. Adds a CI workflow to prevent direct PRs to `main` from non-`develop` branches.

## Changes

### Documentation (Task 1)
- **AGENTS.md**: Expanded "Branch & PR Conventions" — explicit rules for creating branches from `develop`, targeting PRs to `develop`, and restricting `main` to release-only PRs from `develop`
- **CONTRIBUTING.md** (root): Updated workflow examples, branch protection section, and CI-failure triage references to use `develop` instead of `main`
- **docs/agent-workflow.md**: Changed branch creation and worktree examples from `main` to `develop`
- **docs/orchestration/pr-body-conventions.md**: Changed `gh pr create --base main` to `--base develop`
- **agent-orchestrator.yaml**: Changed `defaultBranch: main` to `defaultBranch: develop`

### Branch Protection Workflow (Task 2)
- **`.github/workflows/protect-main-branch.yml`**: New workflow that triggers on PRs targeting `main` and fails if the head branch is not `develop`

### Branch Protection Rules (applied via GitHub API)
- **`main`**: Now requires pull request reviews (direct pushes blocked). Enforced by GitHub branch protection + the new workflow.
- **`develop`**: Now requires pull request reviews, blocks force pushes and deletions.

## Commits on main not in develop (Task 3)

Analysis complete: **no cherry-picking needed**. The only commit on `main` not on `develop` (by SHA) is `fe68d77` (PR #1829 "Fused energy loops"), but `develop` already contains `ae571ed` — the same PR #1829 with identical file changes, just a different squash SHA. The `develop` branch is ~30 commits ahead of `main` and contains all content from `main`.

## Summary by Sourcery

Clarify that develop is the default integration branch and enforce a release-only workflow for main, backed by CI.

CI:
- Add a protect-main-branch workflow that fails PRs targeting main when the head branch is not develop.

Documentation:
- Update CONTRIBUTING, AGENTS, and workflow docs to describe develop as the default branch and the required PR-based flow from develop to main.
- Adjust agent orchestration and PR body examples to use develop as the base branch instead of main.