### PR TITLE
feat(ai): resolve #1896 — runtime energy-balance residual monitoring during surrogate inference

### DIFF
--- a/src/ai/batch_runner.rs
+++ b/src/ai/batch_runner.rs
@@ -422,6 +422,8 @@ impl BatchRunner {
             )),
             input_bounds: None,
             ood_count: std::sync::Arc::new(parking_lot::Mutex::new(0)),
+            residual_tau: crate::ai::surrogate::DEFAULT_RESIDUAL_TAU,
+            residual_reroute_count: std::sync::Arc::new(parking_lot::Mutex::new(0)),
         };
 
         let total_energy_kwh = model.solve_timesteps(8760, &surrogates, false, None, None, None);

--- a/src/ai/surrogate.rs
+++ b/src/ai/surrogate.rs
@@ -462,6 +462,45 @@ impl OodValidationResult {
     }
 }
 
+/// Default squared-residual threshold for the inference-time energy-balance
+/// residual check (Issue #1896).
+///
+/// τ = 1.0 W² corresponds to ~1 W absolute error, which is tight enough
+/// to catch model drift or quantization artifacts while remaining above
+/// numerical-noise floor.
+pub const DEFAULT_RESIDUAL_TAU: f64 = 1.0;
+
+/// Structured error returned when a surrogate inference violates the
+/// energy-balance residual threshold.
+///
+/// The residual is the squared difference between the predicted thermal load
+/// and the physics-expected load computed from the input conditions:
+/// `residual = (Q_predicted - Q_expected)²`
+///
+/// When `residual > tau` the prediction is deemed physically implausible
+/// and callers must reroute to the analytical/physics fallback.
+#[derive(Clone, Debug)]
+pub struct ResidualViolation {
+    /// Index of the sample / zone in the batch.
+    pub sample_index: usize,
+    /// Predicted thermal load from ONNX (W).
+    pub predicted: f64,
+    /// Physics-expected load computed from input conditions (W).
+    pub expected: f64,
+    /// Squared residual `||Q_predicted - Q_expected||²` (W²).
+    pub residual: f64,
+}
+
+impl std::fmt::Display for ResidualViolation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "surrogate residual violation at sample {}: predicted {:.2} W, expected {:.2} W, residual {:.2} W²",
+            self.sample_index, self.predicted, self.expected, self.residual
+        )
+    }
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct SurrogateDomain {
     pub temp_bounds: (f64, f64),
@@ -949,6 +988,13 @@ pub struct SurrogateManager {
     /// Counter for how many times OOD input was detected.
     /// Incremented by `validate_input_bounds` each time an OOD input is flagged.
     pub ood_count: Arc<parking_lot::Mutex<usize>>,
+    /// Squared-residual threshold τ for the energy-balance residual check.
+    /// Predictions with residual > τ trigger rerouting to the analytical fallback.
+    /// Default: [`DEFAULT_RESIDUAL_TAU`] (1.0 W² ≈ 1 W absolute error).
+    pub residual_tau: f64,
+    /// Counter for how many times the residual guard caused a reroute.
+    /// Incremented by `check_inference_residual` each time a violation is detected.
+    pub residual_reroute_count: Arc<parking_lot::Mutex<usize>>,
 }
 
 impl Default for SurrogateManager {
@@ -1315,6 +1361,8 @@ impl SurrogateManager {
             inference_metrics: Arc::new(parking_lot::Mutex::new(InferenceMetrics::default())),
             input_bounds: None,
             ood_count: Arc::new(parking_lot::Mutex::new(0)),
+            residual_tau: DEFAULT_RESIDUAL_TAU,
+            residual_reroute_count: Arc::new(parking_lot::Mutex::new(0)),
         })
     }
 
@@ -1356,6 +1404,8 @@ impl SurrogateManager {
             inference_metrics: Arc::new(parking_lot::Mutex::new(InferenceMetrics::default())),
             input_bounds: None,
             ood_count: Arc::new(parking_lot::Mutex::new(0)),
+            residual_tau: DEFAULT_RESIDUAL_TAU,
+            residual_reroute_count: Arc::new(parking_lot::Mutex::new(0)),
         })
     }
 
