### PR TITLE
test(ci): resolve #1932 — code coverage tracking and quality gates

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,6 +1,35 @@
+# Code Coverage Gate (Issue #1932)
+#
+# Runs cargo-llvm-cov on every PR and on every push to `develop`, then:
+#   1. Uploads an LCOV trace to Codecov for trend tracking + PR comments.
+#   2. Buckets coverage by the four ARCHITECTURE.md critical physics paths
+#      (Weather→Solar, Weather→Ventilation, Conduction→Zone Balance,
+#      HVAC→Zone Balance) and publishes a per-path table to the run summary.
+#   3. Enforces a one-way ratchet gate: any critical path whose committed
+#      baseline (validation/coverage_baseline.json) has been set will fail
+#      the build if line coverage regresses by more than 1% relative.
+#      Paths with a 0.0 baseline are unenforced (collection pending).
+#
+# Tool choice
+# -----------
+# cargo-llvm-cov replaces cargo-tarpaulin.  The docs already documented
+# llvm-cov (`docs/CONTRIBUTING.md` "Coverage Measurement" section) so this
+# brings CI in sync with the documented workflow, and llvm-cov is the only
+# Rust coverage tool that emits native branch coverage.  Unlike tarpaulin,
+# llvm-cov is compatible with sccache, so the wrapper is re-enabled here.
+#
+# Branch-protection
+# -----------------
+# The job is named `Code Coverage Gate (Issue #1932)` and is registered as
+# a required check in release_gates.yaml (mirrors the #1333 / #1351 / #1618
+# gate-naming pattern).
+
 name: Code Coverage
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches: [develop]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -8,141 +37,93 @@ concurrency:
 
 jobs:
   coverage:
-    name: Code Coverage
+    name: Code Coverage Gate (Issue #1932)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust-env
         with:
-          # sccache sets RUSTC_WRAPPER=sccache which intercepts the compiler
-          # and breaks tarpaulin's instrumentation. Disable it for coverage runs.
-          sccache: 'false'
+          # llvm-cov instruments at the LLVM level and is fully compatible
+          # with sccache (unlike tarpaulin, which intercepted the compiler
+          # frontend).  Keep sccache on for faster incremental builds.
+          sccache: 'true'
+          components: 'llvm-tools'
 
-      - name: Install tarpaulin
-        uses: baptiste0928/cargo-install@v3
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
         with:
-          crate: cargo-tarpaulin
+          tool: cargo-llvm-cov
 
-      - name: Generate coverage
+      - name: Generate coverage (cargo llvm-cov)
         env:
-          RUSTFLAGS: "-C target-cpu=x86-64"
           RUST_MIN_STACK: 16777216
           RUST_LOG: debug
-        shell: bash
         run: |
           set -o pipefail
+          mkdir -p target/llvm-cov
 
-          echo "=== DEBUG INFO ==="
-          cargo tarpaulin --version 2>&1 || echo "tarpaulin not installed yet"
+          echo "=== Toolchain ==="
+          cargo llvm-cov --version
           rustc --version
           cargo --version
-          echo "Starting tarpaulin at $(date -Iseconds)"
-          echo "===================="
 
-          # Run tarpaulin over the library crate to measure coverage of
-          # src/physics/ and other source modules.
-          # NOTE: We use --lib (inline #[test] functions) rather than an
-          # integration test binary name because integration test names can
-          # change during refactors.  If a named binary is needed in future,
-          # verify it exists in Cargo.toml [[test]] before adding --test.
-          cargo tarpaulin \
-            --timeout 600 \
+          # Run library tests with LLVM source-based coverage, emitting LCOV.
+          # --lib matches the previous tarpaulin scope (inline #[test]
+          # functions).  --features wiring-tracing matches the test matrix.
+          # Excludes tests/, benches/, and target/ from the report so the
+          # per-path numbers reflect production code only.
+          cargo llvm-cov \
             --lib \
-            --out Xml \
-            --output-dir ./ \
-            --ignore-panics \
             --features wiring-tracing \
-            2>&1 | tee tarpaulin.log
-          TARPAULIN_EXIT=${PIPESTATUS[0]}
+            --lcov \
+            --output-path target/llvm-cov/lcov.info \
+            --ignore-filename-pattern '/tests/|/benches/|/target/|/fluxion-mcp/' \
+            2>&1 | tee target/llvm-cov/llvm-cov.log
+          COV_EXIT=${PIPESTATUS[0]}
 
           echo ""
-          echo "=== tarpaulin finished at $(date -Iseconds) with exit code $TARPAULIN_EXIT ==="
+          echo "=== llvm-cov finished with exit code $COV_EXIT ==="
+          ls -la target/llvm-cov/
 
-          echo ""
-          echo "=== Files in current directory ==="
-          ls -la *.xml *.log 2>/dev/null || echo "No xml/log files found"
-
-          if [ $TARPAULIN_EXIT -ne 0 ]; then
-            echo "::error::cargo-tarpaulin failed with exit code $TARPAULIN_EXIT"
-            echo "=== Last 50 lines of tarpaulin.log ==="
-            tail -50 tarpaulin.log
-            exit $TARPAULIN_EXIT
+          if [ $COV_EXIT -ne 0 ]; then
+            echo "::error::cargo-llvm-cov failed with exit code $COV_EXIT"
+            tail -50 target/llvm-cov/llvm-cov.log
+            exit $COV_EXIT
           fi
 
-      - name: Extract Physics Coverage
-        if: success()
-        run: |
-          python3 << 'EOF'
-          import xml.etree.ElementTree as ET
-          import os
-
-          tree = ET.parse('cobertura.xml')
-          root = tree.getroot()
-
-          physics_files = []
-          total_lines = 0
-          covered_lines = 0
-
-          for cls in root.findall('.//class'):
-              filename = cls.get('filename', '')
-              if 'src/physics/' in filename:
-                  physics_files.append(filename)
-                  line_rate = float(cls.get('line-rate', '0'))
-                  lines_valid = int(cls.get('lines-valid', '0'))
-                  lines_covered = int(cls.get('lines-covered', '0'))
-                  total_lines += lines_valid
-                  covered_lines += lines_covered
-
-          if total_lines > 0:
-              physics_coverage = (covered_lines / total_lines) * 100
-              print(f"Physics coverage: {physics_coverage:.2f}%")
-              print(f"Physics files analyzed: {len(physics_files)}")
-              with open(os.environ['GITHUB_ENV'], 'a') as f:
-                  f.write(f"PHYSICS_COVERAGE={physics_coverage:.2f}\n")
-                  f.write(f"PHYSICS_FILE_COUNT={len(physics_files)}\n")
-          else:
-              print("Warning: No physics files found matching src/physics/ in coverage report")
-              with open(os.environ['GITHUB_ENV'], 'a') as f:
-                  f.write("PHYSICS_COVERAGE=0.00\n")
-                  f.write("PHYSICS_FILE_COUNT=0\n")
-
-          print("")
-          print("Physics files covered:")
-          for f in physics_files:
-              print(f"  - {f}")
-          EOF
-
-      - name: Check Physics Coverage Threshold
-        if: success()
-        run: |
-          # TODO: Re-enable the 70% threshold once baseline coverage is
-          # established.  For now, threshold is 0 (never fail) so we can
-          # measure without blocking PRs.
-          THRESHOLD=0
-          echo "Checking physics coverage threshold (target: ${THRESHOLD}%)"
-
-          if (( $(echo "$PHYSICS_COVERAGE < $THRESHOLD" | bc -l) )); then
-            echo "::error::Physics coverage ${PHYSICS_COVERAGE}% is below ${THRESHOLD}% threshold"
+          if [ ! -s target/llvm-cov/lcov.info ]; then
+            echo "::error::lcov.info is empty or missing"
             exit 1
-          else
-            echo "::notice::Physics coverage ${PHYSICS_COVERAGE}% meets ${THRESHOLD}% threshold"
           fi
 
-      - name: Generate Physics Coverage Summary
-        if: success()
+      - name: Critical-path coverage analysis + ratchet gate
         run: |
-          echo "## Physics Coverage Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **Coverage**: ${PHYSICS_COVERAGE}% (Target: 70% — currently unenforced)" >> $GITHUB_STEP_SUMMARY
-          echo "- **Status**: $(if (( $(echo \"$PHYSICS_COVERAGE >= 70\" | bc -l) )); then echo \"✅ PASS\"; else echo \"⚠️  Below 70% target\"; fi)" >> $GITHUB_STEP_SUMMARY
-          echo "- **Files Analyzed**: ${PHYSICS_FILE_COUNT}" >> $GITHUB_STEP_SUMMARY
+          # Always publish the per-path summary table, even if an earlier
+          # step failed, so contributors can see the numbers.  The --gate
+          # flag is what makes the job fail on regression.
+          python3 scripts/coverage_critical_paths.py \
+            --lcov target/llvm-cov/lcov.info \
+            --baseline validation/coverage_baseline.json \
+            --summary-file "$GITHUB_STEP_SUMMARY" \
+            --gate
 
       - name: Upload to codecov
         if: success() && !env.ACT
         uses: codecov/codecov-action@v4
         with:
-          files: ./cobertura.xml
+          files: target/llvm-cov/lcov.info
           fail_ci_if_error: false
-          flags: unit_tests,physics
+          flags: weather_solar,weather_ventilation,conduction_zone,hvac_zone
           name: codecov-fluxion
           verbose: true
+
+      - name: Upload coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            target/llvm-cov/lcov.info
+            target/llvm-cov/llvm-cov.log
+          if-no-files-found: warn
+          retention-days: 14

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,7 @@ ML-surrogate swap-point traits:
 - `Fluxion Determinism Gate (Issue #1351)` — listener on Cross-Platform Determinism CI workflow
 - `Fluxion Performance Gate (Issue #1618)` — listener on Performance Dashboard workflow
 - `Architecture Drift Detection` (nightly + on `src/**/*.rs` / `ARCHITECTURE.md` changes) — `scripts/check_architecture_drift.py`
+- `Code Coverage Gate (Issue #1932)` — `cargo llvm-cov` + per-critical-path ratchet (baseline in `validation/coverage_baseline.json`; starts unenforced)
 - `Mutation Testing (advisory)` (Issue #1891) — diff-scoped `cargo mutants --in-diff` PR check; non-blocking. `Mutation Testing (nightly)` runs the full suite against `develop`.
 
 Heavy Linux jobs honour `vars.FLUXION_LINUX_RUNNER` (self-hosted Hetzner fallback; see `docs/self-hosted-runners.md`).
@@ -199,6 +200,9 @@ Heavy Linux jobs honour `vars.FLUXION_LINUX_RUNNER` (self-hosted Hetzner fallbac
 | `release_gates.yaml` | Required branch-protection checks + thresholds |
 | `scripts/check_architecture_drift.py` | ARCHITECTURE.md vs source-code drift |
 | `scripts/check_ashrae_cases_cycle.py` | `sim ↔ validation` cycle regression guard |
+| `scripts/coverage_critical_paths.py` | Per-critical-path coverage analysis + ratchet gate (#1932) |
+| `scripts/coverage_baseline.py` | Record/refresh the coverage ratchet baseline (#1932) |
+| `validation/coverage_baseline.json` | Committed coverage baseline (0.0 = unenforced) |
 | `scripts/release_gate_checker.py` | Validates `release_gates.yaml` gates against current results |
 | `scripts/mutants_diff_files.sh` | Extracts changed `.rs` files for diff-scoped mutation testing (`--in-diff`) |
 | `.github/workflows/mutation-testing.yml` | Advisory diff-scoped mutation PR check (Issue #1891) |

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,10 @@
+# Codecov configuration — aligned to the four ARCHITECTURE.md critical
+# physics paths tracked by the Code Coverage Gate (Issue #1932).
+#
+# Flags map to the per-path buckets computed by
+# scripts/coverage_critical_paths.py.  The `unit_tests` flag is retained
+# for backward compatibility with any existing codecov dashboards.
+
 coverage:
   precision: 2
   round: down
@@ -6,9 +13,13 @@ coverage:
 flag_coverage:
   - unit_tests
   - integration_tests
+  - weather_solar
+  - weather_ventilation
+  - conduction_zone
+  - hvac_zone
 
 comment:
-  layout: "header, diff, files"
+  layout: "header, diff, flags, files"
   behavior: default
   require_changes: false
   require_base: false
@@ -20,6 +31,9 @@ ignore:
   - "docs/"
   - "examples/"
   - "tools/"
+  - "tests/"
+  - "benches/"
+  - "fluxion-mcp/"
 
 codecov:
   require_ci_to_pass: true

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -7,7 +7,7 @@ Related to: validation_report.md (results), FIX.md (placeholder fixes), ARCHITEC
 Status: Post-#1323 baseline refresh — pre-#1323 numbers are obsolete per ARCHITECTURE.md §Current Module Status.
 Action: Check this document before attributing validation failures to new issues; many may be known.
 
-*Last Updated: 2026-07-16* (Post-#1323 / post-Wave-5 baseline refresh; #1421 Case 600 ref-range unified to benchmark.rs:124-127 across validator, CSV, doc, and this document; see issue #1443)
+*Last Updated: 2026-07-26* (Post-#1323 / post-Wave-5 baseline refresh; #1421 Case 600 ref-range unified to benchmark.rs:124-127 across validator, CSV, doc, and this document; see issue #1443. CI-01 code-coverage gate #1932 added.)
 
 > **Post-#1323 baseline changes (read first)** — Between the prior "Last Updated" header
 > (2026-03-30) and this revision, ~100 days and 30+ validation-affecting PRs landed.
@@ -751,6 +751,21 @@ they are physically correct and flip one marginal test.
 - **Status:** 🔄 Open (05-04 will enhance)
 - **Phase Addressed:** Phase 5
 - **Resolution Notes:** Will add phase comparison section to ASHRAE140_RESULTS.md.
+
+### CI-01: Code coverage gate (issue #1932) — thresholds not yet enforced
+
+- **Affected:** CI quality gate, not physics output.
+- **Status:** 🔄 Infrastructure shipped; enforcement pending baseline collection.
+- **Details:** The Code Coverage Gate (`Code Coverage Gate (Issue #1932)` in
+  `release_gates.yaml`) runs `cargo-llvm-cov` on every PR and `develop` push,
+  buckets results by the four ARCHITECTURE.md critical paths, and enforces a
+  1% relative-drop ratchet. The committed baseline
+  (`validation/coverage_baseline.json`) starts with all values at `0.0`,
+  which means *unenforced* — the gate passes regardless until a maintainer
+  records real numbers via `scripts/coverage_baseline.py --update`.
+- **Resolution:** After a green `develop` CI run, run
+  `python3 scripts/coverage_baseline.py --update --lcov target/llvm-cov/lcov.info`
+  and commit the updated baseline. See `docs/coverage.md` for the full workflow.
 
 ## Summary
 

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -1,0 +1,89 @@
+# Code Coverage Tracking
+
+Tracks line and branch coverage across the four ARCHITECTURE.md critical physics paths.
+Runs `cargo-llvm-cov` in CI (`.github/workflows/code-coverage.yml`) on every PR and `develop` push.
+Coverage is bucketed per critical path by `scripts/coverage_critical_paths.py` and enforced via a one-way ratchet gate.
+Targets: 80% overall, 85% per critical path (see docs/CONTRIBUTING.md §Coverage Measurement).
+Related: release_gates.yaml (required check), validation/coverage_baseline.json (ratchet floor), docs/KNOWN_ISSUES.md.
+
+## Overview
+
+The Code Coverage Gate (Issue #1932) replaces the previous tarpaulin-based
+informational job with a cargo-llvm-cov pipeline that:
+
+1. **Collects** line + branch coverage for the library crate (`--lib
+   --features wiring-tracing`), matching the `docs/CONTRIBUTING.md`
+   "Coverage Measurement" workflow.
+2. **Buckets** the results into the four critical physics paths defined
+   in `ARCHITECTURE.md`:
+
+   | Path | Files |
+   |------|-------|
+   | Weather → Solar | `fluxion-core/src/weather/**`, `src/sim/solar.rs`, `src/sim/solar_gain_distribution.rs` |
+   | Weather → Ventilation | `fluxion-core/src/weather/**`, `src/sim/ventilation.rs` |
+   | Conduction → Zone Balance | `src/physics/**`, `src/sim/thermal_model*.rs`, `src/sim/per_surface_conduction.rs` |
+   | HVAC → Zone Balance | `src/sim/hvac/**`, `src/sim/thermal_model_hvac.rs`, `src/sim/hvac_controller.rs` |
+
+   Files may contribute to more than one path (e.g. `weather/` is on both
+   the solar and ventilation paths) — this mirrors the real data flow.
+
+3. **Enforces** a one-way ratchet: any path whose baseline
+   (`validation/coverage_baseline.json`) has a non-zero value will fail the
+   build if its line coverage drops more than 1% relative to the baseline.
+   The baseline only ever moves upward.
+
+## Reproducing a coverage run locally
+
+```bash
+# Install once
+rustup component add llvm-tools
+cargo install cargo-llvm-cov
+
+# Match what CI runs
+cargo llvm-cov --lib --features wiring-tracing \
+  --lcov --output-path target/llvm-cov/lcov.info \
+  --ignore-filename-pattern '/tests/|/benches/|/target/|/fluxion-mcp/'
+
+# Print the per-critical-path table
+python3 scripts/coverage_critical_paths.py --lcov target/llvm-cov/lcov.info
+
+# Check the gate (non-zero exit = regression)
+python3 scripts/coverage_critical_paths.py \
+  --lcov target/llvm-cov/lcov.info \
+  --baseline validation/coverage_baseline.json \
+  --gate
+```
+
+## Activating the ratchet
+
+The committed baseline starts with all values at `0.0`, which means
+*unenforced*. The gate passes regardless of coverage until a maintainer
+records real numbers:
+
+```bash
+# After a green develop CI run, download the lcov.info artifact then:
+python3 scripts/coverage_baseline.py --update \
+  --lcov target/llvm-cov/lcov.info \
+  --baseline validation/coverage_baseline.json
+
+git add validation/coverage_baseline.json
+git commit -m "ci(coverage): record baseline for #1932 ratchet gate"
+```
+
+Once committed, every subsequent PR is held to the recorded floor. Re-run
+the command after coverage improvements to bump the ratchet upward.
+
+## Targets
+
+| Metric | Target | Notes |
+|--------|--------|-------|
+| Overall line coverage | >80% | `docs/CONTRIBUTING.md` baseline is 69.36% (Phase 10) |
+| Per-critical-path line coverage | >85% | Ratchet enforces "no regression" first |
+| Branch coverage | Informational | Reported in step summary, not yet gated |
+
+## Related
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) §Coverage Measurement — documented workflow
+- [release_gates.yaml](../release_gates.yaml) — registers the gate as a required check
+- [KNOWN_ISSUES.md](KNOWN_ISSUES.md) — open limitations, including baseline-collection status
+- [tests/physics/README.md](../tests/physics/README.md) — physics test catalog

--- a/docs/doc-inventory.md
+++ b/docs/doc-inventory.md
@@ -10,6 +10,7 @@ Self-healing inventory of all documentation in the Fluxion repository. Each doc 
 | [CODEBASE_MAP.md](../../CODEBASE_MAP.md) | Code navigation, module dependency graph, Rust/Python/JS overview | ✅ Has summary |
 | [FIX.md](../../FIX.md) | Known bugs placeholder, ASHRAE 140 CI gate fixes | ✅ Has summary |
 | [docs/KNOWN_ISSUES.md](../../docs/KNOWN_ISSUES.md) | Known systematic issues, ASHRAE 140 validation issues | ✅ Has summary |
+| [docs/coverage.md](../../docs/coverage.md) | Code coverage tracking, critical-path ratchet gate, llvm-cov workflow | ✅ Has summary |
 | [documentation/performance_guide.md](../../documentation/performance_guide.md) | Performance validation user guide, CLI usage | ✅ Has summary |
 | [documentation/performance.md](../../documentation/performance.md) | Performance benchmarks, optimization, validation targets | ✅ Has summary |
 | [validation_report.md](../../validation_report.md) | ASHRAE 140 validation results, pass/fail rates | ✅ Has summary |

--- a/release_gates.yaml
+++ b/release_gates.yaml
@@ -213,6 +213,16 @@ ci:
     # a PR comment linking the upstream run URL.
     - "Fluxion Performance Gate (Issue #1618)"
 
+    # Issue #1932: per-critical-path coverage ratchet gate.  Runs
+    # cargo-llvm-cov, buckets results by the four ARCHITECTURE.md critical
+    # physics paths (Weather→Solar, Weather→Ventilation, Conduction→Zone
+    # Balance, HVAC→Zone Balance), and fails the build when any path whose
+    # baseline has been set (validation/coverage_baseline.json) regresses by
+    # more than 1% relative.  Paths with a 0.0 baseline are unenforced
+    # (collection pending) and never trip the gate — see the KNOWN_ISSUES.md
+    # entry titled "Code coverage gate (issue #1932)".
+    - "Code Coverage Gate (Issue #1932)"
+
   # Job-to-workflow map (informational; branch-protection reads job
   # names directly). Used by `scripts/release_gate_checker.py` to verify
   # the required_checks list is in sync with the workflows directory.
@@ -240,3 +250,8 @@ ci:
       observes_workflow_file: ".github/workflows/performance_dashboard.yml"
       issue: 1618
       triggered_by: "workflow_run on Performance Dashboard completion + PR trigger"
+
+    - job: "Code Coverage Gate (Issue #1932)"
+      workflow: ".github/workflows/code-coverage.yml"
+      issue: 1932
+      triggered_by: "PR + push to develop"

--- a/scripts/coverage_baseline.py
+++ b/scripts/coverage_baseline.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""
+Record the current coverage as the ratchet baseline for the Code Coverage
+Gate (Issue #1932).
+
+A maintainer runs this once after a clean ``develop`` CI run to flip the
+gate from *unenforced* (baseline ``0.0``) to *enforced*.  Re-running it
+bumps the baseline upward when coverage improves — the ratchet only
+ever moves in the direction of the latest measurement, so coverage can
+rise but never silently fall.
+
+Usage
+~~~~~
+::
+
+    # After a green CI run, download the lcov.info artifact then:
+    python3 scripts/coverage_baseline.py --update \\
+        --lcov target/llvm-cov/lcov.info \\
+        --baseline validation/coverage_baseline.json
+
+    # Dry run: print what would be written without touching the file.
+    python3 scripts/coverage_baseline.py --lcov target/llvm-cov/lcov.info
+
+Exit codes: 0 on success, 2 on script error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Import the shared bucketing logic from the sibling script.
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+from coverage_critical_paths import (  # noqa: E402  (sys.path insert above)
+    bucket_coverage,
+    load_baseline,
+    parse_lcov,
+)
+
+
+PATH_ORDER = ["overall", "weather_solar", "weather_ventilation", "conduction_zone", "hvac_zone"]
+
+
+def build_baseline_payload(reports: dict, previous: dict) -> dict:
+    """Compose the JSON payload that becomes the new baseline.
+
+    Each path records ``line`` and ``branch`` percentages plus the raw
+    counts so a future reader can audit the sample size.  ``_ratchet``
+    documents the one-way tolerance the gate applies.
+    """
+    paths_section = previous.get("paths", {}) if isinstance(previous, dict) else {}
+    new_paths: dict[str, dict] = {}
+    for name in PATH_ORDER:
+        rep = reports.get(name)
+        prev_entry = paths_section.get(name, {}) if isinstance(paths_section, dict) else {}
+        prev_line = float(prev_entry.get("line", 0.0)) if isinstance(prev_entry, dict) else 0.0
+
+        current_line = round(rep.line_pct, 4) if rep else 0.0
+        # Ratchet: never move the floor *down* once it has been set.  This
+        # stops a bad merge from quietly lowering the bar; the floor only
+        # rises (or stays flat) as coverage improves.
+        ratcheted_line = max(current_line, prev_line) if prev_line > 0.0 else current_line
+
+        new_paths[name] = {
+            "line": ratcheted_line,
+            "branch": round(rep.branch_pct, 4) if rep else 0.0,
+            "lines_hit": rep.lines_hit if rep else 0,
+            "lines_found": rep.lines_found if rep else 0,
+            "branches_hit": rep.branches_hit if rep else 0,
+            "branches_found": rep.branches_found if rep else 0,
+        }
+
+    return {
+        "_comment": (
+            "Coverage baseline for the Code Coverage Gate (#1932). "
+            "A line value of 0.0 means the path is unenforced; the gate "
+            "activates automatically once a real number is recorded here. "
+            "Regenerate with `python scripts/coverage_baseline.py --update "
+            "--lcov target/llvm-cov/lcov.info`."
+        ),
+        "_issue": 1932,
+        "_updated": datetime.now(timezone.utc).isoformat(timespec="seconds").replace(
+            "+00:00", "Z"
+        ),
+        "_ratchet": {
+            "tolerance": 0.01,
+            "description": (
+                "Gate fails when a path's current line coverage drops below "
+                "baseline × (1 − tolerance). Baseline never moves downward."
+            ),
+        },
+        "paths": new_paths,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Record coverage baseline for the #1932 ratchet gate"
+    )
+    parser.add_argument(
+        "--lcov",
+        type=Path,
+        default=REPO_ROOT / "target" / "llvm-cov" / "lcov.info",
+        help="Path to lcov.info from `cargo llvm-cov --lcov`",
+    )
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=REPO_ROOT / "validation" / "coverage_baseline.json",
+        help="Path to the baseline JSON to read/update",
+    )
+    parser.add_argument(
+        "--update",
+        action="store_true",
+        help="Write the new baseline (without this flag the script is a dry run)",
+    )
+    args = parser.parse_args()
+
+    try:
+        files = parse_lcov(args.lcov)
+    except FileNotFoundError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    reports = bucket_coverage(files)
+    previous = load_baseline(args.baseline)
+    payload = build_baseline_payload(reports, previous)
+
+    print("Baseline payload:")
+    print(json.dumps(payload, indent=2))
+
+    if args.update:
+        args.baseline.parent.mkdir(parents=True, exist_ok=True)
+        with open(args.baseline, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2)
+            fh.write("\n")
+        print(f"\n✅ Baseline written to {args.baseline}")
+        print(
+            "The Code Coverage Gate will now enforce these floors on the next "
+            "CI run. Re-run this command after coverage improvements to bump "
+            "the ratchet upward."
+        )
+    else:
+        print(f"\nℹ️  Dry run — pass --update to write to {args.baseline}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(2)

--- a/scripts/coverage_critical_paths.py
+++ b/scripts/coverage_critical_paths.py
@@ -1,0 +1,440 @@
+#!/usr/bin/env python3
+"""
+Per-critical-path coverage analysis + ratchet gate for the Code Coverage
+Gate (Issue #1932).
+
+Parses an LCOV ``lcov.info`` produced by ``cargo llvm-cov --lcov`` and
+buckets the results into the four ARCHITECTURE.md critical physics paths:
+
+    1. Weather  -> Solar          (fluxion-core/src/weather/**, src/sim/solar*)
+    2. Weather  -> Ventilation    (fluxion-core/src/weather/**, src/sim/ventilation.rs)
+    3. Conduction -> Zone Balance (src/physics/**, src/sim/thermal_model*)
+    4. HVAC      -> Zone Balance   (src/sim/hvac/**, src/sim/*hvac*)
+
+Plus an ``overall`` bucket that covers every instrumented source file.
+
+Usage
+-----
+Report-only (prints a Markdown table to stdout / $GITHUB_STEP_SUMMARY)::
+
+    python3 scripts/coverage_critical_paths.py \\
+        --lcov target/llvm-cov/lcov.info
+
+Gate mode (non-zero exit if any enforced path regresses beyond the
+ratchet tolerance read from the baseline file)::
+
+    python3 scripts/coverage_critical_paths.py \\
+        --lcov target/llvm-cov/lcov.info \\
+        --baseline validation/coverage_baseline.json \\
+        --gate
+
+The baseline stores one entry per critical path.  A baseline value of
+``0.0`` means *unenforced* (collection pending) — the gate passes with
+a notice for that path.  Once a maintainer records real numbers via
+``scripts/coverage_baseline.py --update`` the ratchet activates
+automatically.
+
+Exit codes
+~~~~~~~~~~
+  0  report-only, or gate passed
+  1  gate failed (one or more enforced paths regressed)
+  2  script error (missing file, malformed input)
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# ---------------------------------------------------------------------------
+# Critical path definitions.
+#
+# A path is a list of fnmatch globs matched against the *repo-relative* path
+# found in the LCOV ``SF:`` records.  Files are allowed to contribute to more
+# than one path (e.g. ``fluxion-core/src/weather/`` is on both the solar and
+# ventilation paths) — this reflects the real data flow in ARCHITECTURE.md.
+# ---------------------------------------------------------------------------
+CRITICAL_PATHS: dict[str, list[str]] = {
+    "weather_solar": [
+        "fluxion-core/src/weather/**",
+        "src/sim/solar.rs",
+        "src/sim/solar_gain_distribution.rs",
+    ],
+    "weather_ventilation": [
+        "fluxion-core/src/weather/**",
+        "src/sim/ventilation.rs",
+    ],
+    "conduction_zone": [
+        "src/physics/**",
+        "src/sim/thermal_model.rs",
+        "src/sim/thermal_model_core.rs",
+        "src/sim/thermal_model_solvers.rs",
+        "src/sim/thermal_model_iterative.rs",
+        "src/sim/thermal_model_data.rs",
+        "src/sim/thermal_model_physics/**",
+        "src/sim/per_surface_conduction.rs",
+    ],
+    "hvac_zone": [
+        "src/sim/hvac/**",
+        "src/sim/thermal_model_hvac.rs",
+        "src/sim/hvac_controller.rs",
+        "src/sim/multi_node_hvac_runner.rs",
+    ],
+}
+
+# Human-readable labels for the step summary table.
+PATH_LABELS: dict[str, str] = {
+    "weather_solar": "Weather → Solar",
+    "weather_ventilation": "Weather → Ventilation",
+    "conduction_zone": "Conduction → Zone Balance",
+    "hvac_zone": "HVAC → Zone Balance",
+    "overall": "Overall (all instrumented)",
+}
+
+# Relative drop allowed before the ratchet trips.  A 1% relative drop means a
+# path at 80.0% passes at 79.2% but fails at 79.1%.  Tuned to absorb noise
+# from minor refactors while catching real regressions.
+RATCHET_TOLERANCE = 0.01
+
+
+@dataclass
+class FileCoverage:
+    """Line + branch coverage for one source file."""
+
+    path: str
+    lines_found: int = 0
+    lines_hit: int = 0
+    branches_found: int = 0
+    branches_hit: int = 0
+
+    @property
+    def line_pct(self) -> float:
+        return 100.0 * self.lines_hit / self.lines_found if self.lines_found else 0.0
+
+    @property
+    def branch_pct(self) -> float:
+        return (
+            100.0 * self.branches_hit / self.branches_found
+            if self.branches_found
+            else 0.0
+        )
+
+
+@dataclass
+class PathReport:
+    """Aggregated coverage for one critical path."""
+
+    name: str
+    files: list[FileCoverage] = field(default_factory=list)
+
+    @property
+    def lines_found(self) -> int:
+        return sum(f.lines_found for f in self.files)
+
+    @property
+    def lines_hit(self) -> int:
+        return sum(f.lines_hit for f in self.files)
+
+    @property
+    def branches_found(self) -> int:
+        return sum(f.branches_found for f in self.files)
+
+    @property
+    def branches_hit(self) -> int:
+        return sum(f.branches_hit for f in self.files)
+
+    @property
+    def line_pct(self) -> float:
+        return 100.0 * self.lines_hit / self.lines_found if self.lines_found else 0.0
+
+    @property
+    def branch_pct(self) -> float:
+        return (
+            100.0 * self.branches_hit / self.branches_found
+            if self.branches_found
+            else 0.0
+        )
+
+    @property
+    def file_count(self) -> int:
+        return len(self.files)
+
+
+# ---------------------------------------------------------------------------
+# LCOV parsing
+# ---------------------------------------------------------------------------
+def parse_lcov(lcov_path: Path) -> list[FileCoverage]:
+    """Parse an LCOV trace file into a list of per-file coverage records.
+
+    Understands the DA / LF / LH / BRF / BRH records produced by
+    ``cargo llvm-cov --lcov``.  Files with zero instrumented lines are
+    skipped (they add noise without signal).
+    """
+    if not lcov_path.exists():
+        raise FileNotFoundError(f"LCOV file not found: {lcov_path}")
+
+    files: list[FileCoverage] = []
+    current: Optional[FileCoverage] = None
+
+    for raw in lcov_path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = raw.strip()
+        if line.startswith("SF:"):
+            # SF: may contain an absolute or relative path; normalise to
+            # repo-relative so the fnmatch globs work either way.
+            sf = line[3:]
+            current = FileCoverage(path=_repo_relative(sf))
+        elif line.startswith("LF:") and current is not None:
+            current.lines_found = int(line[3:])
+        elif line.startswith("LH:") and current is not None:
+            current.lines_hit = int(line[3:])
+        elif line.startswith("BRF:") and current is not None:
+            current.branches_found = int(line[4:])
+        elif line.startswith("BRH:") and current is not None:
+            current.branches_hit = int(line[4:])
+        elif line == "end_of_record" and current is not None:
+            if current.lines_found > 0:
+                files.append(current)
+            current = None
+
+    return files
+
+
+def _repo_relative(path: str) -> str:
+    """Strip absolute-prefix noise so fnmatch globs match consistently."""
+    p = Path(path)
+    try:
+        rel = p.relative_to(REPO_ROOT)
+        return rel.as_posix()
+    except ValueError:
+        pass
+    # Fall back to stripping common prefixes that llvm-cov emits.
+    for marker in ("/src/", "/fluxion-core/src/"):
+        idx = path.find(marker)
+        if idx != -1:
+            return path[idx + 1 :]
+    return path
+
+
+def _matches_any(path: str, globs: list[str]) -> bool:
+    """True if *path* matches any of the fnmatch globs.
+
+    ``**`` is treated as a recursive wildcard (matches any number of path
+    segments), mirroring .gitignore semantics.
+    """
+    for g in globs:
+        if g.endswith("/**"):
+            prefix = g[:-3]
+            if path == prefix or path.startswith(prefix + "/"):
+                return True
+        elif fnmatch.fnmatch(path, g):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Bucketing + reporting
+# ---------------------------------------------------------------------------
+def bucket_coverage(files: list[FileCoverage]) -> dict[str, PathReport]:
+    """Assign every file to the critical paths it belongs to + an overall bucket."""
+    reports: dict[str, PathReport] = {}
+    for path_name in CRITICAL_PATHS:
+        reports[path_name] = PathReport(name=path_name)
+    reports["overall"] = PathReport(name="overall")
+
+    for fc in files:
+        reports["overall"].files.append(fc)
+        for path_name, globs in CRITICAL_PATHS.items():
+            if _matches_any(fc.path, globs):
+                reports[path_name].files.append(fc)
+
+    return reports
+
+
+def render_markdown_table(reports: dict[str, PathReport]) -> str:
+    """Render a GFM table for $GITHUB_STEP_SUMMARY."""
+    rows = [
+        "## Code Coverage by Critical Path (Issue #1932)",
+        "",
+        "| Critical path | Line coverage | Branch coverage | Files |",
+        "|---------------|--------------:|----------------:|------:|",
+    ]
+    order = ["overall", "weather_solar", "weather_ventilation", "conduction_zone", "hvac_zone"]
+    for name in order:
+        rep = reports.get(name)
+        if rep is None or rep.file_count == 0:
+            rows.append(
+                f"| {PATH_LABELS[name]} | — | — | 0 |"
+            )
+            continue
+        rows.append(
+            f"| {PATH_LABELS[name]} "
+            f"| {rep.line_pct:.2f}% ({rep.lines_hit}/{rep.lines_found}) "
+            f"| {rep.branch_pct:.2f}% ({rep.branches_hit}/{rep.branches_found}) "
+            f"| {rep.file_count} |"
+        )
+    return "\n".join(rows)
+
+
+def load_baseline(baseline_path: Optional[Path]) -> dict:
+    """Load the baseline JSON, returning an empty dict when absent."""
+    if baseline_path is None or not baseline_path.exists():
+        return {}
+    with open(baseline_path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def evaluate_gate(
+    reports: dict[str, PathReport],
+    baseline: dict,
+    tolerance: float,
+) -> list[str]:
+    """Return a list of human-readable failure lines (empty list = pass).
+
+    The gate trips when a path's current line coverage drops below
+    ``baseline * (1 - tolerance)``.  Paths whose baseline is ``0.0`` (or
+    absent) are *unenforced* and never trip the gate; they emit a notice
+    instead so the baseline-collection status is visible.
+    """
+    failures: list[str] = []
+    paths_section = baseline.get("paths", {}) if isinstance(baseline, dict) else {}
+    order = ["overall", "weather_solar", "weather_ventilation", "conduction_zone", "hvac_zone"]
+    for name in order:
+        rep = reports.get(name)
+        base_entry = paths_section.get(name, {}) if isinstance(paths_section, dict) else {}
+        base_line = float(base_entry.get("line", 0.0)) if isinstance(base_entry, dict) else 0.0
+
+        if base_line <= 0.0:
+            print(
+                f"   ℹ️  {name}: baseline not set (unenforced) — "
+                f"current line coverage "
+                f"{rep.line_pct:.2f}%"
+                if rep and rep.lines_found
+                else f"   ℹ️  {name}: baseline not set (unenforced) — no instrumented files"
+            )
+            continue
+
+        if rep is None or rep.lines_found == 0:
+            failures.append(
+                f"{name}: no instrumented files found (baseline {base_line:.2f}%)"
+            )
+            continue
+
+        floor = base_line * (1.0 - tolerance)
+        if rep.line_pct < floor:
+            failures.append(
+                f"{name}: line coverage {rep.line_pct:.2f}% fell below "
+                f"ratchet floor {floor:.2f}% "
+                f"(baseline {base_line:.2f}% × (1 − {tolerance:.0%}))"
+            )
+        else:
+            print(
+                f"   ✅ {name}: {rep.line_pct:.2f}% ≥ ratchet floor {floor:.2f}% "
+                f"(baseline {base_line:.2f}%)"
+            )
+    return failures
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Per-critical-path coverage analysis + ratchet gate (#1932)"
+    )
+    parser.add_argument(
+        "--lcov",
+        type=Path,
+        default=REPO_ROOT / "target" / "llvm-cov" / "lcov.info",
+        help="Path to the lcov.info produced by `cargo llvm-cov --lcov`",
+    )
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=REPO_ROOT / "validation" / "coverage_baseline.json",
+        help="Path to the committed coverage baseline JSON",
+    )
+    parser.add_argument(
+        "--gate",
+        action="store_true",
+        help="Fail (exit 1) when an enforced path regresses past the ratchet",
+    )
+    parser.add_argument(
+        "--tolerance",
+        type=float,
+        default=RATCHET_TOLERANCE,
+        help="Relative drop allowed before the ratchet trips (default: 0.01 = 1%%)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the computed per-path metrics as JSON to stdout",
+    )
+    parser.add_argument(
+        "--summary-file",
+        type=Path,
+        default=None,
+        help="Append the Markdown table to this file (use $GITHUB_STEP_SUMMARY in CI)",
+    )
+    args = parser.parse_args()
+
+    try:
+        files = parse_lcov(args.lcov)
+    except FileNotFoundError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    reports = bucket_coverage(files)
+    table = render_markdown_table(reports)
+
+    if args.json:
+        payload = {
+            name: {
+                "line_pct": round(rep.line_pct, 4),
+                "branch_pct": round(rep.branch_pct, 4),
+                "lines_hit": rep.lines_hit,
+                "lines_found": rep.lines_found,
+                "branches_hit": rep.branches_hit,
+                "branches_found": rep.branches_found,
+                "files": rep.file_count,
+            }
+            for name, rep in reports.items()
+        }
+        print(json.dumps(payload, indent=2))
+
+    print(table)
+    print()
+
+    if args.summary_file is not None:
+        with open(args.summary_file, "a", encoding="utf-8") as fh:
+            fh.write(table)
+            fh.write("\n")
+
+    if args.gate:
+        baseline = load_baseline(args.baseline)
+        print("Ratchet gate evaluation:")
+        failures = evaluate_gate(reports, baseline, args.tolerance)
+        if failures:
+            print()
+            print(f"❌ {len(failures)} path(s) regressed past the ratchet:")
+            for f in failures:
+                print(f"   • {f}")
+            return 1
+        print()
+        print("✅ All enforced critical paths held their ratchet floor.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(2)

--- a/tests/physics/README.md
+++ b/tests/physics/README.md
@@ -84,6 +84,13 @@ cargo test test_critical_paths
 cargo test test_coverage_enhancement
 ```
 
+The CI [Code Coverage Gate (#1932)](../../docs/coverage.md) buckets the
+coverage of these critical paths (Weather→Solar, Weather→Ventilation,
+Conduction→Zone Balance, HVAC→Zone Balance) and enforces a one-way ratchet
+against `validation/coverage_baseline.json`. Run the gate locally with
+`python3 scripts/coverage_critical_paths.py --gate` after generating an
+LCOV trace (see `docs/coverage.md`).
+
 ### With Performance Metrics
 ```bash
 # Run tests with timing information

--- a/validation/coverage_baseline.json
+++ b/validation/coverage_baseline.json
@@ -1,0 +1,51 @@
+{
+  "_comment": "Coverage baseline for the Code Coverage Gate (#1932). A line value of 0.0 means the path is unenforced; the gate activates automatically once a real number is recorded here. Regenerate with `python scripts/coverage_baseline.py --update --lcov target/llvm-cov/lcov.info`.",
+  "_issue": 1932,
+  "_updated": null,
+  "_ratchet": {
+    "tolerance": 0.01,
+    "description": "Gate fails when a path's current line coverage drops below baseline x (1 - tolerance). Baseline never moves downward."
+  },
+  "paths": {
+    "overall": {
+      "line": 0.0,
+      "branch": 0.0,
+      "lines_hit": 0,
+      "lines_found": 0,
+      "branches_hit": 0,
+      "branches_found": 0
+    },
+    "weather_solar": {
+      "line": 0.0,
+      "branch": 0.0,
+      "lines_hit": 0,
+      "lines_found": 0,
+      "branches_hit": 0,
+      "branches_found": 0
+    },
+    "weather_ventilation": {
+      "line": 0.0,
+      "branch": 0.0,
+      "lines_hit": 0,
+      "lines_found": 0,
+      "branches_hit": 0,
+      "branches_found": 0
+    },
+    "conduction_zone": {
+      "line": 0.0,
+      "branch": 0.0,
+      "lines_hit": 0,
+      "lines_found": 0,
+      "branches_hit": 0,
+      "branches_found": 0
+    },
+    "hvac_zone": {
+      "line": 0.0,
+      "branch": 0.0,
+      "lines_hit": 0,
+      "lines_found": 0,
+      "branches_hit": 0,
+      "branches_found": 0
+    }
+  }
+}


### PR DESCRIPTION
Closes #1932

Replaces the tarpaulin-based informational coverage job with a cargo-llvm-cov pipeline that collects line + branch coverage, buckets it by the four ARCHITECTURE.md critical physics paths (Weather→Solar, Weather→Ventilation, Conduction→Zone Balance, HVAC→Zone Balance), publishes a per-path table to the run summary, and enforces a one-way ratchet gate. The gate is wired as a required branch-protection check (Code Coverage Gate (Issue #1932)) in release_gates.yaml but starts with an all-zero unenforced baseline (validation/coverage_baseline.json); a maintainer activates enforcement by running scripts/coverage_baseline.py --update after a green develop CI run. New scripts/coverage_critical_paths.py parses the LCOV trace and fails the build when any path whose baseline has been set regresses by more than 1% relative. Also aligns codecov.yml flags to the critical paths, adds docs/coverage.md, and records the unenforced-threshold status in docs/KNOWN_ISSUES.md (CI-01).