### PR TITLE
feat(measures): resolve #1816 — track applied Deltas and Python Measures on FluxionModel

### DIFF
--- a/docs/measures.md
+++ b/docs/measures.md
@@ -4,9 +4,10 @@
 <!-- 1: This document describes the FluxionMeasure Python base class and AOT runner. -->
 <!-- 2: Read it before writing a custom measure or modifying the measures subsystem. -->
 <!-- 3: Key concepts: AOT-only rule, GIL/rayon rationale, snapshot/owned-value lifecycle. -->
-<!-- 4: Companion to docs/bindings.md (memory safety) and ARCHITECTURE.md (module boundaries). -->
-<!-- 5: Stable as of issue #1814 — measures API is feature-frozen pending OSM integration. -->
-<!-- 6: After changes, run `maturin develop` then `pytest tests/python/test_apply_measures_cli.py`. -->
+<!-- 4: Also covers the AppliedDelta provenance chain (Issue #1816) and its schema. -->
+<!-- 5: Companion to docs/bindings.md (memory safety) and ARCHITECTURE.md (module boundaries). -->
+<!-- 6: Stable as of issue #1816 — measures API + provenance contract are feature-frozen pending OSM integration. -->
+<!-- 7: After changes, run `maturin develop` then `pytest tests/python/test_apply_measures_cli.py`. -->
 
 ## TL;DR
 
@@ -137,3 +138,92 @@ south = [s for s in data['surfaces'] if s['orientation'] == 'South']
 print('south surfaces with overhang:', sum(1 for s in south if s['overhang_depth']))
 "
 ```
+
+## Provenance — the `AppliedDelta` chain (Issue #1816)
+
+When a building model is altered by either a JSON Patch (#1811) or a Python
+Measure (#1814), the resulting output dataset must be able to answer *"why did
+this model change?"*. This is critical for ML feature tracking, debugging, and
+reproducibility — ML data engineers need to know exactly which parametric
+permutations produced a given energy-use number.
+
+### The contract
+
+Every successful mutation appends an **`AppliedDelta`** entry to the model's
+provenance chain, in application order. The chain travels with the serialized
+model / `results.json` so downstream consumers can reconstruct the full
+mutation history without re-running.
+
+- **JSON Patches** applied via `fluxion::measures::json_patch::apply_delta`
+  (Rust) append an entry automatically, with a SHA-256 `digest` of the patch
+  payload.
+- **Python Measures** executed via `apply_measures` (the AOT runner) append an
+  entry per measure when the caller passes an `applied_deltas` accumulator.
+
+### The `AppliedDelta` schema
+
+```json
+{
+  "source": "json_patch",
+  "name": "json_patch:a1b2c3d4e5f60718",
+  "timestamp": "0000000000000000",
+  "digest": "a1b2c3d4e5f60718..."
+}
+```
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `source` | `"json_patch"` \| `"python_measure"` | Which subsystem produced the mutation. |
+| `name` | string | Identifier of the patch file or measure class. For auto-recorded JSON patches this defaults to `json_patch:<short-digest>`; use `apply_delta_with_name(model, patch, name)` (Rust) for a human-readable label. |
+| `timestamp` | string | **Logical sequence** (zero-padded, pure-Rust path) or an ISO-8601 wall-clock instant (Python AOT-runner path). See *Determinism* below. |
+| `digest` | string \| `null` | SHA-256 (hex) of the patch payload. `null` when there is no deterministic payload to hash (e.g. a Python measure that mutates via the snapshot API). |
+
+The Rust source of truth is `src/measures/provenance.rs`
+(`AppliedDelta` / `DeltaSource`); the Python mirror is
+`fluxion.measures.make_applied_delta`. The two are kept byte-compatible.
+
+### Determinism
+
+The `timestamp` field is a **monotonic logical clock** (a zero-padded sequence
+index assigned from `applied_deltas.len()`) on the pure-Rust path, **not** a
+wall-clock instant. This is deliberate: the Fluxion determinism gate
+(Issue #1351) requires that two byte-identical inputs produce byte-identical
+serialized output, and `SystemTime::now()` would violate that contract. The
+Python AOT runner — which is not subject to the determinism gate — overwrites
+`timestamp` with a real ISO-8601 instant at the application layer.
+
+### Round-trip example
+
+A model run through a JSON patch **and** a Python measure produces a chain with
+both entries, in application order:
+
+```python
+from fluxion.measures import make_applied_delta, save_model
+
+# ... after apply_delta (Rust) and apply_measures (Python) ...
+chain = [
+    make_applied_delta("json_patch", "patches/insulation.json", digest="abc..."),
+    make_applied_delta("python_measure", "AddSouthOverhang"),
+]
+save_model(model, "results.json", applied_deltas=chain)
+```
+
+`results.json` now carries:
+
+```json
+{
+  "schema_version": "1.0.0",
+  "...": "...",
+  "applied_deltas": [
+    { "source": "json_patch",      "name": "patches/insulation.json", "timestamp": "...", "digest": "abc..." },
+    { "source": "python_measure",  "name": "AddSouthOverhang",         "timestamp": "..." }
+  ],
+  "_fluxion_run": {
+    "applied": ["AddSouthOverhang"],
+    "applied_deltas": [ /* same chain, echoed for convenience */ ]
+  }
+}
+```
+
+ML pipelines (cf. #1337) consume `applied_deltas` to reconstruct the provenance
+chain and feature-hash identical permutations via the `digest`.

--- a/fluxion/__init__.py
+++ b/fluxion/__init__.py
@@ -31,9 +31,11 @@ else:
 from fluxion.measures import (  # noqa: E402
     FluxionMeasure,
     apply_measures,
+    digest_of_json_payload,
     discover_measures,
     dict_to_model,
     load_model,
+    make_applied_delta,
     model_to_dict,
     save_model,
 )
@@ -41,9 +43,11 @@ from fluxion.measures import (  # noqa: E402
 __all__ = [
     "FluxionMeasure",
     "apply_measures",
+    "digest_of_json_payload",
     "discover_measures",
     "dict_to_model",
     "load_model",
+    "make_applied_delta",
     "model_to_dict",
     "save_model",
 ]

--- a/fluxion/cli.py
+++ b/fluxion/cli.py
@@ -185,18 +185,22 @@ def _handle_apply_measures(args: argparse.Namespace) -> int:
         logger.error("Failed to load model: %s", e)
         return 1
 
-    # Apply each measure in order.
+    # Apply each measure in order. Build the provenance chain (Issue #1816)
+    # so the serialized output can reconstruct which measures ran.
+    applied_deltas: list[dict[str, Any]] = []
     try:
-        applied = apply_measures(model, measure_classes, measure_args)
+        applied = apply_measures(
+            model, measure_classes, measure_args, applied_deltas=applied_deltas
+        )
     except Exception as e:
         logger.error("Measure execution failed: %s", e)
         return 1
 
-    # Serialize the result.
+    # Serialize the result (embed the provenance chain in the payload).
     logger.info("Writing mutated model to %s", args.output)
     args.output.parent.mkdir(parents=True, exist_ok=True)
     try:
-        save_model(model, args.output)
+        save_model(model, args.output, applied_deltas=applied_deltas)
     except Exception as e:
         logger.error("Failed to write model: %s", e)
         return 1
@@ -205,6 +209,7 @@ def _handle_apply_measures(args: argparse.Namespace) -> int:
     # tooling can introspect what happened without re-running.
     summary = {
         "applied": applied,
+        "applied_deltas": applied_deltas,
         "output": str(args.output),
         "model": {
             "num_zones": model.num_zones(),

--- a/fluxion/measures.py
+++ b/fluxion/measures.py
@@ -39,6 +39,8 @@ See :mod:`fluxion.cli` for the ``fluxion apply-measures`` entrypoint.
 
 from __future__ import annotations
 
+import datetime as _dt
+import hashlib
 import importlib.util
 import inspect
 import json
@@ -273,6 +275,73 @@ _SENTINEL: Any = object()
 
 
 # =============================================================================
+# Provenance — AppliedDelta tracking (Issue #1816)
+# =============================================================================
+#
+# Every mutation applied to a model (a JSON Patch from Issue #1811 or a Python
+# Measure from Issue #1814) is recorded as an ``AppliedDelta`` dict so the final
+# ``results.json`` / serialized output can reconstruct the provenance chain.
+# The schema mirrors the Rust ``fluxion::measures::provenance::AppliedDelta``
+# struct exactly (``source`` / ``name`` / ``timestamp`` / ``digest``).
+
+#: Stable source tags — must match the Rust ``DeltaSource`` snake_case serde tags.
+SOURCE_JSON_PATCH = "json_patch"
+SOURCE_PYTHON_MEASURE = "python_measure"
+
+
+def _now_iso8601() -> str:
+    """Return the current UTC instant as an ISO-8601 string.
+
+    The Python AOT runner is *not* subject to the Rust determinism gate
+    (Issue #1351), so a real wall-clock timestamp is appropriate here. The
+    pure-Rust ``apply_delta`` path uses a deterministic logical sequence
+    instead (see ``src/measures/provenance.rs``).
+    """
+    return _dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds")
+
+
+def make_applied_delta(
+    source: str,
+    name: str,
+    digest: str | None = None,
+    *,
+    timestamp: str | None = None,
+) -> dict[str, Any]:
+    """Build a single ``AppliedDelta`` provenance entry.
+
+    Parameters
+    ----------
+    source : str
+        One of :data:`SOURCE_JSON_PATCH` / :data:`SOURCE_PYTHON_MEASURE`.
+    name : str
+        Identifier of the patch file or measure class.
+    digest : str, optional
+        SHA-256 (hex) of the patch payload, or ``None`` when there is no
+        deterministic payload to hash.
+    timestamp : str, optional
+        ISO-8601 wall-clock instant. Defaults to the current UTC time.
+    """
+    entry: dict[str, Any] = {
+        "source": source,
+        "name": name,
+        "timestamp": timestamp if timestamp is not None else _now_iso8601(),
+    }
+    if digest is not None:
+        entry["digest"] = digest
+    return entry
+
+
+def digest_of_json_payload(payload: Any) -> str:
+    """Compute a stable SHA-256 hex digest of a JSON-serialisable payload.
+
+    The payload is serialised with ``sort_keys=True`` so two semantically
+    equal payloads with different key insertion order hash identically.
+    """
+    blob = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()
+
+
+# =============================================================================
 # Model serialization (AOT file format)
 # =============================================================================
 
@@ -281,18 +350,26 @@ _SENTINEL: Any = object()
 SCHEMA_VERSION = "1.0.0"
 
 
-def model_to_dict(model: Any) -> dict[str, Any]:
+def model_to_dict(
+    model: Any,
+    applied_deltas: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
     """Serialize a ``fluxion.Model`` to a JSON-compatible dict.
 
     Uses the snapshot API (``model.zones()``, ``model.surfaces()``,
     ``model.hvac_system()``) so the output is consistent with the
     PyO3 ownership contract described in ``docs/bindings.md``.
 
-    The schema is intentionally minimal and versioned — see
-    :data:`SCHEMA_VERSION`. The Rust runtime today does not yet consume this
-    format directly; the serialized file is meant for round-tripping through
-    :func:`dict_to_model` and for CI smoke tests that verify a measure chain
-    is idempotent.
+    Parameters
+    ----------
+    model : fluxion.Model
+        The model to snapshot.
+    applied_deltas : list of dict, optional
+        Provenance chain (Issue #1816). Each entry is an ``AppliedDelta`` dict
+        built by :func:`make_applied_delta`. When provided, it is embedded in
+        the output under the ``applied_deltas`` key so downstream consumers can
+        reconstruct the provenance chain. Omitted from the output when ``None``
+        or empty.
     """
     zones = [
         {
@@ -308,7 +385,7 @@ def model_to_dict(model: Any) -> dict[str, Any]:
     ]
     flat_surfaces = [_surface_to_dict(s) for s in model.surfaces()]
     hvac = model.hvac_system()
-    return {
+    payload: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
         "num_zones": model.num_zones(),
         "temperatures": list(model.get_temperatures()),
@@ -327,6 +404,9 @@ def model_to_dict(model: Any) -> dict[str, Any]:
             "supply_air_temp": hvac.supply_air_temp,
         },
     }
+    if applied_deltas:
+        payload["applied_deltas"] = applied_deltas
+    return payload
 
 
 def dict_to_model(payload: dict[str, Any]) -> Any:
@@ -457,14 +537,25 @@ def _dict_to_hvac(d: dict[str, Any]) -> Any:
     )
 
 
-def save_model(model: Any, path: str | os.PathLike[str]) -> None:
+def save_model(
+    model: Any,
+    path: str | os.PathLike[str],
+    applied_deltas: list[dict[str, Any]] | None = None,
+) -> None:
     """Write a model to disk as JSON (or msgpack if ``msgpack`` is installed).
 
     The output format is selected by file extension: ``.json`` -> JSON,
     ``.msgpack`` -> msgpack (if available; falls back to JSON if msgpack is
     not importable). All other extensions default to JSON for safety.
+
+    Parameters
+    ----------
+    applied_deltas : list of dict, optional
+        Provenance chain (Issue #1816). Embedded under ``applied_deltas`` in
+        the serialized payload when non-empty, so downstream consumers can
+        reconstruct which Deltas/Measures produced the model.
     """
-    payload = model_to_dict(model)
+    payload = model_to_dict(model, applied_deltas=applied_deltas)
     target = Path(path)
     suffix = target.suffix.lower()
     if suffix == ".msgpack":
@@ -608,6 +699,7 @@ def apply_measures(
     model: Any,
     measures: Iterable[type[FluxionMeasure] | FluxionMeasure],
     measure_args: dict[str, dict[str, Any]] | None = None,
+    applied_deltas: list[dict[str, Any]] | None = None,
 ) -> list[str]:
     """Apply each measure in sequence to ``model``, mutating it in place.
 
@@ -627,6 +719,11 @@ def apply_measures(
         Mapping of ``measure.name`` -> parsed arguments dict. Measures not
         present in the mapping receive an empty dict (which is then merged
         with declared defaults via :meth:`FluxionMeasure.parse_arguments`).
+    applied_deltas : list, optional
+        Provenance accumulator (Issue #1816). When provided, a
+        :func:`make_applied_delta` entry is appended for each measure *after*
+        it runs successfully, so the caller can embed the chain in
+        ``results.json`` via :func:`save_model`. The list is mutated in place.
     """
     measure_args = measure_args or {}
     applied: list[str] = []
@@ -642,17 +739,28 @@ def apply_measures(
         raw = measure_args.get(instance.name, {}) or {}
         args = instance.parse_arguments(raw)
         instance.apply(model, args)
-        applied.append(instance.name or instance.__class__.__name__)
+        measure_name = instance.name or instance.__class__.__name__
+        applied.append(measure_name)
+        # Record provenance (Issue #1816): a Python measure has no
+        # deterministic patch payload to hash, so digest is None.
+        if applied_deltas is not None:
+            applied_deltas.append(
+                make_applied_delta(SOURCE_PYTHON_MEASURE, measure_name)
+            )
     return applied
 
 
 __all__ = [
     "FluxionMeasure",
     "SCHEMA_VERSION",
+    "SOURCE_JSON_PATCH",
+    "SOURCE_PYTHON_MEASURE",
     "apply_measures",
+    "digest_of_json_payload",
     "discover_measures",
     "dict_to_model",
     "load_model",
+    "make_applied_delta",
     "model_to_dict",
     "save_model",
 ]

--- a/src/measures/json_patch.rs
+++ b/src/measures/json_patch.rs
@@ -65,6 +65,7 @@ use serde_json::Value;
 
 use crate::measures::error::DeltaError;
 use crate::measures::model::FluxionModel;
+use crate::measures::provenance::digest_of_patch;
 
 /// Apply a JSON Patch (RFC 6902) to a [`FluxionModel`] in place.
 ///
@@ -122,6 +123,53 @@ pub fn apply_delta(model: &mut FluxionModel, patch: &Patch) -> Result<(), DeltaE
 
     // Commit.
     *model = patched;
+
+    // Step 4 (Issue #1816): record provenance. The patch payload is hashed
+    // so downstream consumers can deduplicate / feature-hash identical
+    // permutations. The default name is derived from the digest so the
+    // chain is self-describing even when no file path is available.
+    let digest = digest_of_patch(patch);
+    let name = match &digest {
+        Some(d) if d.len() >= 16 => format!("json_patch:{}", &d[..16]),
+        Some(d) => format!("json_patch:{}", d),
+        None => "json_patch".to_string(),
+    };
+    model.record_json_patch_named(&name, digest);
+    Ok(())
+}
+
+/// Apply a JSON Patch to a [`FluxionModel`] and record provenance under an
+/// explicit `name` (e.g. the patch file path or measure id).
+///
+/// This is the traced variant of [`apply_delta`]: the mutation is identical,
+/// but the appended [`crate::measures::provenance::AppliedDelta`] entry carries
+/// `name` instead of an auto-derived `json_patch:<digest>` label. Use it when
+/// the caller knows the originating file or measure identifier — it makes the
+/// provenance chain readable for ML feature tracking and debugging.
+///
+/// # Errors
+///
+/// Same failure modes as [`apply_delta`]; on error `model` is unchanged **and**
+/// no provenance entry is appended.
+pub fn apply_delta_with_name(
+    model: &mut FluxionModel,
+    patch: &Patch,
+    name: &str,
+) -> Result<(), DeltaError> {
+    // Step 1–3: identical round-trip semantics to `apply_delta`.
+    let mut doc: Value =
+        serde_json::to_value(&*model).map_err(|e| DeltaError::Serialize(e.to_string()))?;
+
+    apply_json_patch(&mut doc, patch).map_err(map_patch_error)?;
+
+    let patched: FluxionModel =
+        serde_json::from_value(doc).map_err(|e| classify_deserialize_error(&e))?;
+
+    *model = patched;
+
+    // Step 4: record provenance with the caller-supplied name.
+    let digest = digest_of_patch(patch);
+    model.record_json_patch_named(name, digest);
     Ok(())
 }
 
@@ -550,5 +598,167 @@ mod tests {
             absorptance: 0.5,
         };
         assert!((layer.r_value() - 1.65).abs() < 1e-9);
+    }
+
+    // ------------------------------------------------------------------
+    // Provenance tracking (Issue #1816)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn apply_delta_records_json_patch_provenance() {
+        // Acceptance test: every JSON patch applied via apply_delta appends an
+        // AppliedDelta entry with source = JsonPatch.
+        let mut model = FluxionModel::ashrae_140_case_600();
+        let p = patch_from_value(json!([
+            { "op": "replace", "path": "/zones/zone_1/volume", "value": 200.0 }
+        ]));
+        assert!(model.applied_deltas().is_empty());
+
+        apply_delta(&mut model, &p).unwrap();
+
+        let chain = model.applied_deltas();
+        assert_eq!(chain.len(), 1, "exactly one entry per patch");
+        assert_eq!(
+            chain[0].source,
+            crate::measures::provenance::DeltaSource::JsonPatch
+        );
+        assert!(
+            chain[0].name.starts_with("json_patch:"),
+            "default name should be derived from the digest, got {}",
+            chain[0].name
+        );
+        assert!(chain[0].digest.is_some(), "digest must be populated");
+        assert!(
+            chain[0].digest.as_ref().unwrap().len() >= 16,
+            "digest is a SHA-256 hex string"
+        );
+    }
+
+    #[test]
+    fn apply_delta_with_name_records_explicit_name() {
+        let mut model = FluxionModel::ashrae_140_case_600();
+        let p = patch_from_value(json!([
+            { "op": "replace", "path": "/zones/zone_1/volume", "value": 200.0 }
+        ]));
+        apply_delta_with_name(&mut model, &p, "patches/volume_increase.json").unwrap();
+
+        let chain = model.applied_deltas();
+        assert_eq!(chain.len(), 1);
+        assert_eq!(chain[0].name, "patches/volume_increase.json");
+        assert!(chain[0].digest.is_some());
+    }
+
+    #[test]
+    fn failed_patch_records_no_provenance() {
+        // A patch that fails must NOT append a provenance entry.
+        let mut model = FluxionModel::ashrae_140_case_600();
+        let p = patch_from_value(json!([
+            { "op": "replace", "path": "/zones/zone_does_not_exist/volume", "value": 999.0 }
+        ]));
+        let _ = apply_delta(&mut model, &p);
+        assert!(
+            model.applied_deltas().is_empty(),
+            "failed patch must not record provenance"
+        );
+    }
+
+    #[test]
+    fn multiple_patches_accumulate_in_order() {
+        let mut model = FluxionModel::ashrae_140_case_900();
+        let p1 = patch_from_value(json!([
+            { "op": "replace", "path": "/zones/zone_1/volume", "value": 200.0 }
+        ]));
+        let p2 = patch_from_value(json!([
+            { "op": "replace", "path": "/assemblies/wall_1/layers/1/conductivity", "value": 0.03 }
+        ]));
+        apply_delta(&mut model, &p1).unwrap();
+        apply_delta(&mut model, &p2).unwrap();
+
+        let chain = model.applied_deltas();
+        assert_eq!(chain.len(), 2);
+        // Timestamps are monotonic logical sequences.
+        assert!(chain[0].timestamp < chain[1].timestamp);
+        // Different patches → different digests.
+        assert_ne!(chain[0].digest, chain[1].digest);
+    }
+
+    #[test]
+    fn identical_patches_produce_identical_digests() {
+        let mut a = FluxionModel::ashrae_140_case_600();
+        let mut b = FluxionModel::ashrae_140_case_600();
+        let p = patch_from_value(json!([
+            { "op": "replace", "path": "/zones/zone_1/volume", "value": 200.0 }
+        ]));
+        apply_delta(&mut a, &p).unwrap();
+        apply_delta(&mut b, &p).unwrap();
+        assert_eq!(a.applied_deltas()[0].digest, b.applied_deltas()[0].digest);
+    }
+
+    #[test]
+    fn provenance_preserved_through_round_trip() {
+        // Determinism: two models patched with the same patch must serialize
+        // identically, INCLUDING the applied_deltas chain. This guards the
+        // Fluxion determinism gate (Issue #1351).
+        let mut original = FluxionModel::ashrae_140_case_900();
+        let mut copy: FluxionModel =
+            serde_json::from_str(&serde_json::to_string(&original).unwrap()).unwrap();
+
+        let p = patch_from_value(json!([
+            { "op": "replace", "path": "/assemblies/wall_1/layers/1/conductivity", "value": 0.0333 }
+        ]));
+
+        apply_delta(&mut original, &p).unwrap();
+        apply_delta(&mut copy, &p).unwrap();
+
+        let original_json = serde_json::to_string(&original).unwrap();
+        let copy_json = serde_json::to_string(&copy).unwrap();
+        assert_eq!(
+            original_json, copy_json,
+            "provenance recording must not break determinism"
+        );
+    }
+
+    #[test]
+    fn round_trip_patch_then_measure_contains_both_in_order() {
+        // Issue #1816 acceptance test: a model run through a #1811 patch AND
+        // a #1814 measure → the provenance chain contains both entries in
+        // application order.
+        let mut model = FluxionModel::ashrae_140_case_900();
+
+        // 1. Apply a JSON Patch (Issue #1811) — records a JsonPatch entry.
+        let p = patch_from_value(json!([
+            { "op": "replace", "path": "/assemblies/wall_1/layers/1/conductivity", "value": 0.03 }
+        ]));
+        apply_delta(&mut model, &p).unwrap();
+
+        // 2. Apply a Python Measure (Issue #1814) — records a PythonMeasure
+        //    entry. In the pure-Rust path this is modelled via the recorder;
+        //    the Python AOT runner appends the same shape via make_applied_delta.
+        model.record_python_measure("AddSouthOverhang", None);
+
+        // 3. Serialize to "results.json" and verify the chain.
+        let json = serde_json::to_string_pretty(&model).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let chain = v["applied_deltas"]
+            .as_array()
+            .expect("applied_deltas present");
+
+        assert_eq!(chain.len(), 2, "both entries must be present");
+        assert_eq!(chain[0]["source"], "json_patch");
+        assert!(
+            chain[0]["name"]
+                .as_str()
+                .unwrap()
+                .starts_with("json_patch:"),
+            "patch entry name is derived from the digest"
+        );
+        assert!(
+            chain[0]["digest"].is_string(),
+            "patch entry carries a digest"
+        );
+        assert_eq!(chain[1]["source"], "python_measure");
+        assert_eq!(chain[1]["name"], "AddSouthOverhang");
+        // Application order: patch before measure.
+        assert!(chain[0]["timestamp"].as_str().unwrap() < chain[1]["timestamp"].as_str().unwrap());
     }
 }

--- a/src/measures/mod.rs
+++ b/src/measures/mod.rs
@@ -46,11 +46,13 @@
 pub mod error;
 pub mod json_patch;
 pub mod model;
+pub mod provenance;
 
 // Convenience re-exports so callers can write
 // `use fluxion::measures::{FluxionModel, apply_delta, DeltaError};`
 pub use error::DeltaError;
-pub use json_patch::apply_delta;
+pub use json_patch::{apply_delta, apply_delta_with_name};
 pub use model::{
     AssemblySpec, ConstructionSpec, FluxionModel, MaterialLayer, ZoneSpec, MEASURES_SCHEMA_VERSION,
 };
+pub use provenance::{digest_of_patch, logical_timestamp, AppliedDelta, DeltaSource};

--- a/src/measures/model.rs
+++ b/src/measures/model.rs
@@ -66,6 +66,8 @@
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
+use crate::measures::provenance::{digest_of_patch, AppliedDelta, DeltaSource};
+
 /// Marker for the measures schema format.
 ///
 /// Bumping this string is a breaking change for any persisted Delta / model
@@ -188,6 +190,17 @@ pub struct FluxionModel {
     /// Assemblies keyed by stable identifier (e.g. `"wall_1"`).
     #[serde(default)]
     pub assemblies: BTreeMap<String, AssemblySpec>,
+
+    /// Provenance chain — every Delta (JSON Patch or Python Measure) applied
+    /// to this model, in application order (Issue #1816).
+    ///
+    /// Empty for a freshly-constructed model. Each successful
+    /// [`crate::measures::json_patch::apply_delta`] call appends one entry;
+    /// Python Measures append via [`FluxionModel::record_python_measure`].
+    /// The field is omitted from serialized JSON when empty, so existing
+    /// serialized models round-trip unchanged.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub applied_deltas: Vec<AppliedDelta>,
 }
 
 fn default_schema_version() -> String {
@@ -204,6 +217,7 @@ impl Default for FluxionModel {
             zones: BTreeMap::new(),
             constructions: BTreeMap::new(),
             assemblies: BTreeMap::new(),
+            applied_deltas: Vec::new(),
         }
     }
 }
@@ -299,6 +313,7 @@ impl FluxionModel {
             zones,
             constructions,
             assemblies,
+            applied_deltas: Vec::new(),
         }
     }
 
@@ -354,6 +369,7 @@ impl FluxionModel {
             zones,
             constructions: BTreeMap::new(),
             assemblies,
+            applied_deltas: Vec::new(),
         }
     }
 
@@ -372,6 +388,71 @@ impl FluxionModel {
         self.assemblies
             .get(assembly)
             .map(AssemblySpec::total_r_value)
+    }
+
+    // ------------------------------------------------------------------
+    // Provenance (Issue #1816)
+    // ------------------------------------------------------------------
+
+    /// The provenance chain — every Delta applied to this model, in order.
+    ///
+    /// This is a borrowed view over [`FluxionModel::applied_deltas`]; use the
+    /// `record_*` methods to append entries.
+    pub fn applied_deltas(&self) -> &[AppliedDelta] {
+        &self.applied_deltas
+    }
+
+    /// Append a fully-constructed [`AppliedDelta`] entry.
+    ///
+    /// Low-level escape hatch; prefer [`Self::record_json_patch`] or
+    /// [`Self::record_python_measure`] which assign a deterministic logical
+    /// timestamp automatically.
+    pub fn push_applied_delta(&mut self, entry: AppliedDelta) {
+        self.applied_deltas.push(entry);
+    }
+
+    /// Record a JSON Patch mutation (Issue #1811) in the provenance chain.
+    ///
+    /// `name` is a caller-supplied identifier (e.g. the patch file path); the
+    /// SHA-256 `digest` of the patch payload is computed automatically when the
+    /// [`json_patch::Patch`] is supplied. When the caller only has a name (no
+    /// payload), pass `record_json_patch_named(name, None)`.
+    pub fn record_json_patch(&mut self, name: &str, patch: &json_patch::Patch) {
+        let digest = digest_of_patch(patch);
+        let seq = self.applied_deltas.len();
+        self.applied_deltas
+            .push(AppliedDelta::new_json_patch(name, digest, seq));
+    }
+
+    /// Record a JSON Patch mutation with an explicit (or absent) digest.
+    ///
+    /// Use this when the digest is already known (e.g. computed upstream) or
+    /// when there is no patch payload to hash.
+    pub fn record_json_patch_named(&mut self, name: &str, digest: Option<String>) {
+        let seq = self.applied_deltas.len();
+        self.applied_deltas
+            .push(AppliedDelta::new_json_patch(name, digest, seq));
+    }
+
+    /// Record a Python Measure mutation (Issue #1814) in the provenance chain.
+    ///
+    /// Python measures mutate the PyO3 model via the snapshot API, so there is
+    /// no deterministic patch payload — `digest` is usually `None`.
+    pub fn record_python_measure(&mut self, name: &str, digest: Option<String>) {
+        let seq = self.applied_deltas.len();
+        self.applied_deltas
+            .push(AppliedDelta::new_python_measure(name, digest, seq));
+    }
+
+    /// Remove all provenance entries. Rarely needed — useful for tests that
+    /// need a model with a clean chain after mutating it.
+    pub fn clear_applied_deltas(&mut self) {
+        self.applied_deltas.clear();
+    }
+
+    /// Returns `true` if any entry in the chain has the given source.
+    pub fn has_delta_source(&self, source: DeltaSource) -> bool {
+        self.applied_deltas.iter().any(|d| d.source == source)
     }
 }
 
@@ -443,5 +524,72 @@ mod tests {
     fn missing_assembly_returns_none() {
         let model = FluxionModel::default();
         assert!(model.assembly_total_r_value("nonexistent").is_none());
+    }
+
+    // ------------------------------------------------------------------
+    // Provenance (Issue #1816)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn fresh_model_has_empty_applied_deltas() {
+        let model = FluxionModel::ashrae_140_case_600();
+        assert!(model.applied_deltas().is_empty());
+        // Serialized form omits the empty field.
+        let v: serde_json::Value = serde_json::to_value(&model).unwrap();
+        assert!(v.get("applied_deltas").is_none());
+    }
+
+    #[test]
+    fn record_methods_append_in_order() {
+        let mut model = FluxionModel::default();
+        model.record_json_patch_named("patch_a", Some("deadbeef".to_string()));
+        model.record_python_measure("AddOverhang", None);
+        model.record_json_patch_named("patch_b", None);
+
+        let chain = model.applied_deltas();
+        assert_eq!(chain.len(), 3);
+        assert_eq!(chain[0].name, "patch_a");
+        assert_eq!(chain[0].source, super::DeltaSource::JsonPatch);
+        assert_eq!(chain[1].name, "AddOverhang");
+        assert_eq!(chain[1].source, super::DeltaSource::PythonMeasure);
+        assert_eq!(chain[2].name, "patch_b");
+    }
+
+    #[test]
+    fn logical_timestamps_are_monotonic() {
+        let mut model = FluxionModel::default();
+        model.record_python_measure("a", None);
+        model.record_python_measure("b", None);
+        let chain = model.applied_deltas();
+        assert!(chain[0].timestamp < chain[1].timestamp);
+    }
+
+    #[test]
+    fn applied_deltas_round_trip_through_json() {
+        let mut model = FluxionModel::ashrae_140_case_900();
+        model.record_json_patch_named("insulation_r_value", Some("abc123".to_string()));
+        model.record_python_measure("AddSouthOverhang", None);
+
+        let json = serde_json::to_string(&model).unwrap();
+        let parsed: FluxionModel = serde_json::from_str(&json).unwrap();
+        assert_eq!(model, parsed);
+        assert_eq!(parsed.applied_deltas().len(), 2);
+    }
+
+    #[test]
+    fn has_delta_source_filters() {
+        let mut model = FluxionModel::default();
+        model.record_python_measure("M", None);
+        assert!(model.has_delta_source(super::DeltaSource::PythonMeasure));
+        assert!(!model.has_delta_source(super::DeltaSource::JsonPatch));
+    }
+
+    #[test]
+    fn clear_applied_deltas_empties_chain() {
+        let mut model = FluxionModel::default();
+        model.record_python_measure("M", None);
+        assert_eq!(model.applied_deltas().len(), 1);
+        model.clear_applied_deltas();
+        assert!(model.applied_deltas().is_empty());
     }
 }

--- a/src/measures/provenance.rs
+++ b/src/measures/provenance.rs
@@ -1,0 +1,248 @@
+// Copyright 2026 Fluxion. All rights reserved.
+// SPDX-License-Identifier: MIT.
+
+//! Provenance tracking for applied Deltas and Python Measures (Issue #1816).
+//!
+//! When a [`crate::measures::model::FluxionModel`] is mutated — either by a
+//! JSON Patch (RFC 6902, Issue #1811) or by a Python Measure executed via the
+//! AOT runner (Issue #1814) — the resulting output dataset must be able to
+//! answer the question *"why did this model change?"*. This module provides
+//! the data structures that make the mutation chain reconstructable.
+//!
+//! # The provenance contract
+//!
+//! Every successful mutation appends an [`AppliedDelta`] entry to
+//! [`crate::measures::model::FluxionModel::applied_deltas`], in application
+//! order. Downstream consumers (ML feature pipelines, debugging tools,
+//! reproducibility audits) read the chain back from the serialized model /
+//! `results.json` to reconstruct exactly which permutations produced a given
+//! energy-use number.
+//!
+//! # Determinism
+//!
+//! The `timestamp` field is a **monotonic logical clock** (a zero-padded
+//! sequence index assigned from `applied_deltas.len()` at append time), not a
+//! wall-clock instant. This is deliberate: the Fluxion determinism gate
+//! (Issue #1351) requires that two byte-identical inputs produce byte-identical
+//! serialized output, and `SystemTime::now()` would violate that contract.
+//! Callers that need a wall-clock instant (e.g. the Python AOT runner) are free
+//! to overwrite `timestamp` with an ISO-8601 string at the application layer,
+//! where the determinism gate does not apply.
+//!
+//! # The `AppliedDelta` schema
+//!
+//! ```json
+//! {
+//!   "source": "json_patch",
+//!   "name": "json_patch:a1b2c3d4e5f60718",
+//!   "timestamp": "0000000000000000",
+//!   "digest": "a1b2c3d4e5f60718..."
+//! }
+//! ```
+//!
+//! - `source` — `"json_patch"` or `"python_measure"` ([`DeltaSource`]).
+//! - `name`   — identifier of the patch file / measure class.
+//! - `timestamp` — logical sequence (pure-Rust path) or ISO-8601 (Python path).
+//! - `digest`  — optional SHA-256 of the patch payload (hex). `null` when the
+//!   mutation has no deterministic payload to hash (e.g. a Python measure that
+//!   mutates via the snapshot API).
+
+use json_patch::Patch;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// The subsystem that produced a mutation.
+///
+/// Serialised as `snake_case` so downstream JSON consumers can pattern-match on
+/// a stable string regardless of Rust rename refactors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeltaSource {
+    /// A declarative JSON Patch (RFC 6902) applied via
+    /// [`crate::measures::json_patch::apply_delta`] (Issue #1811).
+    JsonPatch,
+    /// A Python Measure executed by the AOT runner (Issue #1814).
+    PythonMeasure,
+}
+
+impl DeltaSource {
+    /// The stable string used in the `source` JSON field.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            DeltaSource::JsonPatch => "json_patch",
+            DeltaSource::PythonMeasure => "python_measure",
+        }
+    }
+}
+
+/// A single provenance entry — one mutation applied to a
+/// [`crate::measures::model::FluxionModel`].
+///
+/// Entries are appended in application order, so `applied_deltas[i]` describes
+/// the `i`-th mutation. See the module-level docs for the determinism rationale
+/// behind the `timestamp` field.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AppliedDelta {
+    /// What kind of mutation produced this entry.
+    pub source: DeltaSource,
+    /// Identifier of the patch file or Python measure class
+    /// (e.g. `"json_patch:a1b2…"` or `"AddSouthOverhang"`).
+    pub name: String,
+    /// Logical sequence index (zero-padded, pure-Rust path) or an ISO-8601
+    /// wall-clock string (Python AOT-runner path).
+    pub timestamp: String,
+    /// Optional SHA-256 (hex) of the patch payload. `None` when there is no
+    /// deterministic payload to hash.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub digest: Option<String>,
+}
+
+impl AppliedDelta {
+    /// Construct an entry for a JSON Patch mutation.
+    ///
+    /// `name` is the caller-supplied identifier (e.g. a patch file path);
+    /// `digest` is the SHA-256 of the patch payload (see [`digest_of_patch`]).
+    /// `seq` is the logical sequence index — normally
+    /// `model.applied_deltas.len()` at append time.
+    pub fn new_json_patch(name: impl Into<String>, digest: Option<String>, seq: usize) -> Self {
+        Self {
+            source: DeltaSource::JsonPatch,
+            name: name.into(),
+            timestamp: logical_timestamp(seq),
+            digest,
+        }
+    }
+
+    /// Construct an entry for a Python Measure mutation.
+    ///
+    /// Python measures mutate the PyO3 model via the snapshot API, so there is
+    /// no deterministic patch payload to hash — `digest` is accepted but is
+    /// usually `None` for this source.
+    pub fn new_python_measure(name: impl Into<String>, digest: Option<String>, seq: usize) -> Self {
+        Self {
+            source: DeltaSource::PythonMeasure,
+            name: name.into(),
+            timestamp: logical_timestamp(seq),
+            digest,
+        }
+    }
+
+    /// Return the short (16-char) prefix of the digest, or `"unnamed"` if the
+    /// digest is absent. Useful for building human-readable default names.
+    pub fn short_digest_or(&self, fallback: &str) -> String {
+        match &self.digest {
+            Some(d) if d.len() >= 16 => d[..16].to_string(),
+            Some(d) => d.clone(),
+            None => fallback.to_string(),
+        }
+    }
+}
+
+/// Render a logical timestamp for sequence index `seq`.
+///
+/// A zero-padded 16-digit decimal string. This sorts lexicographically in the
+/// same order as the numeric sequence, so `applied_deltas` chains compare
+/// correctly when serialized.
+pub fn logical_timestamp(seq: usize) -> String {
+    format!("{:016}", seq)
+}
+
+/// Compute the SHA-256 digest (64-char lowercase hex) of a JSON Patch payload.
+///
+/// The patch is serialised via `serde_json`, whose field ordering is fixed by
+/// the `json-patch` crate's `#[derive(Serialize)]`, so two structurally-equal
+/// patches always produce the same digest. Returns `None` only if serialisation
+/// fails (which, for a `Patch`, is effectively never).
+pub fn digest_of_patch(patch: &Patch) -> Option<String> {
+    let bytes = serde_json::to_vec(patch).ok()?;
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    let hash = hasher.finalize();
+    Some(hash.iter().map(|b| format!("{:02x}", b)).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn delta_source_serializes_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&DeltaSource::JsonPatch).unwrap(),
+            r#""json_patch""#
+        );
+        assert_eq!(
+            serde_json::to_string(&DeltaSource::PythonMeasure).unwrap(),
+            r#""python_measure""#
+        );
+    }
+
+    #[test]
+    fn delta_source_round_trips() {
+        for src in [DeltaSource::JsonPatch, DeltaSource::PythonMeasure] {
+            let s = serde_json::to_string(&src).unwrap();
+            let back: DeltaSource = serde_json::from_str(&s).unwrap();
+            assert_eq!(src, back);
+        }
+    }
+
+    #[test]
+    fn applied_delta_serializes_with_optional_digest() {
+        let with_digest = AppliedDelta::new_json_patch("p", Some("abc".to_string()), 0);
+        let v: serde_json::Value = serde_json::to_value(&with_digest).unwrap();
+        assert_eq!(v["digest"], json!("abc"));
+        assert_eq!(v["source"], json!("json_patch"));
+
+        let no_digest = AppliedDelta::new_python_measure("m", None, 1);
+        let v: serde_json::Value = serde_json::to_value(&no_digest).unwrap();
+        // digest is skipped when None.
+        assert!(v.get("digest").is_none() || v["digest"].is_null());
+        assert_eq!(v["source"], json!("python_measure"));
+    }
+
+    #[test]
+    fn logical_timestamp_is_zero_padded_and_sorts() {
+        assert_eq!(logical_timestamp(0), "0000000000000000");
+        assert_eq!(logical_timestamp(7), "0000000000000007");
+        // Lexicographic order matches numeric order for equal-width strings.
+        assert!(logical_timestamp(3) < logical_timestamp(12));
+    }
+
+    #[test]
+    fn digest_of_patch_is_deterministic() {
+        let p1: Patch = serde_json::from_value(json!([
+            { "op": "replace", "path": "/zones/zone_1/volume", "value": 200.0 }
+        ]))
+        .unwrap();
+        let p2: Patch = serde_json::from_value(json!([
+            { "op": "replace", "path": "/zones/zone_1/volume", "value": 200.0 }
+        ]))
+        .unwrap();
+        let d1 = digest_of_patch(&p1).unwrap();
+        let d2 = digest_of_patch(&p2).unwrap();
+        assert_eq!(d1, d2, "identical patches must hash identically");
+        assert_eq!(d1.len(), 64, "SHA-256 hex is 64 chars");
+    }
+
+    #[test]
+    fn digest_differs_for_different_patches() {
+        let p1: Patch = serde_json::from_value(json!([
+            { "op": "replace", "path": "/zones/zone_1/volume", "value": 200.0 }
+        ]))
+        .unwrap();
+        let p2: Patch = serde_json::from_value(json!([
+            { "op": "replace", "path": "/zones/zone_1/volume", "value": 300.0 }
+        ]))
+        .unwrap();
+        assert_ne!(digest_of_patch(&p1).unwrap(), digest_of_patch(&p2).unwrap());
+    }
+
+    #[test]
+    fn short_digest_or_fallbacks() {
+        let d = AppliedDelta::new_json_patch("p", Some("abcdef0123456789extra".to_string()), 0);
+        assert_eq!(d.short_digest_or("x"), "abcdef0123456789");
+        let none = AppliedDelta::new_python_measure("m", None, 0);
+        assert_eq!(none.short_digest_or("unnamed"), "unnamed");
+    }
+}