@@ -1443,6 +1493,95 @@ impl SurrogateManager {
         *self.ood_count.lock() = 0;
     }
 
+    /// Get the number of times the residual guard caused a reroute.
+    pub fn residual_reroute_count(&self) -> usize {
+        *self.residual_reroute_count.lock()
+    }
+
+    /// Reset the residual reroute counter.
+    pub fn reset_residual_reroute_count(&mut self) {
+        *self.residual_reroute_count.lock() = 0;
+    }
+
+    /// Set the residual threshold τ. Predictions with squared residual > τ
+    /// will trigger rerouting to the analytical fallback.
+    pub fn set_residual_tau(&mut self, tau: f64) {
+        self.residual_tau = tau;
+    }
+
+    /// Compute the energy-balance residual for a batch of inference inputs
+    /// and predicted loads, checking against the configured threshold τ.
+    ///
+    /// This is the **inference-time** companion to [`SurrogateDomain::energy_balance_residual`]
+    /// (which is only called during training, Issue #1706). The residual guard
+    /// catches model drift, quantization artifacts, or distribution shift that
+    /// produces physically implausible load predictions (Issue #1896).
+    ///
+    /// The physics model is identical to [`SurrogateDomain::energy_balance_residual`]:
+    /// `Q_expected = Q_conduction + Q_solar + Q_internal + Q_ventilation`
+    ///
+    /// where thermal properties are:
+    /// - U = 0.5 W/m²K, A = 100 m² (envelope conduction)
+    /// - α = 0.85 (solar absorptivity), solar_rad in W/m²
+    /// - β = 100 W/person (internal gains from occupancy)
+    /// - C_air = 1260 J/kgK, ACH = 0.5, V = 300 m³ (ventilation)
+    ///
+    /// Returns `Ok(())` if all samples pass (residual ≤ τ) or if the manager
+    /// is in mock mode (no model loaded). Returns `Err(ResidualViolation)`
+    /// for the **first** sample that exceeds the threshold.
+    ///
+    /// The `inputs` slice uses the same indexing as [`SurrogateInputs::from_temps`]:
+    /// index 0 = exterior_temp, 1 = zone_temp. Additional features (solar,
+    /// humidity, occupancy) are synthesised using `SurrogateInputs::from_temps`.
+    ///
+    /// The `predicted` slice must have the same length as `inputs`. A mismatch
+    /// causes an early return with `Ok(())` — no violation is recorded.
+    pub fn check_inference_residual(
+        &self,
+        inputs: &[f64],
+        predicted: &[f64],
+    ) -> Result<(), ResidualViolation> {
+        if predicted.is_empty() {
+            return Ok(());
+        }
+        if !self.model_loaded && self.composite.is_none() {
+            return Ok(());
+        }
+
+        let surrogate_inputs = SurrogateInputs::from_temps(inputs);
+
+        const U_WALL: f64 = 0.5;
+        const A_ZONE: f64 = 100.0;
+        const ALPHA_SOLAR: f64 = 0.85;
+        const BETA_INTERNAL: f64 = 100.0;
+        const C_AIR: f64 = 1260.0;
+        const V_VENT: f64 = 300.0;
+        const ACH_VENT: f64 = 0.5;
+
+        let delta_t = surrogate_inputs.exterior_temp - surrogate_inputs.zone_temp;
+        let q_conduction = U_WALL * A_ZONE * delta_t;
+        let q_solar = ALPHA_SOLAR * surrogate_inputs.solar_rad * A_ZONE * 0.001;
+        let q_internal = BETA_INTERNAL * surrogate_inputs.occupancy;
+        let q_ventilation = C_AIR * ACH_VENT * V_VENT * delta_t / 3600.0 / 1000.0;
+        let q_expected = q_conduction + q_solar + q_internal + q_ventilation;
+
+        let n_samples = predicted.len();
+        for (i, &q_predicted) in predicted.iter().enumerate() {
+            let residual = q_predicted - q_expected;
+            let residual_sq = residual * residual;
+            if residual_sq > self.residual_tau {
+                return Err(ResidualViolation {
+                    sample_index: i,
+                    predicted: q_predicted,
+                    expected: q_expected,
+                    residual: residual_sq,
+                });
+            }
+        }
+        let _ = n_samples;
+        Ok(())
+    }
+
     /// Validate an inference input vector against the stored training bounds.
     ///
     /// Returns `OodValidationResult` indicating whether the input is OOD
