### PR TITLE
fix(ci): resolve #1866 — ensure CI gate coverage checks match all expected tests

### DIFF
--- a/.github/workflows/surrogate_drift_gate.yml
+++ b/.github/workflows/surrogate_drift_gate.yml
@@ -5,9 +5,14 @@
 #
 # What it runs
 # ------------
-# Two tests that run the Case 900 (high-mass) benchmark building through
-# both the physics-based 9R4C model and the surrogate model, then compare
-# per-timestep zone temperatures:
+# Four tests from the `surrogate_drift_gate` binary. All four are enumerated
+# in the coverage check below so a rename/removal is caught (Issue #1866:
+# CI gate coverage checks must use cargo test filters that match ALL
+# expected tests). The two heavy simulations run in their own steps so the
+# per-test `mode=`/`max_drift=` diagnostics (printed under `--nocapture`,
+# Issue #1865) stay deterministic; the two light unit tests run in a
+# separate step with precise one-test filters that do not collide with the
+# heavy test names (mirrors the ashrae_140_strict_energy_gate pattern).
 #
 #   1. test_surrogate_drift_gate_case_900_9r4c  (surrogate_drift_gate)
 #      filter: _surrogate_drift_gate_case_900_9r4c
@@ -16,6 +21,15 @@
 #   2. test_surrogate_drift_gate_annual_simulation  (surrogate_drift_gate)
 #      filter: _surrogate_drift_gate_annual_simulation
 #      8760-timestep (annual) simulation for full-year drift gate
+#
+#   3. test_surrogate_drift_metric_definition  (surrogate_drift_gate)
+#      filter: _surrogate_drift_metric_definition
+#      Pure unit test on the drift metric formula (no simulation).
+#
+#   4. test_surrogate_drift_gate_lenient_fallback_contract  (surrogate_drift_gate)
+#      filter: _lenient_fallback_contract
+#      Issue #1865 regression guard: locks the two-mode lenient-fallback
+#      contract (50% drift must not trip the gate when no model is loaded).
 #
 # Drift metric defined as:
 #   drift_pct = |T_surrogate - T_physics| / max(|T_physics|, ε) × 100
@@ -135,7 +149,7 @@ jobs:
           fi
 
       - name: Case 900 9R4C 1-week drift check
-        # Test 1/2: 168-timestep (1-week) drift gate
+        # Test 1/4: 168-timestep (1-week) drift gate
         # Filter `_surrogate_drift_gate_case_900_9r4c` is precise — no other
         # test in the workspace shares this suffix.
         # `--nocapture` surfaces the per-test `mode=` / `max_drift=` diagnostic
@@ -150,7 +164,7 @@ jobs:
           echo "exit_code=$?"
 
       - name: Case 900 Annual simulation drift check
-        # Test 2/2: 8760-timestep (annual) drift gate
+        # Test 2/4: 8760-timestep (annual) drift gate
         run: |
           cargo test --release --features ort --verbose \
             --test surrogate_drift_gate \
@@ -160,12 +174,36 @@ jobs:
           echo "---"
           echo "exit_code=$?"
 
+      - name: Drift metric + lenient-fallback contract tests
+        # Tests 3/4 & 4/4: light unit tests that must run on every gate
+        # invocation (Issue #1866). cargo accepts only one TESTNAME before
+        # `--`, so the two precise substring filters go AFTER `--` and are
+        # passed to the libtest runner, which ORs them: a test runs if its
+        # name contains ANY token. Neither token matches the two heavy
+        # simulations above, and no other test in the workspace shares
+        # either suffix, so exactly these two tests run.
+        # `test_surrogate_drift_gate_lenient_fallback_contract` is the
+        # Issue #1865 regression guard added in PR #1874, which was silently
+        # unrun by the gate before this step.
+        run: |
+          cargo test --release --features ort --verbose \
+            --test surrogate_drift_gate \
+            -- _surrogate_drift_metric_definition _lenient_fallback_contract --nocapture \
+            2>&1 | tee -a /tmp/surrogate_drift_output.txt
+          echo "---"
+          echo "exit_code=$?"
+
       - name: Verify gate coverage and extract results
         run: |
           echo "=== Surrogate drift gate coverage check ==="
+          # All four tests in `tests/surrogate_drift_gate.rs` must appear in
+          # the cargo output. A name missing means a filter silently dropped
+          # it (Issue #1866) — fail honestly rather than report a false PASS.
           for t in \
             test_surrogate_drift_gate_case_900_9r4c \
-            test_surrogate_drift_gate_annual_simulation ; do
+            test_surrogate_drift_gate_annual_simulation \
+            test_surrogate_drift_metric_definition \
+            test_surrogate_drift_gate_lenient_fallback_contract ; do
             if grep -qE "^test $t \\.\\.\\. (ok|ignored|FAILED)" /tmp/surrogate_drift_output.txt; then
               echo "  COVERED: $t"
             else
@@ -183,7 +221,7 @@ jobs:
 
           FAILED=$(grep -cE '^test .* \.\.\. FAILED$' /tmp/surrogate_drift_output.txt || true)
           PANICS=$(grep -cE 'panicked at' /tmp/surrogate_drift_output.txt || true)
-          PASSED=$(grep -cE '^test test_surrogate_drift_gate.* \.\.\. ok$' /tmp/surrogate_drift_output.txt || true)
+          PASSED=$(grep -cE '^test test_surrogate_drift_(gate|metric).* \.\.\. ok$' /tmp/surrogate_drift_output.txt || true)
 
           # Test self-reported mode + peak drift (printed via eprintln! under
           # --nocapture). Used to cross-check the independently resolved mode.


### PR DESCRIPTION
Closes #1866

Audited all three CI workflows that use the `for t in ... grep -qE "^test $t"` coverage-check pattern. `hybrid_empirical_validation.yml` and `ashrae_140_strict_energy_gate.yml` were already correct (no filter / one precise suffix filter per checked test, respectively). The `surrogate_drift_gate.yml` workflow had a real silent-coverage gap: its test file defines four tests but the gate only ran and coverage-checked two (`test_surrogate_drift_gate_case_900_9r4c`, `test_surrogate_drift_gate_annual_simulation`). The two light tests — `test_surrogate_drift_metric_definition` and `test_surrogate_drift_gate_lenient_fallback_contract` (the Issue #1865 lenient-fallback regression guard added in PR #1874) — were never executed by the gate, defeating #1874's regression guard exactly as #1866 warns.

The fix keeps the two heavy simulation steps intact (preserving #1874's deterministic `--nocapture` `mode=`/`max_drift=` diagnostics), adds a third step that runs the two light tests via libtest OR filters passed after `--` (cargo accepts only one TESTNAME before `--`; each token is a precise substring that matches exactly one intended test with no workspace collisions, mirroring the ashrae strict-gate pattern), expands the coverage check to enumerate all four test names so a future rename/removal fails honestly, and updates the PASSED counter regex to count all four gate tests. Verified locally: all four tests compile and pass under `--features ort`, the workflow's coverage regex matches every output line, and the PASSED counter reads 4.