--- a/tests/python/test_apply_measures_cli.py
+++ b/tests/python/test_apply_measures_cli.py
@@ -707,3 +707,162 @@ def _import_example(class_name: str):
     finally:
         if added:
             sys.path.remove(measures_path)
+
+
+# ---------------------------------------------------------------------------
+# Provenance — AppliedDelta tracking (Issue #1816)
+# ---------------------------------------------------------------------------
+
+
+class TestAppliedDeltasProvenance:
+    """Issue #1816 — the AOT runner records a provenance chain.
+
+    These tests exercise the pure-Python provenance surface
+    (:func:`make_applied_delta`, :func:`digest_of_json_payload`, the
+    ``applied_deltas`` out-param on :func:`apply_measures`, and the
+    ``applied_deltas`` embedding in :func:`model_to_dict` / :func:`save_model`).
+    They do not require the native bindings unless they touch a real
+    ``fluxion.Model``.
+    """
+
+    def test_make_applied_delta_shape(self):
+        from fluxion.measures import (
+            SOURCE_PYTHON_MEASURE,
+            make_applied_delta,
+        )
+
+        entry = make_applied_delta(SOURCE_PYTHON_MEASURE, "AddOverhang")
+        assert entry["source"] == "python_measure"
+        assert entry["name"] == "AddOverhang"
+        assert "timestamp" in entry and entry["timestamp"]
+        # digest is optional and omitted when None.
+        assert "digest" not in entry
+
+        entry2 = make_applied_delta(
+            "json_patch", "p.json", digest="abc123", timestamp="2026-01-01T00:00:00+00:00"
+        )
+        assert entry2["source"] == "json_patch"
+        assert entry2["digest"] == "abc123"
+        assert entry2["timestamp"] == "2026-01-01T00:00:00+00:00"
+
+    def test_digest_of_json_payload_is_stable(self):
+        from fluxion.measures import digest_of_json_payload
+
+        a = digest_of_json_payload({"b": 1, "a": 2})
+        b = digest_of_json_payload({"a": 2, "b": 1})
+        assert a == b, "key order must not affect the digest"
+        assert len(a) == 64, "SHA-256 hex"
+        assert a != digest_of_json_payload({"a": 2, "b": 3})
+
+    def test_apply_measures_appends_applied_deltas(self):
+        from fluxion import FluxionMeasure
+        from fluxion.measures import (
+            SOURCE_PYTHON_MEASURE,
+            apply_measures,
+        )
+
+        order: list[str] = []
+
+        class A(FluxionMeasure):
+            def apply(self, model, arguments):
+                order.append("A")
+
+        class B(FluxionMeasure):
+            def apply(self, model, arguments):
+                order.append("B")
+
+        m = _StubModel()
+        chain: list[dict] = []
+        applied = apply_measures(m, [A, B], applied_deltas=chain)
+
+        # Return value is unchanged (backward compatible).
+        assert applied == ["A", "B"]
+        assert order == ["A", "B"]
+        # Provenance chain has one entry per measure, in order.
+        assert len(chain) == 2
+        assert [e["name"] for e in chain] == ["A", "B"]
+        assert all(e["source"] == SOURCE_PYTHON_MEASURE for e in chain)
+        # Timestamps are populated and monotonic (ISO-8601 sorts correctly).
+        assert chain[0]["timestamp"] <= chain[1]["timestamp"]
+
+    def test_apply_measures_without_chain_is_backward_compatible(self):
+        from fluxion import FluxionMeasure
+        from fluxion.measures import apply_measures
+
+        class M(FluxionMeasure):
+            def apply(self, model, arguments):
+                pass
+
+        m = _StubModel()
+        # No applied_deltas kwarg -> behaves exactly as before.
+        applied = apply_measures(m, [M])
+        assert applied == ["M"]
+
+    @requires_fluxion
+    def test_save_model_embeds_applied_deltas(self, tmp_path):
+        from fluxion.measures import make_applied_delta, save_model
+
+        fluxion_mod = importlib.import_module("fluxion")
+        model = fluxion_mod.Model(num_zones=1)
+        chain = [
+            make_applied_delta("json_patch", "volume.json", digest="deadbeef"),
+            make_applied_delta("python_measure", "AddSouthOverhang"),
+        ]
+        out_path = tmp_path / "results.json"
+        save_model(model, out_path, applied_deltas=chain)
+
+        payload = json.loads(out_path.read_text())
+        assert "applied_deltas" in payload
+        embedded = payload["applied_deltas"]
+        assert [e["name"] for e in embedded] == ["volume.json", "AddSouthOverhang"]
+        assert embedded[0]["source"] == "json_patch"
+        assert embedded[1]["source"] == "python_measure"
+
+    @requires_fluxion
+    def test_cli_output_contains_applied_deltas(self, tmp_path):
+        fluxion_mod = importlib.import_module("fluxion")
+        from fluxion.measures import save_model
+
+        base = fluxion_mod.Model(num_zones=1)
+        base_path = tmp_path / "base.json"
+        save_model(base, base_path)
+
+        out_path = tmp_path / "results.json"
+        result = _run_fluxion_cli(
+            "apply-measures",
+            "--model", str(base_path),
+            "--measures", str(MEASURES_DIR),
+            "--output", str(out_path),
+        )
+        assert result.returncode == 0, result.stderr
+
+        payload = json.loads(out_path.read_text())
+        # The payload carries the chain at the top level...
+        assert "applied_deltas" in payload
+        names = [e["name"] for e in payload["applied_deltas"]]
+        assert "AddSouthOverhang" in names
+        assert "SetHVACCOP" in names
+        assert all(e["source"] == "python_measure" for e in payload["applied_deltas"])
+        # ...and the _fluxion_run summary echoes it too.
+        assert "applied_deltas" in payload["_fluxion_run"]
+        assert len(payload["_fluxion_run"]["applied_deltas"]) == len(names)
+
+
+class _StubModel:
+    """Minimal stand-in for ``fluxion.Model`` for pure-Python tests.
+
+    ``apply_measures`` only calls ``instance.apply(model, args)`` and the
+    runtime guard; it never introspects the model, so a bare object suffices
+    for provenance-ordering tests that don't need the native bindings.
+    """
+
+
+def _run_fluxion_cli(*args: str) -> subprocess.CompletedProcess:
+    """Invoke ``python -m fluxion.cli`` from the repo root."""
+    return subprocess.run(
+        [sys.executable, "-m", "fluxion.cli", *args],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+


### PR DESCRIPTION
Closes #1816

Add an `applied_deltas: Vec<AppliedDelta>` provenance chain to `FluxionModel` (Rust) and mirror it in the Python AOT runner so the final output dataset can reconstruct exactly which mutations produced a given model. Each `AppliedDelta` records `source` (`json_patch` | `python_measure`), `name`, `timestamp`, and an optional SHA-256 `digest` of the patch payload. Every JSON patch applied via `apply_delta` now appends a `JsonPatch` entry (with a content-hash digest), and the Python `apply_measures` runner appends a `PythonMeasure` entry per measure; both travel with the serialized model / `results.json` for ML feature tracking and reproducibility. The `timestamp` uses a deterministic logical sequence on the pure-Rust path (preserving the determinism gate) and an ISO-8601 wall-clock instant on the Python path. Includes `apply_delta_with_name` for human-readable patch labels, round-trip and determinism tests (a model run through a JSON patch and a Python measure yields both entries in application order), Python provenance tests, and `docs/measures.md` documenting the provenance contract and the `AppliedDelta` schema.

## Summary by Sourcery

Introduce provenance tracking for model mutations by recording an AppliedDelta chain on FluxionModel and propagating it through Rust JSON patch application and the Python measures AOT runner into serialized outputs.

New Features:
- Add an applied_deltas provenance chain to FluxionModel to capture all JSON patch and Python measure mutations in application order.
- Expose AppliedDelta, DeltaSource, logical_timestamp, and digest_of_patch in the Rust measures module for downstream consumers.
- Add Python-side helpers (make_applied_delta, digest_of_json_payload) and extend model_to_dict/save_model to embed applied_deltas in results.json and CLI summaries.
- Extend apply_measures to optionally accumulate an applied_deltas chain for each measure run while preserving backwards-compatible behavior.
- Introduce apply_delta_with_name to label JSON patches with explicit human-readable identifiers in the provenance chain.

Enhancements:
- Ensure JSON patch application automatically records provenance entries with stable SHA-256 digests while preserving determinism in serialized models.
- Document the AppliedDelta schema and provenance contract in docs/measures.md, including determinism behavior and integration examples.

Tests:
- Add Rust tests validating JSON patch provenance recording, ordering, determinism, digest stability, and round-trip behavior of applied_deltas.
- Add Python tests covering AppliedDelta shape, JSON payload digest stability, apply_measures provenance accumulation, embedding in saved models, and CLI output including applied_deltas.