### PR TITLE
fix(ci): resolve #1891 — Re-enable mutation testing CI coverage with crate-split strategy

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,13 +1,22 @@
 # cargo-mutants configuration for fluxion
 # See https://mutants.rs/config.html
 #
-# Issue #1244: Mutation testing is DISABLED on CI due to cargo-mutants OOM.
-# cargo-mutants 27.x requires ~28GB RAM to analyze fluxion's type hierarchies.
-# Standard CI runners have 7GB RAM. See workflow file for details.
+# Issue #1891: Mutation testing uses a DUAL-PIPELINE strategy:
+#   1. PR check (mutation-testing.yml) — diff-scoped via `cargo mutants --in-diff`,
+#      advisory (non-blocking), runs only on changed lines.
+#   2. Nightly full suite (mutation-nightly.yml) — runs this config in full
+#      against `develop` on a 32 GB runner.
 #
-# To run mutation testing manually (requires 32GB+ RAM machine):
+# Issue #1244: The full-workspace suite requires ~28 GB RAM (cargo-mutants 27.x
+# analyzing fluxion's type hierarchies). The diff-scoped PR check sidesteps
+# this by mutating only changed lines, keeping per-PR runtime to minutes.
+#
+# To run mutation testing manually (requires 32GB+ RAM for full suite):
 #   cargo install cargo-mutants --locked
 #   cargo mutants
+# Diff-scoped (any machine):
+#   scripts/mutants_diff_files.sh origin/develop mutants_diff.patch
+#   cargo mutants --config .cargo/mutants.toml -p fluxion --in-diff mutants_diff.patch
 
 # Skip common allocator-sizes patterns that don't represent real bugs
 skip_calls = ["with_capacity", "new", "default"]

