### PR TITLE
fix(ai): resolve #1865 — make surrogate drift gate handle missing ONNX model in CI

### DIFF
--- a/.github/workflows/surrogate_drift_gate.yml
+++ b/.github/workflows/surrogate_drift_gate.yml
@@ -21,8 +21,24 @@
 #   drift_pct = |T_surrogate - T_physics| / max(|T_physics|, ε) × 100
 # Where ε = 0.1°C prevents division by zero.
 #
-# The gate fails if any timestep exceeds 1% drift, with a message showing
-# the offending timesteps (zone index, step, physics temp, surrogate temp, drift).
+# Two-mode gate (Issue #1865):
+#   - ONNX mode    — a trained model is resolvable (FLUXION_ONNX_MODEL or
+#                    models/surrogate_zone_thermal.onnx). The strict ±1%
+#                    per-timestep tolerance is enforced; any breach fails
+#                    the gate.
+#   - FALLBACK mode — no trained model is registered. The surrogate runs
+#                    the analytical predictor and the gate degrades to a
+#                    lenient ≤100% ceiling so PRs that don't ship a model
+#                    are not blocked. In this mode the gate is ADVISORY:
+#                    it cannot catch real surrogate regressions, so the
+#                    verify step emits a ::warning:: annotation surfacing
+#                    the dormant strict gate (Issue #1865).
+#
+# The active mode is resolved by the "Resolve surrogate gate mode" step,
+# which mirrors SurrogateManager::new_with_auto_load() in
+# src/ai/surrogate.rs. The verify step branches its success/error message
+# on that mode so the CI summary always reports whether the strict 1% gate
+# was actually active (rather than unconditionally claiming "<1% drift").
 #
 # Why --release
 # --------------
@@ -92,14 +108,43 @@ jobs:
           restore-keys: |
             surrogate-drift-gate-${{ runner.os }}-
 
+      - name: Resolve surrogate gate mode
+        # Mirror SurrogateManager::new_with_auto_load() (src/ai/surrogate.rs):
+        #   1. FLUXION_ONNX_MODEL env var (if it points at an existing file)
+        #   2. models/surrogate_zone_thermal.onnx (built-in default)
+        #   3. otherwise → fallback (analytical predictor, lenient gate)
+        # The resolved mode drives the success/error messaging in the verify
+        # step below so the CI summary reflects whether the strict 1% gate
+        # was actually active (Issue #1865).
+        id: gate-mode
+        run: |
+          model=""
+          if [ -n "${FLUXION_ONNX_MODEL:-}" ] && [ -f "${FLUXION_ONNX_MODEL}" ]; then
+            model="${FLUXION_ONNX_MODEL}"
+          elif [ -f "models/surrogate_zone_thermal.onnx" ]; then
+            model="models/surrogate_zone_thermal.onnx"
+          fi
+          if [ -n "$model" ]; then
+            echo "mode=onnx" >> "$GITHUB_OUTPUT"
+            echo "model=$model" >> "$GITHUB_OUTPUT"
+            echo "Gate mode: ONNX (strict 1% tolerance) — model: $model"
+          else
+            echo "mode=fallback" >> "$GITHUB_OUTPUT"
+            echo "model=" >> "$GITHUB_OUTPUT"
+            echo "Gate mode: FALLBACK (advisory — no trained ONNX model; lenient <=100% ceiling)"
+          fi
+
       - name: Case 900 9R4C 1-week drift check
         # Test 1/2: 168-timestep (1-week) drift gate
         # Filter `_surrogate_drift_gate_case_900_9r4c` is precise — no other
         # test in the workspace shares this suffix.
+        # `--nocapture` surfaces the per-test `mode=` / `max_drift=` diagnostic
+        # line so the verify step can report the actual drift and operating mode.
         run: |
           cargo test --release --features ort --verbose \
             --test surrogate_drift_gate \
             _surrogate_drift_gate_case_900_9r4c \
+            -- --nocapture \
             2>&1 | tee -a /tmp/surrogate_drift_output.txt
           echo "---"
           echo "exit_code=$?"
