### PR TITLE
fix(ci): resolve #1864 — fix OSimFlow pytest coverage threshold path normalization

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -77,48 +77,14 @@ jobs:
             --junitxml=scripts/ci/junit.xml
 
       - name: Enforce per-file coverage thresholds
+        # Path normalization lives in scripts/check_osimflow_coverage.py so it
+        # can be unit-tested. See Issue #1864 — the previous inline Python
+        # matched bare ``cloud_campaign_manager.py`` against canonical
+        # ``scripts/...`` keys and reported every target as "no coverage data".
         shell: bash
         run: |
           set -euo pipefail
-          python - <<'PY'
-          """Fail the job if any of the three OSimFlow files drops below 60%."""
-          import xml.etree.ElementTree as ET
-
-          targets = {
-              "scripts/cloud_campaign_manager.py": 60.0,
-              "scripts/autonomous_parameter_sweep.py": 60.0,
-              "scripts/ashrae_benchmark_harness.py": 60.0,
-          }
-          root = ET.parse("scripts/ci/coverage.xml").getroot()
-
-          line_totals: dict[str, tuple[int, int]] = {}
-          for cls in root.findall(".//class"):
-              filename = cls.get("filename", "")
-              base = filename.split("site-packages/")[-1]
-              line_rate = float(cls.get("line-rate", "0"))
-              lines_valid = int(cls.get("lines-valid", "0"))
-              lines_covered = int(cls.get("lines-covered", "0"))
-              if base in targets:
-                  cur = line_totals.get(base, (0, 0))
-                  line_totals[base] = (cur[0] + lines_valid, cur[1] + lines_covered)
-
-          failures = []
-          for path, threshold in targets.items():
-              valid, covered = line_totals.get(path, (0, 0))
-              if valid == 0:
-                  failures.append((path, 0.0, threshold, "no coverage data"))
-                  continue
-              pct = (covered / valid) * 100
-              if pct < threshold:
-                  failures.append((path, pct, threshold, "below threshold"))
-              print(f"[coverage] {path}: {pct:.2f}% (threshold {threshold:.0f}%)")
-
-          if failures:
-              print("\n::error::OSimFlow coverage threshold failures:")
-              for path, pct, threshold, reason in failures:
-                  print(f"::error::  {path}: {pct:.2f}% < {threshold}% — {reason}")
-              raise SystemExit(1)
-          PY
+          python scripts/check_osimflow_coverage.py scripts/ci/coverage.xml
 
       - name: Upload coverage artifacts
         if: always()

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,6 +11,7 @@ scripts/
 ├── cloud_campaign_manager.py        # AWS/Nomad campaign manager (Issue #1192)
 ├── autonomous_parameter_sweep.py    # Local MAE-divergence sweep (Issue #1450)
 ├── ashrae_benchmark_harness.py      # ASHRAE 140 benchmark harness (Issue #1488)
+├── check_osimflow_coverage.py       # Per-file coverage gate (Issue #1864)
 ├── state_store.py                   # DynamoDB/Redis/in-memory backend (T7.3)
 ├── conftest.py                      # Shared pytest fixtures (see below)
 ├── pytest.ini                       # Pytest config scoped to this directory
@@ -19,7 +20,8 @@ scripts/
     ├── __init__.py                  # Marker for the test package
     ├── test_cloud_campaign_manager.py
     ├── test_autonomous_parameter_sweep.py
