### PR TITLE
feat(ml): resolve #1776 — Configure Monte Carlo parameter sweeps for Phase 2 data generation

### DIFF
--- a/src/ai/sweeps/config.rs
+++ b/src/ai/sweeps/config.rs
@@ -24,12 +24,14 @@ use crate::ai::surrogate::SurrogateDomain;
 use crate::ai::sweeps::distributions::Choice;
 use crate::ai::sweeps::distributions::ParameterDistribution;
 use crate::ai::sweeps::sampling::SamplingStrategy;
+use crate::ai::sweeps::weather::WeatherFileRegistry;
+use serde::{Deserialize, Serialize};
 
 /// Building-geometry parameter distributions.
 ///
 /// These describe the physical shape of the zone being simulated.  All
 /// values use standard SI units.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BuildingGeometryParams {
     /// Conditioned floor area [m²].
     pub floor_area: ParameterDistribution,
@@ -57,7 +59,7 @@ impl Default for BuildingGeometryParams {
 /// These describe the thermal resistance and mass of the building envelope,
 /// enabling sweeps over insulation levels from minimally-code-compliant to
 /// super-insulated.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct InsulationParams {
     /// Overall wall U-value [W/m²K] (lower = better insulated).
     pub wall_u_value: ParameterDistribution,
@@ -87,7 +89,7 @@ impl Default for InsulationParams {
 /// The continuous distributions (temp, solar, humidity, wind) inherit
 /// their bounds from [`SurrogateDomain`].  Climate zones and building
 /// types are discrete and sampled from the domain's lists.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct WeatherSamplingParams {
     /// Exterior dry-bulb temperature [°C].
     pub exterior_temp: ParameterDistribution,
@@ -104,7 +106,7 @@ pub struct WeatherSamplingParams {
 }
 
 /// Occupancy and internal-gain distributions.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct OccupancyParams {
     /// Occupant density [fraction, 0–1].
     pub occupancy: ParameterDistribution,
@@ -127,7 +129,7 @@ impl Default for OccupancyParams {
 /// Master configuration for a Monte Carlo parameter sweep.
 ///
 /// Construct via [`SweepConfig::from_domain`] or [`SweepConfig::builder`].
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SweepConfig {
     /// Building geometry distributions.
     pub geometry: BuildingGeometryParams,
@@ -143,6 +145,10 @@ pub struct SweepConfig {
     pub num_samples: usize,
     /// Random seed for reproducibility.
     pub seed: u64,
+    /// Registry mapping climate-zone labels to representative weather files
+    /// (multi-climate coverage, per Issue #1776 AC1).
+    #[serde(default = "WeatherFileRegistry::standard")]
+    pub weather_registry: WeatherFileRegistry,
 }
 
 /// Number of continuous dimensions swept by a [`SweepConfig`].
@@ -196,6 +202,7 @@ impl SweepConfig {
             strategy: SamplingStrategy::LatinHypercube,
             num_samples: 1000,
             seed: 42,
+            weather_registry: WeatherFileRegistry::standard(),
         }
     }
 
@@ -300,6 +307,7 @@ pub struct SweepConfigBuilder {
     strategy: Option<SamplingStrategy>,
     num_samples: Option<usize>,
     seed: Option<u64>,
+    weather_registry: Option<WeatherFileRegistry>,
 }
 
 impl SweepConfigBuilder {
@@ -338,6 +346,12 @@ impl SweepConfigBuilder {
         self
     }
 
+    /// Override the default standard weather-file registry.
+    pub fn weather_registry(mut self, registry: WeatherFileRegistry) -> Self {
+        self.weather_registry = Some(registry);
+        self
+    }
+
     /// Build the config, filling in defaults from `SurrogateDomain::default_residential()`.
     pub fn build(self) -> SweepConfig {
         let domain = SurrogateDomain::default_residential();
@@ -350,6 +364,7 @@ impl SweepConfigBuilder {
             strategy: self.strategy.unwrap_or(base.strategy),
             num_samples: self.num_samples.unwrap_or(base.num_samples),
             seed: self.seed.unwrap_or(base.seed),
+            weather_registry: self.weather_registry.unwrap_or(base.weather_registry),
         }
     }
 }
@@ -430,5 +445,49 @@ mod tests {
         //   occupancy: occupancy, zone_temp, internal_gain_density = 3
         // Total = 4 + 4 + 4 + 3 = 15
         assert_eq!(NUM_CONTINUOUS_DIMENSIONS, 15);
+    }
+
+    #[test]
+    fn test_from_domain_includes_standard_weather_registry() {
+        // Issue #1776 AC1: from_domain must ship with the standard weather
+        // registry so climate zones resolve to weather files.
+        let domain = SurrogateDomain::default_residential();
+        let config = SweepConfig::from_domain(&domain);
+        for z in &["4A", "5A", "6A"] {
+            assert!(
+                config.weather_registry.lookup(z).is_some(),
+                "standard registry missing {z}"
+            );
+        }
+        assert!(!config.weather_registry.is_empty());
+    }
+
+    #[test]
+    fn test_builder_custom_weather_registry() {
+        use crate::ai::sweeps::weather::{WeatherFileEntry, WeatherFileRegistry};
+        let custom = WeatherFileRegistry::with_entries([WeatherFileEntry::new(
+            "9Z",
+            "Custom City",
+            1.0,
+            2.0,
+            "custom.epw",
+        )]);
+        let config = SweepConfig::builder()
+            .weather_registry(custom)
+            .num_samples(10)
+            .build();
+        assert!(config.weather_registry.lookup("9Z").is_some());
+        assert!(config.weather_registry.lookup("4A").is_none());
+    }
+
+    #[test]
+    fn test_config_serde_roundtrip() {
+        let domain = SurrogateDomain::default_residential();
+        let config = SweepConfig::from_domain(&domain);
+        let json = serde_json::to_string(&config).expect("serialize");
+        let restored: SweepConfig = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(restored.seed, config.seed);
+        assert_eq!(restored.num_samples, config.num_samples);
+        assert!(restored.validate().is_ok());
     }
 }

--- a/src/ai/sweeps/distributions.rs
+++ b/src/ai/sweeps/distributions.rs
@@ -22,12 +22,13 @@ use rand::Rng;
 use rand_distr::LogNormal as LogNormalDist;
 use rand_distr::Normal as NormalDist;
 use rand_distr::NormalError;
+use serde::{Deserialize, Serialize};
 
 /// Statistical distribution for a continuous parameter.
 ///
 /// Used by [`crate::ai::sweeps::config::SweepConfig`] to describe the range
 /// and shape of every swept building/environmental parameter.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ParameterDistribution {
     /// Uniform distribution over `[min, max)`.
     Uniform { min: f64, max: f64 },
@@ -146,7 +147,7 @@ impl ParameterDistribution {
 
 /// Discrete distribution for categorical parameters (e.g. climate zone labels,
 /// building types).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Choice {
     /// The possible values, each sampled with equal probability.
     pub values: Vec<String>,

--- a/src/ai/sweeps/manifest.rs
+++ b/src/ai/sweeps/manifest.rs
@@ -16,13 +16,14 @@ use crate::ai::sweeps::distributions::ParameterDistribution;
 use crate::ai::sweeps::sampling::generate_unit_samples;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
+use serde::{Deserialize, Serialize};
 
 /// A single realised parameter set from a sweep.
 ///
 /// Each field corresponds to a physical quantity.  The struct can be
 /// converted into [`SurrogateInputs`] (for the weather/occupancy portion)
 /// and into a wall-insulation specification (for the envelope portion).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SweepSample {
     // --- Building geometry ---
     /// Conditioned floor area [m²].
@@ -55,6 +56,11 @@ pub struct SweepSample {
     pub wind_speed: f64,
     /// Climate zone label (e.g. "4A").
     pub climate_zone: String,
+    /// Representative weather (EPW) file resolved for `climate_zone` via the
+    /// sweep's [`WeatherFileRegistry`](super::weather::WeatherFileRegistry).
+    /// Empty when the zone was not in the registry.
+    #[serde(default)]
+    pub weather_file: String,
 
     // --- Occupancy / internal gains ---
     /// Occupant density [fraction, 0–1].
@@ -103,8 +109,9 @@ impl SweepSample {
 /// Reproducible manifest for a completed sweep run.
 ///
 /// Contains all information needed to re-generate the exact same set of
-/// [`SweepSample`]s.
-#[derive(Clone, Debug)]
+/// [`SweepSample`]s.  The manifest is serializable (serde) so it can be
+/// **emitted** to JSON alongside the generated dataset (Issue #1776 AC3).
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ParameterManifest {
     /// Random seed used by the sampling strategy.
     pub seed: u64,
@@ -114,22 +121,21 @@ pub struct ParameterManifest {
     pub num_samples: usize,
     /// Number of continuous dimensions.
     pub num_dimensions: usize,
-    /// ISO-8601-ish timestamp of when the manifest was created.
+    /// ISO-8601 timestamp of when the manifest was created.
     pub created_at: String,
     /// Short description of the sweep (human-readable).
     pub description: String,
+    /// Snapshot of the full [`SweepConfig`] used, so the run is exactly
+    /// reproducible from the manifest alone (distribution bounds, weather
+    /// registry, occupancy params, etc.).
+    #[serde(default)]
+    pub config: Option<SweepConfig>,
 }
 
 impl ParameterManifest {
+    /// Current UTC time as a real ISO-8601 string (RFC 3339).
     fn now_iso8601() -> String {
-        let secs = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
-        let days = secs / 86400;
-        let year = 1970 + (days / 365);
-        let day_of_year = days % 365;
-        format!("{year}-{:03}T{}Z", day_of_year, secs % 86400)
+        chrono::Utc::now().to_rfc3339()
     }
 
     /// Create a manifest from a config.
@@ -146,12 +152,27 @@ impl ParameterManifest {
                 config.strategy.name(),
                 config.seed
             ),
+            config: Some(config.clone()),
         }
+    }
+
+    /// Serialize the manifest to a pretty-printed JSON string.
+    ///
+    /// This is how the manifest is "emitted" for reproducibility — the JSON
+    /// can be written to disk alongside the generated dataset and later
+    /// deserialized to regenerate the exact same samples.
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string_pretty(self)
+    }
+
+    /// Deserialize a manifest from a JSON string.
+    pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(json)
     }
 }
 
 /// Result of a sweep generation: the samples + a reproducible manifest.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SweepResult {
     /// Generated parameter samples.
     pub samples: Vec<SweepSample>,
@@ -176,6 +197,11 @@ impl SweepResult {
             .iter()
             .map(|s| s.to_surrogate_inputs())
             .collect()
+    }
+
+    /// Serialize the manifest (not the samples) to pretty JSON for emission.
+    pub fn manifest_to_json(&self) -> Result<String, serde_json::Error> {
+        self.manifest.to_json()
     }
 }
 
@@ -252,6 +278,15 @@ pub fn generate_samples(config: &SweepConfig) -> SweepResult {
             .sample(&mut discrete_rng)
             .to_string();
 
+        // Resolve the representative weather file for this climate zone
+        // (Issue #1776 AC1: "weather files (multi-climate)").
+        let weather_file = config
+            .weather_registry
+            .lookup(&climate_zone)
+            .or_else(|| config.weather_registry.lookup_or_default(&climate_zone))
+            .map(|e| e.epw_filename.clone())
+            .unwrap_or_default();
+
         let humidity = vals[10].clamp(0.0, 100.0);
         let window_to_wall_ratio = vals[2].clamp(0.0, 1.0);
         let occupancy = vals[12].clamp(0.0, 1.0);
@@ -270,6 +305,7 @@ pub fn generate_samples(config: &SweepConfig) -> SweepResult {
             humidity,
             wind_speed: vals[11],
             climate_zone,
+            weather_file,
             occupancy,
             zone_temp: vals[13],
             internal_gain_density: vals[14],
@@ -534,5 +570,205 @@ mod tests {
         for s in &result.samples {
             assert!(s.envelope_area() > 0.0);
         }
+    }
+
+    // ---- Issue #1776 AC1: weather files (multi-climate) ----
+
+    #[test]
+    fn test_samples_resolve_weather_file() {
+        // Every sample's climate zone must resolve to a representative EPW
+        // weather file via the standard registry.
+        let domain = SurrogateDomain::default_residential();
+        let config = SweepConfig::from_domain(&domain);
+        let result = generate_samples(&config);
+
+        for s in &result.samples {
+            assert!(
+                !s.weather_file.is_empty(),
+                "climate zone {} has no weather file",
+                s.climate_zone
+            );
+            assert!(
+                s.weather_file.ends_with(".epw"),
+                "bad weather filename: {}",
+                s.weather_file
+            );
+        }
+    }
+
+    #[test]
+    fn test_weather_file_matches_climate_zone() {
+        // The weather file must be consistent with the climate zone label.
+        let domain = SurrogateDomain::default_residential();
+        let config = SweepConfig::from_domain(&domain);
+        let result = generate_samples(&config);
+
+        let reg = crate::ai::sweeps::weather::WeatherFileRegistry::standard();
+        for s in &result.samples {
+            let entry = reg.lookup(&s.climate_zone).expect("zone in registry");
+            assert_eq!(s.weather_file, entry.epw_filename);
+        }
+    }
+
+    #[test]
+    fn test_multi_climate_coverage() {
+        // With a broad climate-zone set, the sweep must sample multiple
+        // distinct weather files (multi-climate coverage, AC1).
+        let mut domain = SurrogateDomain::default_residential();
+        domain.climate_zones = vec![
+            "1A".into(),
+            "3A".into(),
+            "4A".into(),
+            "5A".into(),
+            "6A".into(),
+            "7".into(),
+        ];
+        let mut config = SweepConfig::from_domain(&domain);
+        config.num_samples = 500;
+        let result = generate_samples(&config);
+
+        let distinct_files: std::collections::HashSet<_> = result
+            .samples
+            .iter()
+            .map(|s| s.weather_file.as_str())
+            .collect();
+        // At least 4 distinct weather files should appear in 500 samples.
+        assert!(
+            distinct_files.len() >= 4,
+            "expected multi-climate coverage, got {} distinct weather files",
+            distinct_files.len()
+        );
+    }
+
+    #[test]
+    fn test_weather_file_empty_for_unknown_zone_without_fallback() {
+        // A climate zone absent from the registry and with no other entries
+        // resolves to an empty weather-file string.
+        let mut domain = SurrogateDomain::default_residential();
+        domain.climate_zones = vec!["ZZ_UNKNOWN".into()];
+        let mut config = SweepConfig::from_domain(&domain);
+        config.weather_registry = crate::ai::sweeps::weather::WeatherFileRegistry::new(); // empty
+        config.num_samples = 10;
+        let result = generate_samples(&config);
+        for s in &result.samples {
+            assert!(s.weather_file.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_weather_registry_fallback_for_unknown_zone() {
+        // When the sampled zone is unknown but the registry has entries,
+        // lookup_or_default resolves deterministically.
+        let mut domain = SurrogateDomain::default_residential();
+        domain.climate_zones = vec!["ZZ_UNKNOWN".into()];
+        let mut config = SweepConfig::from_domain(&domain);
+        config.num_samples = 5;
+        let result = generate_samples(&config);
+        // Every sample gets the deterministic fallback weather file.
+        let first = result.samples[0].weather_file.clone();
+        assert!(!first.is_empty());
+        for s in &result.samples {
+            assert_eq!(s.weather_file, first);
+        }
+    }
+
+    // ---- Issue #1776 AC3: reproducible (seeded) manifest emitted ----
+
+    #[test]
+    fn test_manifest_to_json_roundtrip() {
+        let domain = SurrogateDomain::default_residential();
+        let config = SweepConfig::from_domain(&domain);
+        let result = generate_samples(&config);
+
+        let json = result.manifest_to_json().expect("serialize");
+        assert!(!json.is_empty());
+        assert!(json.contains("\"seed\": 42"));
+        assert!(json.contains("\"strategy\": \"latin_hypercube\""));
+
+        // Round-trip: deserialize and verify key fields.
+        let restored = ParameterManifest::from_json(&json).expect("deserialize");
+        assert_eq!(restored.seed, result.manifest.seed);
+        assert_eq!(restored.strategy, result.manifest.strategy);
+        assert_eq!(restored.num_samples, result.manifest.num_samples);
+    }
+
+    #[test]
+    fn test_manifest_timestamp_is_iso8601() {
+        // created_at must be a real RFC 3339 timestamp, parseable by chrono.
+        let domain = SurrogateDomain::default_residential();
+        let config = SweepConfig::from_domain(&domain);
+        let manifest = ParameterManifest::from_config(&config);
+        chrono::DateTime::parse_from_rfc3339(&manifest.created_at)
+            .expect("created_at must be valid RFC 3339");
+    }
+
+    #[test]
+    fn test_manifest_captures_full_config() {
+        // The manifest must embed the full config so the run is exactly
+        // reproducible from the manifest alone.
+        let mut domain = SurrogateDomain::default_residential();
+        domain.temp_bounds = (-25.0, 45.0);
+        let config = SweepConfig::from_domain(&domain);
+        let manifest = ParameterManifest::from_config(&config);
+
+        let cfg = manifest.config.expect("config snapshot present");
+        match &cfg.weather.exterior_temp {
+            ParameterDistribution::Uniform { min, max } => {
+                assert_eq!(*min, -25.0);
+                assert_eq!(*max, 45.0);
+            }
+            _ => panic!("expected uniform"),
+        }
+        assert_eq!(cfg.seed, config.seed);
+        assert_eq!(cfg.num_samples, config.num_samples);
+    }
+
+    #[test]
+    fn test_manifest_reproducibility_via_json() {
+        // Regenerating samples from a config reconstructed via the emitted
+        // manifest must produce identical samples (true reproducibility).
+        let domain = SurrogateDomain::default_residential();
+        let config = SweepConfig::from_domain(&domain);
+        let result1 = generate_samples(&config);
+
+        let json = result1.manifest_to_json().unwrap();
+        let restored_manifest = ParameterManifest::from_json(&json).unwrap();
+        let restored_config = restored_manifest.config.unwrap();
+
+        let result2 = generate_samples(&restored_config);
+        assert_eq!(result1.len(), result2.len());
+        for (a, b) in result1.samples.iter().zip(result2.samples.iter()) {
+            assert!((a.floor_area - b.floor_area).abs() < 1e-10);
+            assert_eq!(a.climate_zone, b.climate_zone);
+            assert_eq!(a.weather_file, b.weather_file);
+        }
+    }
+
+    #[test]
+    fn test_sweep_result_serializable() {
+        let domain = SurrogateDomain::default_residential();
+        let mut config = SweepConfig::from_domain(&domain);
+        config.num_samples = 5;
+        let result = generate_samples(&config);
+
+        let json = serde_json::to_string(&result).expect("serialize result");
+        let restored: SweepResult = serde_json::from_str(&json).expect("deserialize result");
+        assert_eq!(restored.len(), 5);
+        assert_eq!(restored.samples[0].floor_area, result.samples[0].floor_area);
+    }
+
+    #[test]
+    fn test_sweep_config_json_roundtrip() {
+        // SweepConfig itself must round-trip through JSON so the registry
+        // and all distributions are preserved.
+        let domain = SurrogateDomain::default_residential();
+        let config = SweepConfig::from_domain(&domain);
+        let json = serde_json::to_string_pretty(&config).unwrap();
+        let restored: SweepConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.seed, config.seed);
+        assert_eq!(restored.num_samples, config.num_samples);
+        assert_eq!(restored.strategy, config.strategy);
+        // Registry preserved
+        assert!(restored.weather_registry.lookup("4A").is_some());
     }
 }

--- a/src/ai/sweeps/mod.rs
+++ b/src/ai/sweeps/mod.rs
@@ -38,11 +38,13 @@ pub mod config;
 pub mod distributions;
 pub mod manifest;
 pub mod sampling;
+pub mod weather;
 
 pub use config::{
-    BuildingGeometryParams, InsulationParams, OccupancyParams, SweepConfig, SweepConfigBuilder,
+    BuildingGeometryParams, InsulationParams, SweepConfig, SweepConfigBuilder,
     WeatherSamplingParams, NUM_CONTINUOUS_DIMENSIONS,
 };
 pub use distributions::{Choice, ParameterDistribution};
 pub use manifest::{generate_samples, ParameterManifest, SweepResult, SweepSample};
 pub use sampling::{generate_unit_samples, SamplingStrategy};
+pub use weather::{WeatherFileEntry, WeatherFileRegistry};

--- a/src/ai/sweeps/sampling.rs
+++ b/src/ai/sweeps/sampling.rs
@@ -21,9 +21,10 @@ use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
 use rand::Rng;
 use rand::SeedableRng;
+use serde::{Deserialize, Serialize};
 
 /// Sampling strategy enum.
-#[derive(Clone, Debug, Copy, PartialEq, Eq)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SamplingStrategy {
     /// Independent random Monte Carlo draws.
     RandomMonteCarlo,

--- a/src/ai/sweeps/weather.rs
+++ b/src/ai/sweeps/weather.rs
@@ -1,0 +1,394 @@
+//! Weather-file registry for multi-climate Monte Carlo sweeps (Issue #1776).
+//!
+//! The acceptance criteria require sampling distributions and ranges for
+//! "weather files (multi-climate)".  [`WeatherFileRegistry`] maps ASHRAE
+//! climate-zone labels (e.g. `"4A"`, `"5B"`) to representative EnergyPlus
+//! TMY3 EPW reference files, so that every [`super::manifest::SweepSample`]
+//! can be resolved to a concrete weather-file path that the physics solver
+//! can load.
+//!
+//! # Climate-zone coverage
+//!
+//! The registry ships with the canonical ASHRAE 169 climate-zone set
+//! (zones 1–8, moisture designations A/B/C) using well-known EnergyPlus
+//! reference cities.  This guarantees full multi-climate coverage from
+//! very-hot/moist (1A: Miami) through subarctic (8: Fairbanks).
+//!
+//! ```text
+//!  SurrogateDomain.climate_zones ──► WeatherFileRegistry.lookup(zone)
+//!                                           │
+//!                                           ▼
+//!                                   WeatherFileEntry
+//!                                   { location, lat, lon, epw_filename }
+//! ```
+//!
+//! The registry can also be extended or overridden at runtime via
+//! [`WeatherFileRegistry::with_entries`] so that bespoke weather libraries
+//! (e.g. a project-specific EPW set) can be plugged in.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// A representative weather file for a climate zone.
+///
+/// Contains enough metadata to resolve and load the EPW/TMY3 file and to
+/// record provenance in the parameter manifest.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct WeatherFileEntry {
+    /// ASHRAE climate-zone label (e.g. `"4A"`).
+    pub climate_zone: String,
+    /// Human-readable location name (e.g. `"Baltimore, MD"`).
+    pub location_name: String,
+    /// Latitude [degrees, −90..90].
+    pub latitude: f64,
+    /// Longitude [degrees, −180..180].
+    pub longitude: f64,
+    /// EPW filename (no directory) for the EnergyPlus TMY3 reference file.
+    pub epw_filename: String,
+}
+
+impl WeatherFileEntry {
+    /// Construct a registry entry.
+    pub fn new(
+        climate_zone: impl Into<String>,
+        location_name: impl Into<String>,
+        latitude: f64,
+        longitude: f64,
+        epw_filename: impl Into<String>,
+    ) -> Self {
+        WeatherFileEntry {
+            climate_zone: climate_zone.into(),
+            location_name: location_name.into(),
+            latitude,
+            longitude,
+            epw_filename: epw_filename.into(),
+        }
+    }
+}
+
+/// Registry mapping climate-zone labels to representative weather files.
+///
+/// Construct with [`WeatherFileRegistry::standard`] for the built-in ASHRAE
+/// 169 reference set, or [`WeatherFileRegistry::with_entries`] for a custom
+/// weather library.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct WeatherFileRegistry {
+    entries: HashMap<String, WeatherFileEntry>,
+}
+
+impl WeatherFileRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        WeatherFileRegistry {
+            entries: HashMap::new(),
+        }
+    }
+
+    /// The standard ASHRAE 169 climate-zone reference registry.
+    ///
+    /// Covers zones 1–8 with moisture designations A/B/C, using canonical
+    /// EnergyPlus TMY3 reference cities.  This is the default registry used
+    /// by [`super::config::SweepConfig::from_domain`].
+    pub fn standard() -> Self {
+        let entries: Vec<WeatherFileEntry> = standard_weather_entries();
+        let mut map = HashMap::with_capacity(entries.len());
+        for e in entries {
+            map.insert(e.climate_zone.clone(), e);
+        }
+        WeatherFileRegistry { entries: map }
+    }
+
+    /// Build a registry from an explicit list of entries.
+    ///
+    /// Later entries for the same climate zone win.  Useful for overriding
+    /// the standard set or adding project-specific weather files.
+    pub fn with_entries(entries: impl IntoIterator<Item = WeatherFileEntry>) -> Self {
+        let mut map = HashMap::new();
+        for e in entries {
+            map.insert(e.climate_zone.clone(), e);
+        }
+        WeatherFileRegistry { entries: map }
+    }
+
+    /// Look up the representative weather file for a climate zone.
+    pub fn lookup(&self, climate_zone: &str) -> Option<&WeatherFileEntry> {
+        self.entries.get(climate_zone)
+    }
+
+    /// Insert or replace an entry.
+    pub fn insert(&mut self, entry: WeatherFileEntry) {
+        self.entries.insert(entry.climate_zone.clone(), entry);
+    }
+
+    /// All climate-zone labels known to this registry, sorted.
+    pub fn zones(&self) -> Vec<String> {
+        let mut z: Vec<String> = self.entries.keys().cloned().collect();
+        z.sort();
+        z
+    }
+
+    /// Number of registered climate zones.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the registry is empty.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Resolve a weather file, falling back to a default entry for unknown
+    /// zones so that sweep generation never stalls on an unmapped zone.
+    ///
+    /// Returns the matched entry, or `None` if the registry is empty.
+    pub fn lookup_or_default(&self, climate_zone: &str) -> Option<&WeatherFileEntry> {
+        self.lookup(climate_zone).or_else(|| {
+            // Fallback: pick the alphabetically-first zone so the choice is
+            // deterministic across runs.
+            self.entries.values().min_by_key(|e| &e.climate_zone)
+        })
+    }
+}
+
+/// Canonical ASHRAE 169 climate-zone → EnergyPlus reference-city mapping.
+///
+/// These are the standard TMY3 reference cities used across BEM tools.
+/// Latitudes/longitudes are the airport coordinates of the EPW station.
+fn standard_weather_entries() -> Vec<WeatherFileEntry> {
+    use WeatherFileEntry as W;
+    vec![
+        W::new(
+            "1A",
+            "Miami, FL",
+            25.79,
+            -80.32,
+            "USA_FL_Miami.Intl.AP.722020_TMY3.epw",
+        ),
+        W::new(
+            "2A",
+            "Houston, TX",
+            29.98,
+            -95.36,
+            "USA_TX_Houston.Intercontinental.AP.722430_TMY3.epw",
+        ),
+        W::new(
+            "3A",
+            "Atlanta, GA",
+            33.64,
+            -84.44,
+            "USA_GA_Atlanta-Hartsfield.Jackson.Intl.AP.722190_TMY3.epw",
+        ),
+        W::new(
+            "3B",
+            "Las Vegas, NV",
+            36.08,
+            -115.16,
+            "USA_NV_Las.Vegas-McCarran.Intl.AP.723860_TMY3.epw",
+        ),
+        W::new(
+            "3C",
+            "San Francisco, CA",
+            37.62,
+            -122.38,
+            "USA_CA_San.Francisco.Intl.AP.724940_TMY3.epw",
+        ),
+        W::new(
+            "4A",
+            "Baltimore, MD",
+            39.18,
+            -76.67,
+            "USA_MD_Baltimore-Washington.Intl.AP.724060_TMY3.epw",
+        ),
+        W::new(
+            "4B",
+            "Albuquerque, NM",
+            35.04,
+            -106.61,
+            "USA_NM_Albuquerque.Intl.AP.723650_TMY3.epw",
+        ),
+        W::new(
+            "4C",
+            "Seattle, WA",
+            47.45,
+            -122.30,
+            "USA_WA_Seattle-Tacoma.Intl.AP.727930_TMY3.epw",
+        ),
+        W::new(
+            "5A",
+            "Boston, MA",
+            42.36,
+            -71.06,
+            "USA_MA_Boston-Logan.Intl.AP.725045_TMY3.epw",
+        ),
+        W::new(
+            "5B",
+            "Denver, CO",
+            39.83,
+            -104.65,
+            "USA_CO_Denver.Intl.AP.725650_TMY3.epw",
+        ),
+        W::new(
+            "5C",
+            "Portland, OR",
+            45.59,
+            -122.60,
+            "USA_OR_Portland.Intl.AP.726980_TMY3.epw",
+        ),
+        W::new(
+            "6A",
+            "Minneapolis, MN",
+            44.88,
+            -93.23,
+            "USA_MN_Minneapolis-St.Paul.Intl.AP.726580_TMY3.epw",
+        ),
+        W::new(
+            "6B",
+            "Helena, MT",
+            46.61,
+            -112.01,
+            "USA_MT_Helena.Rgnl.AP.727725_TMY3.epw",
+        ),
+        W::new(
+            "7",
+            "Duluth, MN",
+            46.84,
+            -92.19,
+            "USA_MN_Duluth.Intl.AP.727450_TMY3.epw",
+        ),
+        W::new(
+            "8",
+            "Fairbanks, AK",
+            64.80,
+            -147.88,
+            "USA_AK_Fairbanks.Intl.AP.702610_TMY3.epw",
+        ),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_standard_registry_covers_default_domain_zones() {
+        let reg = WeatherFileRegistry::standard();
+        // SurrogateDomain::default_residential uses 4A, 5A, 6A.
+        for z in ["4A", "5A", "6A"] {
+            assert!(reg.lookup(z).is_some(), "standard registry missing {z}");
+        }
+    }
+
+    #[test]
+    fn test_standard_registry_multi_climate() {
+        let reg = WeatherFileRegistry::standard();
+        // Multi-climate coverage: hot (1A/2A), temperate (3A/4A), cold (5A/6A),
+        // subarctic (7/8).  At least one zone from each band must be present.
+        let zones = reg.zones();
+        assert!(zones
+            .iter()
+            .any(|z| z.starts_with('1') || z.starts_with('2')));
+        assert!(zones
+            .iter()
+            .any(|z| z.starts_with('3') || z.starts_with('4')));
+        assert!(zones
+            .iter()
+            .any(|z| z.starts_with('5') || z.starts_with('6')));
+        assert!(zones
+            .iter()
+            .any(|z| z.starts_with('7') || z.starts_with('8')));
+        assert!(reg.len() >= 10);
+    }
+
+    #[test]
+    fn test_lookup_returns_entry() {
+        let reg = WeatherFileRegistry::standard();
+        let e = reg.lookup("5A").unwrap();
+        assert_eq!(e.climate_zone, "5A");
+        assert!(e.location_name.contains("Boston"));
+        assert!(e.epw_filename.ends_with(".epw"));
+        assert!(e.epw_filename.contains("Boston"));
+    }
+
+    #[test]
+    fn test_lookup_unknown_zone() {
+        let reg = WeatherFileRegistry::standard();
+        assert!(reg.lookup("99Z").is_none());
+    }
+
+    #[test]
+    fn test_lookup_or_default_never_panics() {
+        let reg = WeatherFileRegistry::standard();
+        let e = reg.lookup_or_default("99Z").unwrap();
+        assert!(!e.climate_zone.is_empty());
+    }
+
+    #[test]
+    fn test_empty_registry() {
+        let reg = WeatherFileRegistry::new();
+        assert!(reg.is_empty());
+        assert!(reg.lookup("4A").is_none());
+        assert!(reg.lookup_or_default("4A").is_none());
+    }
+
+    #[test]
+    fn test_with_entries_custom() {
+        let reg = WeatherFileRegistry::with_entries([WeatherFileEntry::new(
+            "9Z",
+            "Test City",
+            0.0,
+            0.0,
+            "test.epw",
+        )]);
+        assert_eq!(reg.len(), 1);
+        let e = reg.lookup("9Z").unwrap();
+        assert_eq!(e.location_name, "Test City");
+    }
+
+    #[test]
+    fn test_insert_overrides() {
+        let mut reg = WeatherFileRegistry::standard();
+        let original = reg.lookup("5A").unwrap().clone();
+        reg.insert(WeatherFileEntry::new(
+            "5A",
+            "Override",
+            0.0,
+            0.0,
+            "override.epw",
+        ));
+        let e = reg.lookup("5A").unwrap();
+        assert_eq!(e.location_name, "Override");
+        assert_ne!(e.location_name, original.location_name);
+    }
+
+    #[test]
+    fn test_zones_sorted() {
+        let reg = WeatherFileRegistry::standard();
+        let zones = reg.zones();
+        let mut sorted = zones.clone();
+        sorted.sort();
+        assert_eq!(zones, sorted);
+    }
+
+    #[test]
+    fn test_all_epw_filenames_valid() {
+        let reg = WeatherFileRegistry::standard();
+        for z in reg.zones() {
+            let e = reg.lookup(&z).unwrap();
+            assert!(e.epw_filename.ends_with(".epw"), "{} bad filename", z);
+            assert!(!e.epw_filename.is_empty());
+            assert!(e.latitude >= -90.0 && e.latitude <= 90.0, "{} bad lat", z);
+            assert!(
+                e.longitude >= -180.0 && e.longitude <= 180.0,
+                "{} bad lon",
+                z
+            );
+        }
+    }
+
+    #[test]
+    fn test_entry_equality() {
+        let a = WeatherFileEntry::new("4A", "Baltimore, MD", 39.18, -76.67, "balt.epw");
+        let b = WeatherFileEntry::new("4A", "Baltimore, MD", 39.18, -76.67, "balt.epw");
+        assert_eq!(a, b);
+    }
+}


### PR DESCRIPTION
Closes #1776

Completes the Monte Carlo parameter-sweep infrastructure for Phase 2 ML data generation (Task T5.1), which was at 35% completion. The existing `src/ai/sweeps/` module sampled climate-zone labels but never resolved them to concrete weather files, and the reproducibility manifest could not be "emitted" (no serialization, non-standard timestamp).

This change closes all three acceptance criteria. (1) **Weather files (multi-climate)**: a new `WeatherFileRegistry` maps ASHRAE 169 climate zones (1A through 8) to canonical EnergyPlus TMY3 EPW reference files; every `SweepSample` now carries a resolved `weather_file` field, and the registry is pluggable via the builder. (2) **Driven by `SurrogateDomain`**: `SweepConfig::from_domain` still inherits weather/occupancy bounds and now also wires the standard weather registry. (3) **Reproducible manifest emitted**: `ParameterManifest`, `SweepConfig`, and all parameter structs gained serde derives; the manifest embeds the full config snapshot and serializes to JSON via `to_json()`, with a real RFC-3339 timestamp; a round-trip test proves samples regenerate exactly from the emitted manifest alone. 25 new tests cover weather-file resolution, multi-climate coverage, and manifest reproducibility.