@@ -110,6 +155,7 @@ jobs:
           cargo test --release --features ort --verbose \
             --test surrogate_drift_gate \
             _surrogate_drift_gate_annual_simulation \
+            -- --nocapture \
             2>&1 | tee -a /tmp/surrogate_drift_output.txt
           echo "---"
           echo "exit_code=$?"
@@ -135,22 +181,44 @@ jobs:
           echo "=== Surrogate drift gate result extraction ==="
           sed -i 's/\x1b\[[0-9;]*m//g' /tmp/surrogate_drift_output.txt
 
-          FAILED=$(grep -cE '^test .* \\.\\.\\. FAILED$' /tmp/surrogate_drift_output.txt || true)
+          FAILED=$(grep -cE '^test .* \.\.\. FAILED$' /tmp/surrogate_drift_output.txt || true)
           PANICS=$(grep -cE 'panicked at' /tmp/surrogate_drift_output.txt || true)
-          PASSED=$(grep -cE '^test test_surrogate_drift_gate.* \\.\\.\\. ok$' /tmp/surrogate_drift_output.txt || true)
+          PASSED=$(grep -cE '^test test_surrogate_drift_gate.* \.\.\. ok$' /tmp/surrogate_drift_output.txt || true)
 
-          echo "  Passed   : $PASSED"
-          echo "  Failed   : $FAILED"
-          echo "  Panics   : $PANICS"
+          # Test self-reported mode + peak drift (printed via eprintln! under
+          # --nocapture). Used to cross-check the independently resolved mode.
+          TEST_MODE=$(grep -oE 'mode=(onnx|fallback)' /tmp/surrogate_drift_output.txt | tail -1 | cut -d= -f2 || true)
+          PEAK_DRIFT=$(grep -oE 'max_drift=[0-9.]+%' /tmp/surrogate_drift_output.txt | tail -1 | cut -d= -f2 || true)
+          RESOLVED_MODE="${{ steps.gate-mode.outputs.mode }}"
+
+          echo "  Passed        : $PASSED"
+          echo "  Failed        : $FAILED"
+          echo "  Panics        : $PANICS"
+          echo "  Resolved mode : $RESOLVED_MODE"
+          echo "  Test mode     : ${TEST_MODE:-n/a}"
+          echo "  Peak drift    : ${PEAK_DRIFT:-n/a}"
+
+          if [ -n "$TEST_MODE" ] && [ "$TEST_MODE" != "$RESOLVED_MODE" ]; then
+            echo "::warning::Gate mode mismatch — workflow resolved '$RESOLVED_MODE' but the test reported '$TEST_MODE'. Verify SurrogateManager::new_with_auto_load() resolution (Issue #1865)."
+          fi
 
           if [ "$FAILED" -gt 0 ] || [ "$PANICS" -gt 0 ]; then
             echo
-            echo "::error::Surrogate drift tolerance gate FAILED — surrogate drifted >1% from 9R4C baseline."
+            if [ "$RESOLVED_MODE" = "onnx" ]; then
+              echo "::error::Surrogate drift tolerance gate FAILED — surrogate drifted >1% from 9R4C baseline (strict ONNX mode). Retrain the surrogate or adjust the drift tolerance (Issue #1784)."
+            else
+              echo "::error::Surrogate drift tolerance gate FAILED — surrogate exceeded the lenient 100% fallback ceiling. This is unexpected in fallback mode; investigate the analytical load predictor (Issue #1865)."
+            fi
             echo "See /tmp/surrogate_drift_output.txt for the failing assertion messages."
-            echo "Per Issue #1784: the surrogate must be retrained or the drift tolerance adjusted."
             exit 1
           fi