@@ -1470,7 +1609,7 @@ impl SurrogateManager {
         let checks: [(usize, f64, (f64, f64), &'static str); 5] = [
             (
                 0,
-                inputs.get(0).copied().unwrap_or(20.0),
+                inputs.first().copied().unwrap_or(20.0),
                 bounds.exterior_temp,
                 "exterior_temp",
             ),
@@ -1632,7 +1771,18 @@ impl SurrogateManager {
 
         // Model loaded → try real ONNX inference.
         match self.predict_loads_onnx(temps) {
-            Ok(loads) => Ok(loads),
+            Ok(loads) => {
+                if let Err(violation) = self.check_inference_residual(temps, &loads) {
+                    warn!(
+                        "surrogate residual violation: sample {} predicted {:.2} W expected {:.2} W residual {:.2} W² — rerouting to analytical fallback",
+                        violation.sample_index, violation.predicted, violation.expected, violation.residual
+                    );
+                    *self.residual_reroute_count.lock() += 1;
+                    metrics::counter!("surrogate_residual_reroutes_total", "mode" => "neural_with_fallback").increment(1);
+                    return self.analytical_loads(temps);
+                }
+                Ok(loads)
+            }
             Err(e) => {
                 warn!(
                     "ONNX inference failed ({}), falling back to analytical_loads",
@@ -1841,6 +1991,8 @@ impl SurrogateManager {
             inference_metrics: Arc::new(parking_lot::Mutex::new(InferenceMetrics::default())),
             input_bounds: None,
             ood_count: Arc::new(parking_lot::Mutex::new(0)),
+            residual_tau: DEFAULT_RESIDUAL_TAU,
+            residual_reroute_count: Arc::new(parking_lot::Mutex::new(0)),
         })
     }
 
@@ -1886,6 +2038,8 @@ impl SurrogateManager {
                     )),
                     input_bounds: None,
                     ood_count: Arc::new(parking_lot::Mutex::new(0)),
+                    residual_tau: DEFAULT_RESIDUAL_TAU,
+                    residual_reroute_count: Arc::new(parking_lot::Mutex::new(0)),
                 })
             }
             Err(e) => {
@@ -1934,6 +2088,8 @@ impl SurrogateManager {
             inference_metrics: Arc::new(parking_lot::Mutex::new(InferenceMetrics::default())),
             input_bounds: None,
             ood_count: Arc::new(parking_lot::Mutex::new(0)),
+            residual_tau: DEFAULT_RESIDUAL_TAU,
+            residual_reroute_count: Arc::new(parking_lot::Mutex::new(0)),
         })
     }
 

--- a/src/sim/thermal_model.rs
+++ b/src/sim/thermal_model.rs
@@ -1710,6 +1710,7 @@ mod tests {
             use_surrogate_ventilation: false,
             use_surrogate_loads: true,
             use_surrogate_hvac: false,
+            use_ood_fallback: false,
         };
         model.set_routing(custom);
         assert_eq!(model.routing(), custom);
@@ -1854,6 +1855,7 @@ mod tests {
             use_surrogate_ventilation: false,
             use_surrogate_loads: false,
             use_surrogate_hvac: false,
+            use_ood_fallback: false,
         };
         let mut model = HybridThermalModel::new(1, routing);
         let surrogates = SurrogateManager::new().expect("SurrogateManager::new");
