### PR TITLE
⚡ Bolt: [performance improvement] Remove unused vector allocation in physics_impl

### DIFF
--- a/src/sim/thermal_model_physics/physics_impl.rs
+++ b/src/sim/thermal_model_physics/physics_impl.rs
@@ -2265,8 +2265,6 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
 
         // (#872) Save raw gain data for multi-node solver before moving into tensors.
         // Used for internal radiative gain injection via step_with_gains().
-        let _phi_ia_data_for_solver = scratch.phi_ia.clone();
-
         let phi_ia = T::from(VectorField::new(std::mem::take(&mut scratch.phi_ia)));
         let phi_st = T::from(VectorField::new(std::mem::take(&mut scratch.phi_st)));
         let phi_m = T::from(VectorField::new(std::mem::take(&mut scratch.phi_m)));


### PR DESCRIPTION
💡 **What**: Removed the line `let _phi_ia_data_for_solver = scratch.phi_ia.clone();` in the 9R4C configuration block of `src/sim/thermal_model_physics/physics_impl.rs`.

🎯 **Why**: The variable `_phi_ia_data_for_solver` was prefixed with `_` indicating it is unused, yet it was performing a `.clone()` operation on a `Vec`. Inside the thermal model's hot loops, cloning vectors creates unnecessary memory allocations and CPU overhead, decreasing throughput.

📊 **Impact**: Reduces heap allocations inside the 9R4C configuration initialization phase per zone by preventing an unused data clone.

🔬 **Measurement**: Verified using `cargo test --lib --benches sim::thermal_model_physics` and `cargo bench --bench engine_bench -- --test`.

---
*PR created automatically by Jules for task [527081489868270931](https://jules.google.com/task/527081489868270931) started by @anchapin*

## Summary by Sourcery

Enhancements:
- Remove unused phi_ia vector allocation to improve performance and reduce heap usage during solver setup.