-          echo "PASS: Surrogate drift tolerance gate holds (<1% drift from 9R4C baseline)."
+
+          if [ "$RESOLVED_MODE" = "onnx" ]; then
+            echo "PASS: Surrogate drift tolerance gate holds (<1% drift from 9R4C baseline, strict ONNX mode${PEAK_DRIFT:+, peak drift $PEAK_DRIFT})."
+          else
+            echo "::warning::Surrogate drift gate ran in ADVISORY (fallback) mode — no trained ONNX model is registered (FLUXION_ONNX_MODEL unset and models/surrogate_zone_thermal.onnx absent). The strict 1% gate is dormant; the lenient <=100% ceiling passed${PEAK_DRIFT:+ (peak drift $PEAK_DRIFT)}. See Issue #1865."
+            echo "PASS: Surrogate drift gate passed in ADVISORY fallback mode (strict 1% gate dormant — no trained ONNX model)."
+          fi
 
       - name: Upload drift-gate log
         if: always()

--- a/tests/surrogate_drift_gate.rs
+++ b/tests/surrogate_drift_gate.rs
@@ -249,3 +249,37 @@ fn test_surrogate_drift_metric_definition() {
         "Large drift expected when physics temp is near zero and surrogate differs by 1°C"
     );
 }
+
+/// Issue #1865 — lock the lenient-fallback contract.
+///
+/// When no trained ONNX model is loaded, the gate must degrade to the lenient
+/// ≤100% ceiling so PRs that don't ship a model are not blocked by the large
+/// drift the analytical fallback naturally produces. This constructs a
+/// synthetic drift result that breaches the strict 1% tolerance but stays
+/// within the lenient ceiling, and asserts the gate does not panic in
+/// fallback mode. It is skipped (not FAILED) when a real ONNX model is
+/// resolvable, since the strict gate would (correctly) reject 50% drift.
+#[test]
+fn test_surrogate_drift_gate_lenient_fallback_contract() {
+    let manager =
+        SurrogateManager::new_with_auto_load().expect("Failed to initialize surrogate manager");
+    if manager.model_loaded {
+        eprintln!(
+            "Skipping lenient-fallback contract test: a trained ONNX model is loaded at {:?}, \
+             so the strict 1% gate is active and 50% drift would (correctly) fail.",
+            manager.model_path
+        );
+        return;
+    }
+
+    // 50% drift: breaches the strict 1% tolerance but is well within the
+    // lenient 100% fallback ceiling.
+    let result = DriftResult {
+        max_drift_pct: 50.0,
+        offending_timesteps: vec![(0, 0, 20.0, 30.0, 50.0)],
+    };
+
+    // Must not panic — this is the contract that keeps the gate green on PRs
+    // that don't ship a trained model (Issue #1865).
+    assert_drift_within_gate(&result, "Issue #1865 lenient-fallback contract");
+}


### PR DESCRIPTION
Closes #1865

The Surrogate Drift Tolerance Gate provided no usable CI signal when no trained ONNX model was registered: the verify step unconditionally printed `PASS: ... (<1% drift ...)` regardless of whether the strict 1% gate or the lenient analytical fallback actually ran, and the test's `mode=`/`max_drift=` diagnostic was swallowed because the workflow didn't pass `--nocapture`. Worse, the FAILED/PASSED `grep` counters used single-quoted `\\.\\.\\.`, which (verified empirically) matches zero lines — so the gate could not detect a real drift failure and would always report PASS. This PR (1) adds a `Resolve surrogate gate mode` step that mirrors `SurrogateManager::new_with_auto_load()` (`FLUXION_ONNX_MODEL` → `models/surrogate_zone_thermal.onnx` → fallback) and branches the success/error messaging on that mode, emitting a visible `::warning::` when the gate runs in advisory fallback mode so the dormant strict gate is surfaced; (2) passes `-- --nocapture` so the per-test mode and peak-drift diagnostic reach the captured log, and cross-checks the test's self-reported mode against the workflow-resolved mode; (3) fixes the broken `grep` dot-escaping so FAILED/PASSED are counted correctly; and (4) adds `test_surrogate_drift_gate_lenient_fallback_contract`, which locks the two-mode lenient-fallback contract (50% drift must not trip the gate when no model is loaded) as a tested regression guard. The strict 1% gate remains the production target once a trained model is registered; until then the gate is honestly reported as advisory rather than falsely claiming <1% drift.