--- a/.github/workflows/mutation-nightly.yml
+++ b/.github/workflows/mutation-nightly.yml
@@ -1,0 +1,183 @@
+name: Mutation Testing (Nightly Full Suite)
+
+# Comprehensive full-workspace mutation testing (Issue #1891, Solution C).
+#
+# The diff-scoped PR check (`mutation-testing.yml`) only mutates changed lines.
+# Indirect mutations — e.g. a trait change that ripples into an untouched solver
+# — are invisible to that scope.  This nightly job closes the gap by running the
+# *entire* mutation suite against `develop` on a 32 GB runner.
+#
+# Results are uploaded as an artifact and summarised in a tracking issue
+# comment (or repository dispatch) rather than gating PRs.
+#
+# Runner selection:
+#   ubuntu-latest-8-cores provides 32 GB RAM, which is sufficient for the
+#   current exclude set in .cargo/mutants.toml.  If `vars.FLUXION_LINUX_RUNNER`
+#   is set (self-hosted Hetzner), the job prefers that runner to avoid the
+#   hosted-runner availability limits documented in docs/self-hosted-runners.md.
+
+on:
+  schedule:
+    # 07:00 UTC daily (off-peak for US/EU contributors).
+    - cron: '0 7 * * *'
+  workflow_dispatch: {}  # manual trigger for on-demand full runs
+
+permissions:
+  contents: read
+  issues: write          # post summary comment on the tracking issue
+  pull-requests: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  mutation-nightly:
+    name: Nightly Full Mutation Suite
+    runs-on: ${{ vars.FLUXION_LINUX_RUNNER || 'ubuntu-latest-8-cores' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev pkg-config libfontconfig1-dev
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-mutants
+        run: cargo install cargo-mutants --locked
+
+      - name: Run full mutation suite
+        id: mutants
+        env:
+          CARGO_INCREMENTAL: "0"
+        run: |
+          # Full-workspace run — NO --in-diff.  The exclude set in
+          # .cargo/mutants.toml keeps the combinatorial physics files out.
+          set +e
+          cargo mutants --config .cargo/mutants.toml -p fluxion --jobs 2 \
+            --baseline skip --features ort \
+            -o mutation_testing_results \
+            -- --test-threads=2
+          MUTANTS_EXIT=$?
+          echo "mutants_exit=$MUTANTS_EXIT" >> $GITHUB_OUTPUT
+          exit 0
+
+      - name: Parse mutation results
+        id: results
+        if: always()
+        run: |
+          OUTCOMES="mutation_testing_results/outcomes.json"
+          if [ ! -f "$OUTCOMES" ]; then
+            echo "caught=0" >> $GITHUB_OUTPUT
+            echo "missed=0" >> $GITHUB_OUTPUT
+            echo "timeout=0" >> $GITHUB_OUTPUT
+            echo "unviable=0" >> $GITHUB_OUTPUT
+            echo "total=0" >> $GITHUB_OUTPUT
+            echo "has_results=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          python3 << 'PYEOF'
+          import json, os
+
+          with open("mutation_testing_results/outcomes.json") as f:
+            outcomes = json.load(f)
+
+          caught = missed = timeout = unviable = 0
+          for item in outcomes:
+              outcome = item.get("outcome", "")
+              if outcome == "caught":
+                  caught += 1
+              elif outcome == "missed":
+                  missed += 1
+              elif outcome == "timeout":
+                  timeout += 1
+              elif outcome == "unviable":
+                  unviable += 1
+
+          total = caught + missed
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"caught={caught}\n")
+              f.write(f"missed={missed}\n")
+              f.write(f"timeout={timeout}\n")
+              f.write(f"unviable={unviable}\n")
+              f.write(f"total={total}\n")
+              f.write("has_results=true\n")
+          PYEOF
+
+      - name: Generate HTML report
+        if: always()
+        run: |
+          mkdir -p mutation_testing_results/reports
+          if [ -f mutation_testing_results/outcomes.json ]; then
+            cargo mutants show -o mutation_testing_results --format html > mutation_testing_results/reports/index.html 2>&1 || true
+          fi
+
+      - name: Upload mutation test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutation-nightly-results
+          path: |
+            mutation_testing_results/
+          retention-days: 90
+
+      - name: Post nightly summary comment
+        if: always() && steps.results.outputs.has_results == 'true'
+        uses: actions/github-script@v7
+        env:
+          MUTANTS_EXIT: ${{ steps.mutants.outputs.mutants_exit }}
+          CAUGHT: ${{ steps.results.outputs.caught }}
+          MISSED: ${{ steps.results.outputs.missed }}
+          TIMEOUT: ${{ steps.results.outputs.timeout }}
+          UNVIABLE: ${{ steps.results.outputs.unviable }}
+          TOTAL: ${{ steps.results.outputs.total }}
+        with:
+          script: |
+            const caught   = parseInt(process.env.CAUGHT   || '0', 10);
+            const missed   = parseInt(process.env.MISSED   || '0', 10);
+            const timeout  = parseInt(process.env.TIMEOUT  || '0', 10);
+            const unviable = parseInt(process.env.UNVIABLE || '0', 10);
+            const total    = parseInt(process.env.TOTAL    || '0', 10);
+            const mutantsExit = parseInt(process.env.MUTANTS_EXIT || '1', 10);
+            const allPassing = mutantsExit === 0 && missed === 0;
+
+            const now = new Date().toISOString().slice(0, 10);
+
+            let body = `## Nightly Mutation Suite — ${now}\n\n`;
+            body += `> Full-workspace run against \`develop\`. `;
+            body += `Diff-scoped PR check: \`mutation-testing.yml\`.\n\n`;
+
+            const emoji = allPassing ? 'PASS' : 'FAIL';
+            body += `| Metric | Value |\n`;
+            body += `|--------|-------|\n`;
+            body += `| Caught (killed) | ${caught} |\n`;
+            body += `| Missed (survived) | ${missed} |\n`;
+            body += `| Timeout | ${timeout} |\n`;
+            body += `| Unviable | ${unviable} |\n`;
+            body += `| Mutation score | ${total > 0 ? Math.round((caught / total) * 100) : 0}% |\n`;
+            body += `| Status | ${emoji} |\n\n`;
+
+            if (missed > 0) {
+              body += `**${missed} mutant(s) survived.** Review the artifact and consider tightening tests.\n\n`;
+            } else if (allPassing) {
+              body += 'All mutants were caught overnight.\n\n';
+            }
+            if (timeout > 0) {
+              body += `**${timeout} mutant(s) timed out.**\n\n`;
+            }
+            body += `**Artifact**: \`mutation-nightly-results\` (90-day retention)\n`;
+
+            // Post to the mutation-testing tracking issue (#1891) for visibility.
+            github.rest.issues.createComment({
+              issue_number: 1891,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,26 +1,30 @@
 name: Mutation Testing
 
-# Mutation testing (issues #1255, #1260, #1440).
+# Diff-scoped advisory mutation testing (Issue #1891, Solution B).
 #
-# The workspace was split into `fluxion` + `fluxion-core` so that cargo-mutants can
-# target only the main `fluxion` crate while `fluxion-core` is built once and cached.
+# This workflow runs cargo-mutants ONLY on the Rust source files (and
+# specifically the changed *lines*) modified in the current PR, using
+# `cargo mutants --in-diff`.  Because the mutation set is tiny compared to a
+# full-workspace run, it completes in minutes on a standard 32 GB runner and
+# restores a mutation signal on PRs — something that was previously zero
+# because the full suite OOMs even on 32 GB machines.
 #
-# IMPORTANT: src/physics/**, src/ai/**, and src/validation/** are EXCLUDED from
-# mutation analysis in .cargo/mutants.toml (the CANONICAL config — there is no
-# longer a root-level mutants.toml) because those modules have complex generic
-# types (CTF solvers, multi-node solvers, ONNX type hierarchies) that cause OOM
-# during cargo-mutants discovery even on 32 GB runners. The long-term fix (moving
-# physics to fluxion-core) is in docs/mutation_testing_crate_split.md Phase 2.
+# This check is **advisory** (non-blocking): the final step never calls
+# `exit 1` on missed mutants.  Results are posted as a PR comment and uploaded
+# as an artifact so reviewers can judge the mutation score.
+#
+# The comprehensive full-workspace run lives in `mutation-nightly.yml`, which
+# executes the entire suite against `develop` on a 32 GB runner overnight.
 #
 # Run locally (requires 32 GB+ machine):
 #   cargo mutants --config .cargo/mutants.toml -p fluxion --jobs 2 --baseline skip
 #
-# See docs/mutation_testing_crate_split.md for the phased plan to reach the <4GB
-# target (Phase 3 gates `ort`/ONNX behind a feature flag).
+# See docs/mutation_testing_crate_split.md for the phased plan to reach the
+# <4 GB target (Phase 3 gates `ort`/ONNX behind a feature flag).
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
@@ -30,6 +34,7 @@ on:
       - '.cargo/mutants.toml'
       - '.cargo/config.toml'
       - '.github/workflows/mutation-testing.yml'
+      - 'scripts/mutants_diff_files.sh'
   workflow_dispatch:
     inputs:
       toolchain:
@@ -37,6 +42,11 @@ on:
         required: false
         default: 'stable'
         type: string
+      full_suite:
+        description: 'Run full suite (ignore diff scope)'
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: mutation-testing-${{ github.ref }}
@@ -53,13 +63,15 @@ env:
 
 jobs:
   mutation-testing:
-    name: Mutation Testing
-    # Targets the main `fluxion` crate only; `fluxion-core` is built once and cached
-    # by cargo-mutants, which is what makes this feasible on a 16GB runner.
-    # (Full <4GB support arrives once `ort` is feature-gated — Phase 3.)
-    runs-on: ubuntu-latest-8-cores  # 32GB RAM machine for mutation testing
+    name: Mutation Testing (diff-scoped)
+    # 32 GB runner — still needed because the per-mutant recompile of the main
+    # crate pulls in `ort` (ONNX) types until Phase 3 gates them.  The runner
+    # pool `ubuntu-latest-8-cores` provides 32 GB.
+    runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so the PR diff is resolvable
 
       - name: Install system dependencies
         run: |
@@ -72,28 +84,56 @@ jobs:
       - name: Install cargo-mutants
         run: cargo install cargo-mutants --locked
 
-      - name: Run mutation testing
+      # ── Diff scope (Solution B) ──────────────────────────────────────────
+      # Generate a unified diff of changed .rs files and pass it to
+      # `cargo mutants --in-diff`.  Only mutants inside the changed hunks are
+      # generated, keeping the per-PR runtime to minutes.
+      - name: Generate PR diff scope
+        id: diffscope
+        run: |
+          # For push events (main/develop) there is no PR base — run the full
+          # suite instead of diff-scoping.
+          if [[ "${{ github.event_name }}" != "pull_request" && "${{ inputs.full_suite }}" != "true" ]]; then
+            # On push to main/develop, skip diff-scoped run (the nightly job
+            # handles full coverage).  Set changed=0 so the job skips cleanly.
+            echo "changed=0" >> $GITHUB_OUTPUT
+            echo "info: push event — deferring to nightly full run" >&2
+            exit 0
+          fi
+
+          BASE_REF="${{ github.event.pull_request.base.ref || 'develop' }}"
+          CHANGED=$(bash scripts/mutants_diff_files.sh "origin/$BASE_REF" mutants_diff.patch)
+          echo "changed=$CHANGED" >> $GITHUB_OUTPUT
+          echo "info: $CHANGED changed .rs file(s) in diff scope" >&2
+
+      - name: Run mutation testing (diff-scoped)
         id: mutants
+        if: steps.diffscope.outputs.changed != '0' || inputs.full_suite == true
         env:
           CARGO_INCREMENTAL: "0"
         run: |
-          # --config: explicitly load .cargo/mutants.toml (the canonical config).
-          # --jobs 2: cap parallelism to bound peak RSS to what the 32 GB runner allows.
+          # --config: explicitly load .cargo/mutants.toml (canonical config).
+          # --jobs 2: cap parallelism to bound peak RSS.
           # -p fluxion: mutate only the main crate; fluxion-core is a cached dep.
           # --baseline skip: skip the no-mutant baseline run to save time + memory.
-          # --features ort: opt in to the ONNX runtime so src/ai/** (issue #1294) is
-          #           included in mutation analysis instead of excluded from
-          #           .cargo/mutants.toml. Without `--features ort`, the build
-          #           excludes `ort` entirely (issue #1294) and src/ai/surrogate
-          #           would fail to compile. The default feature set remains []
-          #           so non-AI builds stay slim — see Cargo.toml.
-          # -o mutation_testing_results: write outcomes to the artifact directory.
+          # --features ort: opt in to ONNX so src/ai/** is included (#1294).
+          # --in-diff: restrict mutants to PR-changed lines (Solution B).
           #
-          # NOTE: cargo-mutants returns non-zero exit when any mutant is missed.
-          # We capture the result so the comment + artifact steps always run.
+          # The job is ADVISORY: we capture the exit code and never fail the
+          # workflow on missed mutants (#1891 recommendation — characterize
+          # flake rate before making this blocking).
           set +e
+
+          EXTRA_ARGS=""
+          if [[ "${{ inputs.full_suite }}" == "true" ]]; then
+            echo "info: full_suite input — ignoring diff scope"
+          elif [[ -s mutants_diff.patch ]]; then
+            EXTRA_ARGS="--in-diff mutants_diff.patch"
+          fi
+
           cargo mutants --config .cargo/mutants.toml -p fluxion --jobs 2 \
             --baseline skip --features ort \
+            $EXTRA_ARGS \
             -o mutation_testing_results \
             -- --test-threads=2
           MUTANTS_EXIT=$?
@@ -102,7 +142,7 @@ jobs:
 
       - name: Parse mutation results
         id: results
-        if: always()
+        if: always() && steps.mutants.outcome != 'skipped'
         run: |
           OUTCOMES="mutation_testing_results/outcomes.json"
           if [ ! -f "$OUTCOMES" ]; then
@@ -146,7 +186,7 @@ jobs:
           PYEOF
 
       - name: Generate HTML report
-        if: always()
+        if: always() && steps.mutants.outcome != 'skipped'
         run: |
           mkdir -p mutation_testing_results/reports
           if [ -f mutation_testing_results/outcomes.json ]; then
@@ -154,7 +194,7 @@ jobs:
           fi
 
       - name: Upload mutation test results
-        if: always()
+        if: always() && steps.mutants.outcome != 'skipped'
         uses: actions/upload-artifact@v4
         with:
           name: mutation-results
@@ -163,7 +203,7 @@ jobs:
           retention-days: 30
 
       - name: Post PR comment with mutation summary
-        if: always() && github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request' && steps.mutants.outcome != 'skipped'
         uses: actions/github-script@v7
         env:
           MUTANTS_EXIT: ${{ steps.mutants.outputs.mutants_exit }}
@@ -173,6 +213,7 @@ jobs:
           UNVIABLE: ${{ steps.results.outputs.unviable }}
           TOTAL: ${{ steps.results.outputs.total }}
           HAS_RESULTS: ${{ steps.results.outputs.has_results }}
+          CHANGED: ${{ steps.diffscope.outputs.changed }}
         with:
           script: |
             const caught   = parseInt(process.env.CAUGHT   || '0', 10);
@@ -182,16 +223,19 @@ jobs:
             const total    = parseInt(process.env.TOTAL    || '0', 10);
             const hasResults = process.env.HAS_RESULTS === 'true';
             const mutantsExit = parseInt(process.env.MUTANTS_EXIT || '1', 10);
+            const changedFiles = parseInt(process.env.CHANGED || '0', 10);
 
             const allPassing = mutantsExit === 0 && missed === 0;
 
-            let body = '## Mutation Testing Results\n\n';
+            let body = '## Mutation Testing Results (diff-scoped, advisory)\n\n';
+            body += `> Scoped to ${changedFiles} changed .rs file(s) in this PR (\`cargo mutants --in-diff\`). `;
+            body += `Full-workspace coverage runs nightly on \`develop\`. See \`docs/mutation_testing_crate_split.md\`.\n\n`;
 
             if (!hasResults) {
               body += 'No mutation results were produced (the run may have failed before analysis).\n\n';
               body += '**Artifact**: `mutation-results` (30-day retention)';
             } else {
-              const emoji = allPassing ? 'PASS' : 'FAIL';
+              const emoji = allPassing ? 'PASS' : 'ADVISORY';
               body += `| Metric | Value |\n`;
               body += `|--------|-------|\n`;
               body += `| Caught (killed) | ${caught} |\n`;
@@ -199,10 +243,10 @@ jobs:
               body += `| Timeout | ${timeout} |\n`;
               body += `| Unviable | ${unviable} |\n`;
               body += `| Mutation score | ${total > 0 ? Math.round((caught / total) * 100) : 0}% |\n`;
-              body += `| Status | ${emoji} |\n\n`;
+              body += `| Status | ${emoji} (non-blocking) |\n\n`;
 
               if (missed > 0) {
-                body += `**${missed} mutant(s) survived testing.** Review the artifact for details.\n\n`;
+                body += `**${missed} mutant(s) survived testing** — review the artifact, but this is **advisory** and will not block the PR.\n\n`;
               } else if (allPassing) {
                 body += 'All mutants were caught. ';
               }
@@ -219,8 +263,6 @@ jobs:
               body: body
             });
 
-      - name: Fail job on missed mutants
-        if: always() && steps.mutants.outputs.mutants_exit != '0'
-        run: |
-          echo "::error::cargo-mutants exited with ${{ steps.mutants.outputs.mutants_exit }} (missed or timed-out mutants detected)"
-          exit 1
+      # NOTE: Intentionally NO "fail on missed mutants" step.
+      # This check is advisory (#1891). The job succeeds regardless of the
+      # mutation score so it can be added as a non-blocking status check.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,7 @@ ML-surrogate swap-point traits:
 - `Fluxion Determinism Gate (Issue #1351)` — listener on Cross-Platform Determinism CI workflow
 - `Fluxion Performance Gate (Issue #1618)` — listener on Performance Dashboard workflow
 - `Architecture Drift Detection` (nightly + on `src/**/*.rs` / `ARCHITECTURE.md` changes) — `scripts/check_architecture_drift.py`
+- `Mutation Testing (advisory)` (Issue #1891) — diff-scoped `cargo mutants --in-diff` PR check; non-blocking. `Mutation Testing (nightly)` runs the full suite against `develop`.
 
 Heavy Linux jobs honour `vars.FLUXION_LINUX_RUNNER` (self-hosted Hetzner fallback; see `docs/self-hosted-runners.md`).
 
@@ -149,7 +150,7 @@ Heavy Linux jobs honour `vars.FLUXION_LINUX_RUNNER` (self-hosted Hetzner fallbac
 ## Toolchain Quirks
 
 - **`rust-toolchain.toml`** pins **stable** + rustfmt + clippy. `.rustfmt.toml` sets `edition = "2021"` — without it rustfmt falls back to 2015 and breaks on `?`/`async`. Stable rustfmt does NOT support `exclude`; auto-generated fixture data must use `#[rustfmt::skip]` per-item (see `tests/per_tilt_per_azimuth_fixture_data.rs`).
-- **Mutation testing (`cargo mutants`)**: requires **32 GB+ RAM**. `.cargo/mutants.toml` excludes combinatorial physics files (`state_space_ctf`, `multi_node_solver`, `ctf_coefficients`, `fd_*`, `ctf_*`, `geometry_tensor`, `cta`, `thermal_mass/**`) and the entire `src/validation/**` tree. Run manually: `cargo mutants --config .cargo/mutants.toml -p fluxion --jobs 2 --baseline skip`.
+- **Mutation testing (`cargo mutants`)**: requires **32 GB+ RAM** for the full suite. `.cargo/mutants.toml` excludes combinatorial physics files (`state_space_ctf`, `multi_node_solver`, `ctf_coefficients`, `fd_*`, `ctf_*`, `geometry_tensor`, `cta`, `thermal_mass/**`) and the entire `src/validation/**` tree. **Dual-pipeline** (Issue #1891): (1) *Diff-scoped advisory PR check* — `mutation-testing.yml` runs `cargo mutants --in-diff` on only the changed lines, completing in minutes on a standard 32 GB runner (non-blocking). (2) *Nightly full suite* — `mutation-nightly.yml` runs the entire workspace against `develop` at 07:00 UTC on a 32 GB runner (self-hosted Hetzner when `vars.FLUXION_LINUX_RUNNER` is set). Run manually: `cargo mutants --config .cargo/mutants.toml -p fluxion --jobs 2 --baseline skip`. See `docs/mutation_testing_crate_split.md` for the Phase 3/4 root-cause fix (gate `ort`/ONNX → <4 GB target).
 - **Feature flags** (default = none): `python-bindings`, `napi-bindings`, `ort` (alias `onnx`), `cuda`, `wiring-tracing`, `multi-zone`, `ashrae_140_v2021`, `pr821-diag`, `loom`, `dwave`. Default builds skip the ONNX runtime — opt in via `--features ort` for AI surrogate / mutation tests.
 - **Crate size**: `Cargo.toml` `exclude` + `.cargoignore` strip `refdata/`, `data/`, `models/`, `assets/`, `tests/`, `docs/`, `target/`, `Cargo.lock`, etc. Published crate must stay under 10 MB.
 - **Two CONTRIBUTING.md files** (root + `docs/CONTRIBUTING.md`) — root is the active short form; `docs/CONTRIBUTING.md` has the long-form guide.
@@ -199,3 +200,6 @@ Heavy Linux jobs honour `vars.FLUXION_LINUX_RUNNER` (self-hosted Hetzner fallbac
 | `scripts/check_architecture_drift.py` | ARCHITECTURE.md vs source-code drift |
 | `scripts/check_ashrae_cases_cycle.py` | `sim ↔ validation` cycle regression guard |
 | `scripts/release_gate_checker.py` | Validates `release_gates.yaml` gates against current results |
+| `scripts/mutants_diff_files.sh` | Extracts changed `.rs` files for diff-scoped mutation testing (`--in-diff`) |
+| `.github/workflows/mutation-testing.yml` | Advisory diff-scoped mutation PR check (Issue #1891) |
+| `.github/workflows/mutation-nightly.yml` | Nightly full-workspace mutation suite against `develop` (Issue #1891) |

--- a/docs/mutation_testing_crate_split.md
+++ b/docs/mutation_testing_crate_split.md
@@ -156,15 +156,51 @@ cargo build -p fluxion-core
 # Mutation testing targets only fluxion (fluxion-core is a cached dep).
 # Always pass --config .cargo/mutants.toml so the canonical config is loaded
 # explicitly (issue #1440 — the root-level mutants.toml has been removed):
-cargo mutants --config .cargo/mutants.toml -p fluxion --list
+
+# Full suite (requires 32 GB+):
 cargo mutants --config .cargo/mutants.toml -p fluxion --baseline skip
+
+# Diff-scoped (mirrors the PR CI check — any machine):
+scripts/mutants_diff_files.sh origin/develop mutants_diff.patch
+cargo mutants --config .cargo/mutants.toml -p fluxion \
+  --baseline skip --in-diff mutants_diff.patch
 ```
 
 ## Summary
 
-| Phase | Status | Effect on cargo-mutants memory |
-|-------|--------|--------------------------------|
-| 1. Workspace + move `weather` to `fluxion-core` | ✅ Done (this PR) | Establishes the seam; `weather` no longer recompiled per mutant |
-| 2. Move shared domain types → `fluxion-core`, then `physics` | ⏳ Planned | Removes physics type hierarchy from per-mutant compile |
-| 3. `SurrogateProvider` trait + gate `ort` | ⏳ Planned | **Removes `ort` from per-mutant compile — reaches < 4 GB target** |
-| 4. Move `validation` | ⏳ Planned | Completeness |
+| 1. Workspace + move `weather` to `fluxion-core` | ✅ Done (#1255) | Establishes the seam; `weather` no longer recompiled per mutant |
+| 2. Move shared domain types → `fluxion-core`, then `physics` | ✅ Done (#1349) | Removes physics type hierarchy from per-mutant compile |
+| 3. `SurrogateProvider` trait + gate `ort` | ⏳ Tracked epic | **Removes `ort` from per-mutant compile — reaches < 4 GB target** |
+| 4. Move `validation` | ⏳ Tracked epic | Completeness |
+
+## Dual-Pipeline CI Strategy (#1891)
+
+While Phases 3 & 4 remain as medium-term architectural fixes, Issue #1891
+researched and selected a hybrid strategy to restore CI mutation coverage
+**immediately** without the large refactor effort:
+
+### Pipeline 1 — Diff-Scoped Advisory PR Check (`mutation-testing.yml`)
+
+Runs on every PR that touches `src/**`. Uses `cargo mutants --in-diff` to
+generate mutants **only in the changed lines** of the PR diff (produced by
+`scripts/mutants_diff_files.sh`). Because only a handful of mutants are
+generated per PR, the run completes in minutes on a standard 32 GB runner
+(`ubuntu-latest-8-cores`).
+
+**Advisory** (non-blocking): the job never fails on missed mutants. Results are
+posted as a PR comment and uploaded as an artifact. The advisory status will be
+revisited once flake rate is characterised (see Issue #1891, Section 6).
+
+### Pipeline 2 — Nightly Full Suite (`mutation-nightly.yml`)
+
+Runs the entire mutation suite (this config, no `--in-diff`) against `develop`
+at 07:00 UTC on a 32 GB runner. Catches indirect mutations that diff-scoping
+misses (e.g. a trait change rippling into an untouched solver). Prefers
+self-hosted Hetzner runners when `vars.FLUXION_LINUX_RUNNER` is set.
+
+### Why both
+
+Diff-scoping is fast and cheap but can miss indirect mutations. The nightly full
+run closes that gap at the cost of delayed feedback (overnight). Phase 3 (gate
+`ort`) remains the durable root-cause fix: once per-mutant memory drops below
+4 GB, the full suite can run on cheaper runners and eventually on PRs too.

--- a/scripts/mutants_diff_files.sh
+++ b/scripts/mutants_diff_files.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# scripts/mutants_diff_files.sh
+#
+# Generate a unified diff of changed Rust source files for scoped mutation
+# testing (Issue #1891, Solution B). The output is consumed by:
+#
+#   cargo mutants --in-diff <diff-file>
+#
+# `--in-diff` restricts mutation generation to only the *lines* touched by the
+# diff, which is far more precise than `--file` (which would mutate every
+# function in a changed file).
+#
+# Usage:
+#   scripts/mutants_diff_files.sh [BASE_REF] [OUTPUT_FILE]
+#
+# Arguments:
+#   BASE_REF     — git ref to diff against (default: origin/develop)
+#   OUTPUT_FILE  — where to write the unified diff (default: mutants_diff.patch)
+#
+# Environment:
+#   In GitHub Actions the checkout action must use fetch-depth: 0 (or at least
+#   enough history to resolve the base ref) so the diff is available locally.
+#
+# Exit codes:
+#   0 — diff written to OUTPUT_FILE (may be empty if no .rs files changed)
+#   1 — git command failure
+#
+# Prints to stdout: the number of changed .rs files (for the workflow to decide
+# whether to skip the mutation job entirely).
+
+set -euo pipefail
+
+BASE_REF="${1:-origin/develop}"
+OUTPUT_FILE="${2:-mutants_diff.patch}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_ROOT"
+
+# Ensure the base ref is resolvable. On a shallow CI checkout the remote ref
+# may not be present; try to fetch it (best-effort — swallow errors).
+if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
+    BASE_BRANCH="${BASE_REF#origin/}"
+    echo "info: base ref '$BASE_REF' not found locally; attempting fetch of '$BASE_BRANCH'…" >&2
+    git fetch origin "$BASE_BRANCH" --depth=200 2>/dev/null || true
+fi
+
+# Fall back to merge-base comparison so only PR-introduced changes are captured
+# (not commits already merged into the base since the branch point).
+if git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
+    MERGE_BASE="$(git merge-base "$BASE_REF" HEAD 2>/dev/null || echo "$BASE_REF")"
+    DIFF_RANGE="${MERGE_BASE}...HEAD"
+else
+    # Last resort: diff against HEAD~1 (single-commit fallback).
+    echo "warn: could not resolve '$BASE_REF'; falling back to HEAD~1" >&2
+    DIFF_RANGE="HEAD~1"
+fi
+
+# Collect the diff for .rs files under src/ (the main crate). We explicitly
+# filter to Rust source so non-code changes (docs, configs) don't trigger a
+# mutation run that has nothing to mutate.
+git diff "$DIFF_RANGE" --diff-filter=d -- 'src/*.rs' 'src/**/*.rs' > "$OUTPUT_FILE" || true
+
+# Count the number of changed .rs files.
+# grep -c always prints a count; on zero matches it exits 1, so we capture
+# stdout and strip any trailing newline instead of relying on exit codes.
+CHANGED_FILES=$(git diff "$DIFF_RANGE" --diff-filter=d --name-only -- 'src/*.rs' 'src/**/*.rs' \
+    | wc -l | tr -d ' ')
+
+echo "$CHANGED_FILES"
+
+if [[ "$CHANGED_FILES" -eq 0 ]]; then
+    echo "info: no Rust source files changed under src/; diff is empty." >&2
+fi


### PR DESCRIPTION
Closes #1891

Implements the recommended hybrid strategy (Solution B + Solution C from the issue's Section 5) to restore mutation testing CI coverage, which was previously zero because the full-workspace suite OOMs even on 32 GB runners.

**Pipeline 1 — Diff-scoped advisory PR check** (`mutation-testing.yml`): Runs `cargo mutants --in-diff` on only the changed lines of each PR (diff generated by the new `scripts/mutants_diff_files.sh`). Because only a handful of mutants are generated per PR, the run completes in minutes on a standard runner. The check is advisory (non-blocking) — results are posted as a PR comment and uploaded as an artifact.

**Pipeline 2 — Nightly full suite** (`mutation-nightly.yml`): Runs the entire mutation suite (no `--in-diff`) against `develop` at 07:00 UTC on a 32 GB runner, catching indirect mutations that diff-scoping misses. Prefers self-hosted Hetzner runners when `vars.FLUXION_LINUX_RUNNER` is set.

Documentation updates: `AGENTS.md` (CI Gates + Toolchain Quirks sections), `.cargo/mutants.toml` header, and `docs/mutation_testing_crate_split.md` (Phase 2 marked done, Phase 3/4 marked as tracked epics, new dual-pipeline section added). Phase 3 (SurrogateProvider trait + gate `ort`/ONNX) remains the durable root-cause fix tracked separately.