-    └── test_ashrae_benchmark_harness.py
+    ├── test_ashrae_benchmark_harness.py
+    └── test_check_osimflow_coverage.py
 ```
 
 ## Running the tests
@@ -67,6 +69,27 @@ Coverage targets (Issue #1847 acceptance criteria):
 `.github/workflows/python-tests.yml` runs the suite on Ubuntu for
 Python 3.10 / 3.11 / 3.12 / 3.13, requires no cloud credentials, no
 D-Wave token, no Redis, and no Kubernetes context.
+
+## Per-file coverage gate
+
+`scripts/check_osimflow_coverage.py` enforces the ≥ 60 % line-coverage
+threshold on each target file from the Cobertura XML produced by the
+pytest run. It is invoked by the workflow's `Enforce per-file coverage
+thresholds` step:
+
+```bash
+pytest scripts/ci/ -c scripts/pytest.ini \
+  --cov-report=xml:scripts/ci/coverage.xml
+python scripts/check_osimflow_coverage.py scripts/ci/coverage.xml
+```
+
+The checker normalizes the `filename` attribute emitted by coverage.py
+(which is relative to `--cov=scripts`, e.g. `cloud_campaign_manager.py`)
+onto the canonical `scripts/<name>` keys, and counts lines from both the
+Cobertura summary attributes and the per-line `<line hits>` records that
+coverage.py >= 6 emits. Tests live in `scripts/ci/test_check_osimflow_coverage.py`
+(Issue #1864 — the previous inline-YAML gate mismatched paths and read
+absent summary attributes, turning every OSimFlow pytest job red).
 
 ## Conventions
 

--- a/scripts/check_osimflow_coverage.py
+++ b/scripts/check_osimflow_coverage.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+# scripts/check_osimflow_coverage.py
+#
+# Enforce per-file line-coverage thresholds for the OSimFlow Python
+# orchestration suite (Issue #1847).
+#
+# This checker was extracted from the inline Python step that lived in
+# ``.github/workflows/python-tests.yml`` (PR #1849).  That inline step had a
+# path-normalization bug: coverage.py records filenames relative to the
+# ``--cov=scripts`` source root (e.g. ``cloud_campaign_manager.py``), but the
+# threshold table keyed on canonical repo paths (``scripts/cloud_campaign_manager.py``),
+# so no ``<class>`` element ever matched and every target was reported as
+# "no coverage data" — turning the OSimFlow pytest job red on every PR
+# (Issue #1864).
+#
+# Exit codes:
+#   0 — every target meets its threshold
+#   1 — one or more targets are missing or below threshold
+#
+# Usage:
+#   python scripts/check_osimflow_coverage.py [path/to/coverage.xml]
+#
+# The default coverage XML path is ``scripts/ci/coverage.xml``, matching the
+# ``--cov-report=xml`` argument in ``python-tests.yml``.
+
+from __future__ import annotations
+
+import os
+import sys
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+
+DEFAULT_COVERAGE_XML = os.path.join("scripts", "ci", "coverage.xml")
+
+# Canonical repository paths → minimum line-coverage percent.
+TARGETS: dict[str, float] = {
+    "scripts/cloud_campaign_manager.py": 60.0,
+    "scripts/autonomous_parameter_sweep.py": 60.0,
+    "scripts/ashrae_benchmark_harness.py": 60.0,
+}
+
+
+@dataclass
+class CoverageResult:
+    """Outcome of evaluating one coverage target."""
+
+    path: str
+    lines_valid: int
+    lines_covered: int
+    threshold: float
+    found: bool
+
+    @property
+    def percent(self) -> float:
+        if self.lines_valid == 0:
+            return 0.0
+        return (self.lines_covered / self.lines_valid) * 100.0
+
+    @property
+    def passed(self) -> bool:
+        return self.found and self.lines_valid > 0 and self.percent >= self.threshold
+
+    @property
+    def reason(self) -> str:
+        if not self.found:
+            return "no coverage data"
+        if self.lines_valid == 0:
+            return "no measurable lines"
+        return "below threshold"
+
+
+def normalize_filename(filename: str) -> str:
+    """Normalize a coverage.py ``filename`` attribute to a canonical repo path.
+
+    coverage.py emits filenames relative to its ``--cov`` source root. With
+    ``--cov=scripts`` the XML stores bare names such as
+    ``cloud_campaign_manager.py``; with ``--cov=.`` it stores
+    ``scripts/cloud_campaign_manager.py``; third-party / installed packages
+    may appear as ``.../site-packages/foo/bar.py``. This helper collapses all
+    of those forms onto the canonical ``scripts/<basename>`` key used by
+    :data:`TARGETS`.
+
+    The normalization is intentionally lenient about directory prefixes and
+    path separators (Windows ``\\`` is tolerated) but strict about the
+    *basename* — only files whose basename matches a known target are mapped.
+    """
+
+    # Strip any ``.../site-packages/`` prefix and use the trailing segment.
+    tail = filename.replace("\\", "/").split("site-packages/")[-1]
+    # Drop leading ``./`` that some coverage.py versions emit.
+    tail = tail.lstrip("./")
+    basename = tail.rsplit("/", 1)[-1]
+    return f"scripts/{basename}"
+
+
+def _class_line_counts(cls: ET.Element) -> tuple[int, int]:
+    """Return ``(lines_valid, lines_covered)`` for one ``<class>`` element.
+
+    Cobertura XML comes in two flavours depending on the coverage.py version:
+
+    * **Summary attributes** — ``lines-valid`` / ``lines-covered`` on the
+      ``<class>`` element (older coverage.py and some CI tools).
+    * **Per-line records only** — coverage.py >= 6 omits the summary
+      attributes on ``<class>`` and emits a ``<lines>`` child containing one
+      ``<line number="N" hits="H"/>`` per executable line. The summary lives
+      only on the root ``<coverage>`` element.
+
+    This helper prefers the summary attributes (a single attribute read) and
+    falls back to counting ``<line>`` children so both shapes work.
+    """
+
+    lv_attr = cls.get("lines-valid")
+    lc_attr = cls.get("lines-covered")
+    if lv_attr is not None and lc_attr is not None:
+        try:
+            return int(lv_attr), int(lc_attr)
+        except ValueError:
+            pass  # fall through to per-line counting
+
+    lines = cls.findall("./lines/line")
+    valid = len(lines)
+    covered = sum(1 for ln in lines if int(ln.get("hits", "0")) > 0)
+    return valid, covered
+
+
+def evaluate_coverage(
+    root: ET.Element, targets: dict[str, float] | None = None
+) -> list[CoverageResult]:
+    """Evaluate per-file coverage against ``targets`` from a parsed Cobertura XML root.
+
+    Aggregates line counts across every ``<class>`` whose normalized filename
+    matches a target, so that split-class or partial-filename reports are
+    summed correctly. Works with both Cobertura summary-attribute and
+    per-line-record XML shapes (see :func:`_class_line_counts`).
+    """
+
+    targets = targets if targets is not None else TARGETS
+    aggregated: dict[str, tuple[int, int]] = {}
+    seen: set[str] = set()
+
+    for cls in root.findall(".//class"):
+        filename = cls.get("filename", "")
+        key = normalize_filename(filename)
+        if key not in targets:
+            continue
+        seen.add(key)
+        lines_valid, lines_covered = _class_line_counts(cls)
+        cur_v, cur_c = aggregated.get(key, (0, 0))
+        aggregated[key] = (cur_v + lines_valid, cur_c + lines_covered)
+
+    results: list[CoverageResult] = []
+    for path, threshold in targets.items():
+        valid, covered = aggregated.get(path, (0, 0))
+        results.append(
+            CoverageResult(
+                path=path,
+                lines_valid=valid,
+                lines_covered=covered,
+                threshold=threshold,
+                found=path in seen,
+            )
+        )
+    return results
+
+
+def report(results: list[CoverageResult]) -> bool:
+    """Print a per-target report and return ``True`` if all targets passed."""
+
+    all_passed = True
+    for r in results:
+        status = "OK  " if r.passed else "FAIL"
+        print(
+            f"{status} {r.path}: {r.percent:.2f}% "
+            f"(threshold {r.threshold:.0f}%, "
+            f"{r.lines_covered}/{r.lines_valid} lines)"
+        )
+        if not r.passed:
+            all_passed = False
+
+    failures = [r for r in results if not r.passed]
+    if failures:
+        print("\n::error::OSimFlow coverage threshold failures:")
+        for r in failures:
+            print(
+                f"::error::  {r.path}: {r.percent:.2f}% "
+                f"< {r.threshold:.0f}% — {r.reason}"
+            )
+    return all_passed
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = argv if argv is not None else sys.argv[1:]
+    coverage_xml = argv[0] if argv else DEFAULT_COVERAGE_XML
+
+    try:
+        root = ET.parse(coverage_xml).getroot()
+    except FileNotFoundError:
+        print(f"::error::coverage XML not found: {coverage_xml}")
+        return 1
+    except ET.ParseError as exc:
+        print(f"::error::failed to parse {coverage_xml}: {exc}")
+        return 1
+
+    results = evaluate_coverage(root)
+    return 0 if report(results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/test_check_osimflow_coverage.py
+++ b/scripts/ci/test_check_osimflow_coverage.py
@@ -1,0 +1,393 @@
+"""
+Tests for ``scripts/check_osimflow_coverage.py`` — Issue #1864.
+
+The OSimFlow pytest workflow failed on every Python version because the
+inline coverage gate matched bare ``cloud_campaign_manager.py`` (the form
+emitted by ``--cov=scripts``) against canonical ``scripts/cloud_campaign_manager.py``
+keys. These tests pin the normalization and aggregation behaviour so the
+regression cannot silently return.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from textwrap import dedent
+
+import check_osimflow_coverage as checker
+import pytest
+
+# ---------------------------------------------------------------------------
+# normalize_filename
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # coverage.py with --cov=scripts emits bare basenames.
+        ("cloud_campaign_manager.py", "scripts/cloud_campaign_manager.py"),
+        # coverage.py with --cov=. emits the full repo-relative path.
+        ("scripts/cloud_campaign_manager.py", "scripts/cloud_campaign_manager.py"),
+        ("./scripts/cloud_campaign_manager.py", "scripts/cloud_campaign_manager.py"),
+        # Third-party / installed modules may carry a site-packages prefix.
+        (
+            "/opt/hostedtoolcache/.../site-packages/scripts/cloud_campaign_manager.py",
+            "scripts/cloud_campaign_manager.py",
+        ),
+        (
+            "site-packages/cloud_campaign_manager.py",
+            "scripts/cloud_campaign_manager.py",
+        ),
+        # Windows separators are tolerated.
+        ("scripts\\cloud_campaign_manager.py", "scripts/cloud_campaign_manager.py"),
+        # Unknown files collapse to scripts/<basename> as well — they simply
+        # never match a TARGETS key and are ignored downstream.
+        ("foo/bar/state_store.py", "scripts/state_store.py"),
+    ],
+)
+def test_normalize_filename_maps_each_form_to_canonical_key(raw, expected):
+    assert checker.normalize_filename(raw) == expected
+
+
+# ---------------------------------------------------------------------------
+# evaluate_coverage
+# ---------------------------------------------------------------------------
+
+
+def _class_elem(
+    filename: str,
+    lines_valid: int,
+    lines_covered: int,
+    *,
+    with_summary_attrs: bool = True,
+) -> ET.Element:
+    """Build a ``<class>`` Cobertura element.
+
+    By default emits the ``lines-valid`` / ``lines-covered`` summary
+    attributes (older coverage.py shape). Pass ``with_summary_attrs=False``
+    to emit only per-line ``<line number hits>`` records, which is what
+    coverage.py >= 6 produces and what caused the second half of Issue #1864.
+    """
+
+    cls = ET.Element("class")
+    cls.set("filename", filename)
+    rate = lines_covered / lines_valid if lines_valid else 0.0
+    cls.set("line-rate", f"{rate:.4f}")
+    if with_summary_attrs:
+        cls.set("lines-valid", str(lines_valid))
+        cls.set("lines-covered", str(lines_covered))
+    else:
+        lines_el = ET.SubElement(cls, "lines")
+        hit = lines_covered
+        for num in range(1, lines_valid + 1):
+            ln = ET.SubElement(lines_el, "line")
+            ln.set("number", str(num))
+            ln.set("hits", "1" if hit > 0 else "0")
+            hit = max(0, hit - 1)
+    return cls
+
+
+def _root(*classes: ET.Element, packages: bool = True) -> ET.Element:
+    root = ET.Element("coverage")
+    if packages:
+        pkg = ET.SubElement(root, "package")
+        for cls in classes:
+            pkg.append(cls)
+    else:
+        for cls in classes:
+            root.append(cls)
+    return root
+
+
+def test_evaluate_coverage_matches_bare_filename_from_cov_scripts():
+    # This is the exact regression shape from Issue #1864.
+    root = _root(
+        _class_elem("cloud_campaign_manager.py", lines_valid=100, lines_covered=68),
+        _class_elem("autonomous_parameter_sweep.py", lines_valid=100, lines_covered=84),
+        _class_elem("ashrae_benchmark_harness.py", lines_valid=100, lines_covered=84),
+    )
+    results = checker.evaluate_coverage(root)
+    assert {r.path for r in results} == set(checker.TARGETS)
+    assert all(r.found for r in results)
+    assert all(r.passed for r in results)
+
+
+def test_evaluate_coverage_matches_prefixed_repo_path():
+    root = _root(
+        _class_elem(
+            "scripts/cloud_campaign_manager.py", lines_valid=100, lines_covered=70
+        ),
+    )
+    results = checker.evaluate_coverage(root)
+    ccm = next(r for r in results if r.path == "scripts/cloud_campaign_manager.py")
+    assert ccm.found
+    assert ccm.percent == pytest.approx(70.0)
+
+
+def test_evaluate_coverage_strips_site_packages_prefix():
+    root = _root(
+        _class_elem(
+            "/usr/lib/python3.12/site-packages/scripts/cloud_campaign_manager.py",
+            lines_valid=50,
+            lines_covered=35,
+        )
+    )
+    results = checker.evaluate_coverage(root)
+    ccm = next(r for r in results if r.path == "scripts/cloud_campaign_manager.py")
+    assert ccm.found
+    assert ccm.lines_valid == 50
+    assert ccm.lines_covered == 35
+
+
+def test_evaluate_coverage_aggregates_split_class_entries():
+    # Some coverage.py versions emit multiple <class> rows per source file
+    # (one per test session / branch report). They must be summed.
+    root = _root(
+        _class_elem("cloud_campaign_manager.py", lines_valid=60, lines_covered=40),
+        _class_elem(
+            "scripts/cloud_campaign_manager.py", lines_valid=40, lines_covered=28
+        ),
+    )
+    results = checker.evaluate_coverage(root)
+    ccm = next(r for r in results if r.path == "scripts/cloud_campaign_manager.py")
+    assert ccm.lines_valid == 100
+    assert ccm.lines_covered == 68
+    assert ccm.percent == pytest.approx(68.0)
+
+
+def test_evaluate_coverage_reports_missing_target_as_not_found():
+    root = _root(
+        _class_elem("cloud_campaign_manager.py", lines_valid=100, lines_covered=68),
+    )
+    results = checker.evaluate_coverage(root)
+    missing = [r for r in results if not r.found]
+    paths = {r.path for r in missing}
+    assert paths == {
+        "scripts/autonomous_parameter_sweep.py",
+        "scripts/ashrae_benchmark_harness.py",
+    }
+    for r in missing:
+        assert r.reason == "no coverage data"
+        assert not r.passed
+
+
+def test_evaluate_coverage_marks_below_threshold_as_failed():
+    root = _root(
+        _class_elem("cloud_campaign_manager.py", lines_valid=100, lines_covered=40),
+    )
+    results = checker.evaluate_coverage(root)
+    ccm = next(r for r in results if r.path == "scripts/cloud_campaign_manager.py")
+    assert ccm.found
+    assert ccm.percent == pytest.approx(40.0)
+    assert not ccm.passed
+    assert ccm.reason == "below threshold"
+
+
+def test_evaluate_coverage_ignores_unrelated_files():
+    root = _root(
+        _class_elem("state_store.py", lines_valid=100, lines_covered=0),
+        _class_elem("cloud_campaign_manager.py", lines_valid=100, lines_covered=68),
+        _class_elem("some/random/module.py", lines_valid=10, lines_covered=10),
+    )
+    results = checker.evaluate_coverage(root)
+    ccm = next(r for r in results if r.path == "scripts/cloud_campaign_manager.py")
+    assert ccm.lines_valid == 100  # not contaminated by state_store / module
+
+
+def test_evaluate_coverage_handles_per_line_records_without_summary_attrs():
+    # coverage.py >= 6 omits lines-valid/lines-covered on <class> and emits
+    # <line number hits> children instead. This is the exact XML shape that
+    # masked the second half of the Issue #1864 regression: even with correct
+    # path normalization, reading the absent summary attrs yields 0/0.
+    root = _root(
+        _class_elem(
+            "cloud_campaign_manager.py",
+            lines_valid=449,
+            lines_covered=305,
+            with_summary_attrs=False,
+        ),
+        _class_elem(
+            "autonomous_parameter_sweep.py",
+            lines_valid=263,
+            lines_covered=220,
+            with_summary_attrs=False,
+        ),
+        _class_elem(
+            "ashrae_benchmark_harness.py",
+            lines_valid=278,
+            lines_covered=233,
+            with_summary_attrs=False,
+        ),
+    )
+    results = checker.evaluate_coverage(root)
+    assert all(r.found for r in results)
+    assert all(r.passed for r in results)
+    ccm = next(r for r in results if r.path == "scripts/cloud_campaign_manager.py")
+    assert ccm.lines_valid == 449
+    assert ccm.lines_covered == 305
+    assert ccm.percent == pytest.approx(67.93, abs=0.1)
+
+
+def test_evaluate_coverage_prefers_summary_attrs_when_present():
+    # When both shapes are available, the summary attributes win so the
+    # checker stays O(attributes) rather than O(lines).
+    root = _root(
+        _class_elem("cloud_campaign_manager.py", lines_valid=100, lines_covered=68),
+    )
+    results = checker.evaluate_coverage(root)
+    ccm = next(r for r in results if r.path == "scripts/cloud_campaign_manager.py")
+    assert ccm.lines_valid == 100
+    assert ccm.lines_covered == 68
+
+
+def test_evaluate_coverage_respects_custom_targets():
+    root = _root(
+        _class_elem("state_store.py", lines_valid=100, lines_covered=50),
+    )
+    custom = {"scripts/state_store.py": 60.0}
+    results = checker.evaluate_coverage(root, targets=custom)
+    assert len(results) == 1
+    assert results[0].path == "scripts/state_store.py"
+    assert results[0].found
+    assert not results[0].passed
+
+
+# ---------------------------------------------------------------------------
+# report
+# ---------------------------------------------------------------------------
+
+
+def test_report_returns_true_and_prints_ok_when_all_pass(capsys):
+    results = [
+        checker.CoverageResult(
+            path="scripts/cloud_campaign_manager.py",
+            lines_valid=100,
+            lines_covered=68,
+            threshold=60.0,
+            found=True,
+        ),
+    ]
+    assert checker.report(results) is True
+    out = capsys.readouterr().out
+    assert "OK  " in out
+    assert "scripts/cloud_campaign_manager.py" in out
+    assert "68.00%" in out
+    assert "::error::" not in out
+
+
+def test_report_returns_false_and_emits_github_error_annotation(capsys):
+    results = [
+        checker.CoverageResult(
+            path="scripts/cloud_campaign_manager.py",
+            lines_valid=100,
+            lines_covered=40,
+            threshold=60.0,
+            found=True,
+        ),
+        checker.CoverageResult(
+            path="scripts/autonomous_parameter_sweep.py",
+            lines_valid=0,
+            lines_covered=0,
+            threshold=60.0,
+            found=False,
+        ),
+    ]
+    assert checker.report(results) is False
+    out = capsys.readouterr().out
+    assert "::error::OSimFlow coverage threshold failures:" in out
+    assert "::error::  scripts/cloud_campaign_manager.py: 40.00%" in out
+    assert "below threshold" in out
+    assert "::error::  scripts/autonomous_parameter_sweep.py:" in out
+    assert "no coverage data" in out
+
+
+# ---------------------------------------------------------------------------
+# main / end-to-end
+# ---------------------------------------------------------------------------
+
+
+def _write_xml(tmp_path, body: str):
+    xml_path = tmp_path / "coverage.xml"
+    xml_path.write_text(dedent(body), encoding="utf-8")
+    return xml_path
+
+
+_PASSING_XML = """
+    <coverage>
+      <packages>
+        <class filename="cloud_campaign_manager.py"
+               line-rate="0.68" lines-valid="100" lines-covered="68"/>
+        <class filename="autonomous_parameter_sweep.py"
+               line-rate="0.84" lines-valid="100" lines-covered="84"/>
+        <class filename="ashrae_benchmark_harness.py"
+               line-rate="0.84" lines-valid="100" lines-covered="84"/>
+      </packages>
+    </coverage>
+"""
+
+
+def test_main_returns_zero_on_passing_xml(tmp_path, capsys):
+    xml_path = _write_xml(tmp_path, _PASSING_XML)
+    rc = checker.main([str(xml_path)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "OK  " in out
+    assert "::error::" not in out
+
+
+def test_main_returns_one_when_a_target_is_missing(tmp_path, capsys):
+    body = """
+        <coverage>
+          <packages>
+            <class filename="cloud_campaign_manager.py"
+                   line-rate="0.68" lines-valid="100" lines-covered="68"/>
+          </packages>
+        </coverage>
+    """
+    xml_path = _write_xml(tmp_path, body)
+    rc = checker.main([str(xml_path)])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "scripts/autonomous_parameter_sweep.py" in out
+    assert "no coverage data" in out
+
+
+def test_main_returns_one_when_below_threshold(tmp_path, capsys):
+    body = """
+        <coverage>
+          <packages>
+            <class filename="cloud_campaign_manager.py"
+                   line-rate="0.40" lines-valid="100" lines-covered="40"/>
+          </packages>
+        </coverage>
+    """
+    xml_path = _write_xml(tmp_path, body)
+    rc = checker.main([str(xml_path)])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "scripts/cloud_campaign_manager.py" in out
+    assert "below threshold" in out
+
+
+def test_main_returns_one_when_xml_missing(tmp_path, capsys):
+    rc = checker.main([str(tmp_path / "does_not_exist.xml")])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "::error::coverage XML not found" in out
+
+
+def test_main_returns_one_on_malformed_xml(tmp_path, capsys):
+    xml_path = _write_xml(tmp_path, "<coverage><not-closed>")
+    rc = checker.main([str(xml_path)])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "::error::failed to parse" in out
+
+
+def test_main_uses_default_path_when_no_arg_given(monkeypatch, tmp_path, capsys):
+    # Redirect DEFAULT_COVERAGE_XML to a passing fixture so the no-arg path
+    # can be exercised without touching the real repo layout.
+    passing = _write_xml(tmp_path, _PASSING_XML)
+    monkeypatch.setattr(checker, "DEFAULT_COVERAGE_XML", str(passing))
+    rc = checker.main([])
+    assert rc == 0


### PR DESCRIPTION
Closes #1864

The OSimFlow pytest workflow failed on all four Python versions (3.10–3.13) on every PR targeting `develop`. The `Enforce per-file coverage thresholds` step — added in PR #1849 as inline Python in `.github/workflows/python-tests.yml` — had two compounding defects that made it report every target as failing regardless of actual coverage:

1. **Path normalization mismatch.** Coverage is configured with `--cov=scripts`, so coverage.py records filenames relative to the `scripts/` source root (e.g. `cloud_campaign_manager.py`). The threshold table keyed on canonical repo paths (`scripts/cloud_campaign_manager.py`), so the `base in targets` membership test never matched and every file was reported as "no coverage data".
2. **Absent summary attributes on `<class>`.** coverage.py >= 6 omits `lines-valid` / `lines-covered` attributes on `<class>` elements (they live only on the root `<coverage>` element) and emits per-line `<line number hits>` records instead. The inline gate read `cls.get("lines-valid", "0")`, which returned `0` for every class — so even with correct path matching the aggregate counts would have been `0/0`.

## Fix

Extracts the gate into a unit-testable `scripts/check_osimflow_coverage.py` (mirroring the existing `scripts/check_*.py` convention) and replaces the inline Python in the workflow with a one-line invocation:

```yaml
python scripts/check_osimflow_coverage.py scripts/ci/coverage.xml
```

The checker normalizes each `<class>` filename onto the canonical `scripts/<basename>` key (tolerating bare names, `scripts/` prefixes, `./` prefixes, `site-packages/` prefixes, and Windows separators) and computes line counts from the Cobertura summary attributes when present, falling back to counting `<line hits>` children for coverage.py >= 6.

## Verification

- All 130 OSimFlow tests pass locally (`pytest scripts/ci/ -c scripts/pytest.ini`).
- The extracted checker reports correct coverage against real `coverage.xml` and exits 0: `cloud_campaign_manager.py 67.93%`, `autonomous_parameter_sweep.py 83.65%`, `ashrae_benchmark_harness.py 83.81%`.
- 25 new unit tests in `scripts/ci/test_check_osimflow_coverage.py` pin the normalization, aggregation, both XML shapes (summary-attribute and per-line-record), missing/below-threshold targets, and the `main`/error-path behaviour.
- `cargo fmt --check` and `cargo clippy --lib` clean; `ruff check` and `ruff format --check` clean on the new Python files.

## Summary by Sourcery

Extract the OSimFlow per-file coverage threshold enforcement from inline workflow code into a dedicated script, wire the CI workflow to use it, and add documentation and tests to ensure robust path normalization and coverage evaluation behavior.

New Features:
- Introduce a dedicated scripts/check_osimflow_coverage.py script to enforce per-file coverage thresholds from Cobertura XML in a unit-testable way.

Enhancements:
- Update the CI Python tests workflow to invoke the extracted coverage checker script instead of inline Python.
- Document the per-file coverage gate and its usage in scripts/README.md.

Tests:
- Add a comprehensive test suite in scripts/ci/test_check_osimflow_coverage.py covering filename normalization, coverage aggregation, XML shape handling, reporting, and main() behavior.