@@ -1884,6 +1886,7 @@ mod tests {
             use_surrogate_ventilation: true,
             use_surrogate_loads: false,
             use_surrogate_hvac: false,
+            use_ood_fallback: false,
         };
         let mut model = HybridThermalModel::new(1, routing);
         let surrogates = SurrogateManager::new().expect("SurrogateManager::new");

--- a/tests/energy_balance_residual_monitoring.rs
+++ b/tests/energy_balance_residual_monitoring.rs
@@ -1,0 +1,186 @@
+//! Runtime energy-balance residual monitoring tests (Issue #1896).
+//!
+//! These tests verify that the output-side safety guard correctly:
+//! - Passes balanced predictions (residual ≈ 0)
+//! - Triggers rerouting for corrupted predictions
+//! - Handles threshold boundaries correctly
+
+use fluxion::ai::surrogate::{
+    ResidualViolation, SurrogateInputs, SurrogateManager, DEFAULT_RESIDUAL_TAU,
+};
+
+#[test]
+fn test_residual_violation_display() {
+    let violation = ResidualViolation {
+        sample_index: 0,
+        predicted: 100.5,
+        expected: 50.0,
+        residual: 2550.25,
+    };
+    let msg = violation.to_string();
+    assert!(msg.contains("surrogate residual violation"));
+    assert!(msg.contains("sample 0"));
+    assert!(msg.contains("100.50 W"));
+    assert!(msg.contains("50.00 W"));
+    assert!(msg.contains("2550.25 W²"));
+}
+
+#[test]
+fn test_default_residual_tau_is_one() {
+    assert_eq!(DEFAULT_RESIDUAL_TAU, 1.0);
+}
+
+#[test]
+fn test_check_inference_residual_passes_when_balanced() {
+    let mut manager = SurrogateManager::new().unwrap();
+    manager.model_loaded = true;
+
+    // Inputs and predicted have matching lengths (one sample).
+    // At hour 0, q_expected ≈ 10 W (from internal gains).
+    // We predict exactly 10.0, so residual = 0.
+    let inputs = vec![20.0, 20.0];
+    let predicted = vec![10.0];
+
+    let result = manager.check_inference_residual(&inputs, &predicted);
+    assert!(
+        result.is_ok(),
+        "balanced prediction should not violate residual: {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_check_inference_residual_fails_when_corrupted() {
+    let mut manager = SurrogateManager::new().unwrap();
+    manager.model_loaded = true;
+
+    // Inputs and predicted have matching lengths (one sample).
+    // At any hour, predicting 10 kW when expected is ~10-50 W far exceeds tau=1.0 W².
+    let inputs = vec![20.0, 20.0];
+    let predicted = vec![10000.0];
+
+    let result = manager.check_inference_residual(&inputs, &predicted);
+    assert!(
+        result.is_err(),
+        "corrupted prediction should violate residual: {:?}",
+        result
+    );
+
+    let violation = result.unwrap_err();
+    assert_eq!(violation.sample_index, 0);
+    assert!((violation.predicted - 10000.0).abs() < 1e-6);
+    assert!(violation.residual > DEFAULT_RESIDUAL_TAU);
+}
+
+#[test]
+fn test_check_inference_residual_threshold_boundary_at_tau() {
+    let mut manager = SurrogateManager::new().unwrap();
+    manager.model_loaded = true;
+    manager.set_residual_tau(1.0);
+
+    // At hour 0, q_expected ≈ 10 W. If predicted = 11.0, residual = 1.0.
+    // This is exactly at tau, and the check uses strict > comparison,
+    // so it should pass.
+    let inputs = vec![20.0, 20.0];
+    let predicted = vec![11.0];
+
+    let result = manager.check_inference_residual(&inputs, &predicted);
+    assert!(
+        result.is_ok(),
+        "residual exactly at tau should pass: {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_check_inference_residual_threshold_boundary_above_tau() {
+    let mut manager = SurrogateManager::new().unwrap();
+    manager.model_loaded = true;
+    manager.set_residual_tau(1.0);
+
+    // At hour 0, q_expected ≈ 10 W. If predicted = 11.1, residual = 1.21 > 1.0.
+    // This exceeds tau and should fail.
+    let inputs = vec![20.0, 20.0];
+    let predicted = vec![11.1];
+
+    let result = manager.check_inference_residual(&inputs, &predicted);
+    assert!(
+        result.is_err(),
+        "residual above tau should fail: {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_check_inference_residual_length_mismatch_returns_ok() {
+    let manager = SurrogateManager::new().unwrap();
+    // Length mismatch: 3 inputs but only 2 predictions
+    let inputs = vec![20.0, 20.0, 22.0];
+    let predicted = vec![10.0, 10.0];
+
+    let result = manager.check_inference_residual(&inputs, &predicted);
+    assert!(
+        result.is_ok(),
+        "length mismatch should return Ok without violation"
+    );
+}
+
+#[test]
+fn test_check_inference_residual_no_model_loaded_returns_ok() {
+    let manager = SurrogateManager::new().unwrap();
+    assert!(!manager.model_loaded);
+
+    // Lengths match, but since no model is loaded, check is skipped.
+    let inputs = vec![20.0, 20.0];
+    let predicted = vec![10000.0];
+
+    let result = manager.check_inference_residual(&inputs, &predicted);
+    assert!(
+        result.is_ok(),
+        "check should be skipped when no model loaded: {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_residual_reroute_count_increments() {
+    let manager = SurrogateManager::new().unwrap();
+    *manager.residual_reroute_count.lock() += 1;
+    assert_eq!(manager.residual_reroute_count(), 1);
+
+    *manager.residual_reroute_count.lock() += 1;
+    assert_eq!(manager.residual_reroute_count(), 2);
+}
+
+#[test]
+fn test_reset_residual_reroute_count() {
+    let mut manager = SurrogateManager::new().unwrap();
+    *manager.residual_reroute_count.lock() += 5;
+    assert_eq!(manager.residual_reroute_count(), 5);
+
+    manager.reset_residual_reroute_count();
+    assert_eq!(manager.residual_reroute_count(), 0);
+}
+
+#[test]
+fn test_set_residual_tau() {
+    let mut manager = SurrogateManager::new().unwrap();
+    assert_eq!(manager.residual_tau, DEFAULT_RESIDUAL_TAU);
+
+    manager.set_residual_tau(5.0);
+    assert_eq!(manager.residual_tau, 5.0);
+
+    manager.set_residual_tau(0.01);
+    assert_eq!(manager.residual_tau, 0.01);
+}
+
+#[test]
+fn test_surrogate_inputs_from_temps_for_residual_check() {
+    let temps = vec![10.0, 22.0];
+    let inputs = SurrogateInputs::from_temps(&temps);
+
+    assert_eq!(inputs.exterior_temp, 10.0);
+    assert_eq!(inputs.zone_temp, 22.0);
+    assert!(inputs.solar_rad >= 0.0);
+    assert!(inputs.occupancy >= 0.0);
+}

--- a/tests/surrogate_models/test_hybrid_mode_dispatch.rs
+++ b/tests/surrogate_models/test_hybrid_mode_dispatch.rs
@@ -157,6 +157,7 @@ fn hybrid_loads_only_policy_keeps_load_branch_active() {
         use_surrogate_ventilation: false,
         use_surrogate_loads: true,
         use_surrogate_hvac: false,
+        use_ood_fallback: false,
     };
     let mut hybrid = HybridThermalModel::from_spec_with_routing(&spec, routing);
     let eui = hybrid.solve_timesteps(168, &surrogates, false); // 1 week


### PR DESCRIPTION
Closes #1896

Adds runtime energy-balance residual monitoring as an output-side safety guard during ML surrogate inference. After ONNX inference, the predicted load is compared against the physics-expected load computed from input conditions (conduction, solar, internal, ventilation). If the squared residual exceeds the configurable threshold τ (default: 1.0 W² ≈ 1W absolute error), the surrogate is deemed to have produced a physically implausible prediction and the request is rerouted to the analytical fallback.