### PR TITLE
perf(physics): remove unused _phi_ia_data_for_solver vector allocation

### DIFF
--- a/src/sim/thermal_model_physics/physics_impl.rs
+++ b/src/sim/thermal_model_physics/physics_impl.rs
@@ -2553,8 +2553,6 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
 
         // (#872) Save raw gain data for multi-node solver before moving into tensors.
         // Used for internal radiative gain injection via step_with_gains().
-        let _phi_ia_data_for_solver = scratch.phi_ia.clone();
-
         let phi_ia = T::from(VectorField::new(std::mem::take(&mut scratch.phi_ia)));
         let phi_st = T::from(VectorField::new(std::mem::take(&mut scratch.phi_st)));
         let phi_m = T::from(VectorField::new(std::mem::take(&mut scratch.phi_m)));


### PR DESCRIPTION
## Re-applies PR #1871 to develop

PR #1871 was accidentally merged to main instead of develop (Bolt bot targeted main). This cherry-picks commit 97c479d onto develop.

**Change**: Removes unused `_phi_ia_data_for_solver` vector clone in physics_impl.rs — avoids unnecessary heap allocation per simulation step.

Trivial 2-line deletion, no functional change.