### PR TITLE
[Grid] Heat pump COP voltage feedback adjustment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "Apache-2.0"
 # that cargo-mutants can build once and cache while mutating only `fluxion`.
 [workspace]
 resolver = "2"
-members = ["fluxion-core"]
+members = ["fluxion-core", "fluxion-grid"]
 # Default to the root package so bare `cargo build`/`cargo test` build `fluxion`.
 default-members = ["."]
 

--- a/fluxion-grid/Cargo.toml
+++ b/fluxion-grid/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "fluxion-grid"
+version = "0.1.0"
+edition = "2021"
+authors = ["Dr. Aris Thorne <aris.thorne@fluxion.org>"]
+description = "Grid-coupled thermal modeling for Fluxion — voltage feedback models for heat pump COP and thermal-electrical coupling."
+repository = "https://github.com/anchapin/fluxion"
+license = "Apache-2.0"
+
+[lib]
+name = "fluxion_grid"
+path = "src/lib.rs"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+thiserror = "1.0"
+
+[dev-dependencies]
+approx = "0.5"

--- a/fluxion-grid/src/error.rs
+++ b/fluxion-grid/src/error.rs
@@ -1,0 +1,13 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum GridModelError {
+    #[error("voltage {voltage:.3} pu is outside valid range [0.5, 1.5]")]
+    VoltageOutOfRange { voltage: f64 },
+
+    #[error("coupler thermal mass is zero — cannot apply voltage adjustment")]
+    ZeroThermalMass,
+
+    #[error("negative COP adjustment factor {factor:.4} would increase COP")]
+    NegativeAdjustment { factor: f64 },
+}

--- a/fluxion-grid/src/heat_pump_voltage_model.rs
+++ b/fluxion-grid/src/heat_pump_voltage_model.rs
@@ -1,0 +1,120 @@
+use crate::{GridModelError, ThermalElectricalCoupler, VoltagePu};
+
+#[derive(Debug, Clone, Default)]
+pub struct HeatPumpVoltageModel {
+    pub a: f64,
+    pub b: f64,
+    pub c: f64,
+    pub voltage_nominal: f64,
+}
+
+impl HeatPumpVoltageModel {
+    pub fn new(a: f64, b: f64, c: f64, voltage_nominal: f64) -> Self {
+        Self {
+            a,
+            b,
+            c,
+            voltage_nominal,
+        }
+    }
+
+    pub fn cop_adjustment_factor(&self, voltage_pu: VoltagePu) -> Result<f64, GridModelError> {
+        if !(0.5..=1.5).contains(&voltage_pu) {
+            return Err(GridModelError::VoltageOutOfRange {
+                voltage: voltage_pu,
+            });
+        }
+        let factor = self.a + self.b * voltage_pu + self.c * voltage_pu * voltage_pu;
+        Ok(factor)
+    }
+
+    pub fn apply_to_coupler(
+        &self,
+        coupler: &mut ThermalElectricalCoupler,
+        voltage_pu: VoltagePu,
+    ) -> Result<(), GridModelError> {
+        if coupler.thermal_mass_j_per_k <= 0.0 {
+            return Err(GridModelError::ZeroThermalMass);
+        }
+        let factor = self.cop_adjustment_factor(voltage_pu)?;
+        if factor < 0.0 {
+            return Err(GridModelError::NegativeAdjustment { factor });
+        }
+        coupler.current_voltage_pu = voltage_pu;
+        coupler.current_cop *= factor;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    fn default_model() -> HeatPumpVoltageModel {
+        HeatPumpVoltageModel::new(0.85, 0.30, -0.15, 230.0)
+    }
+
+    #[test]
+    fn test_cop_at_nominal_is_unity() {
+        let model = default_model();
+        let factor = model.cop_adjustment_factor(1.0).unwrap();
+        assert_relative_eq!(factor, 1.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn test_cop_at_09pu_less_than_cop_at_10pu() {
+        let model = default_model();
+        let f_09 = model.cop_adjustment_factor(0.9).unwrap();
+        let f_10 = model.cop_adjustment_factor(1.0).unwrap();
+        assert!(
+            f_09 < f_10,
+            "COP at 0.9 pu ({f_09}) should be less than COP at 1.0 pu ({f_10})"
+        );
+    }
+
+    #[test]
+    fn test_cop_polynomial_values() {
+        let model = default_model();
+        let f_10 = model.cop_adjustment_factor(1.0).unwrap();
+        let f_09 = model.cop_adjustment_factor(0.9).unwrap();
+        let f_05 = model.cop_adjustment_factor(1.05).unwrap();
+        assert_relative_eq!(f_10, 1.0, epsilon = 1e-10);
+        assert!(f_09 < 1.0, "f(0.9) = {f_09} should be < 1.0");
+        assert!(
+            f_05 < 1.0 && f_05 > f_09,
+            "f(1.05) = {f_05} should be < 1.0 but > f(0.9)"
+        );
+    }
+
+    #[test]
+    fn test_voltage_out_of_range() {
+        let model = default_model();
+        let result = model.cop_adjustment_factor(1.6);
+        assert!(result.is_err());
+        let result = model.cop_adjustment_factor(0.4);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_apply_to_coupler() {
+        let model = default_model();
+        let mut coupler = ThermalElectricalCoupler::new(1000.0, 5000.0);
+        coupler.set_cop(3.5);
+
+        model.apply_to_coupler(&mut coupler, 0.9).unwrap();
+
+        let expected_factor = model.cop_adjustment_factor(0.9).unwrap();
+        let expected_cop = 3.5 * expected_factor;
+        assert_relative_eq!(coupler.current_cop, expected_cop, epsilon = 1e-10);
+        assert_eq!(coupler.current_voltage_pu, 0.9);
+    }
+
+    #[test]
+    fn test_apply_zero_thermal_mass() {
+        let model = default_model();
+        let mut coupler = ThermalElectricalCoupler::new(1000.0, 0.0);
+        let result = model.apply_to_coupler(&mut coupler, 0.9);
+        assert!(result.is_err());
+    }
+}

--- a/fluxion-grid/src/lib.rs
+++ b/fluxion-grid/src/lib.rs
@@ -1,0 +1,19 @@
+//! `fluxion-grid` — Grid-coupled thermal modeling for Fluxion.
+//!
+//! Provides voltage feedback models for heat pump COP adjustment and
+//! thermal-electrical coupling components.
+
+mod error;
+
+pub use error::GridModelError;
+
+/// Voltage-per-unit of nominal frequency (Hz/Hz) type alias for clarity.
+pub type VoltagePu = f64;
+/// Frequency-per-unit of nominal frequency type alias.
+pub type FrequencyPu = f64;
+
+mod thermal_electrical_coupler;
+pub use thermal_electrical_coupler::ThermalElectricalCoupler;
+
+mod heat_pump_voltage_model;
+pub use heat_pump_voltage_model::HeatPumpVoltageModel;

--- a/fluxion-grid/src/thermal_electrical_coupler.rs
+++ b/fluxion-grid/src/thermal_electrical_coupler.rs
@@ -1,0 +1,49 @@
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ThermalElectricalCoupler {
+    pub compressor_power_demand_w: f64,
+    pub thermal_mass_j_per_k: f64,
+    pub current_cop: f64,
+    pub nominal_voltage_v: f64,
+    pub current_voltage_pu: f64,
+}
+
+impl ThermalElectricalCoupler {
+    pub fn new(compressor_power_demand_w: f64, thermal_mass_j_per_k: f64) -> Self {
+        Self {
+            compressor_power_demand_w,
+            thermal_mass_j_per_k,
+            current_cop: 1.0,
+            nominal_voltage_v: 230.0,
+            current_voltage_pu: 1.0,
+        }
+    }
+
+    pub fn with_voltage(mut self, voltage_pu: f64) -> Self {
+        self.current_voltage_pu = voltage_pu;
+        self
+    }
+
+    pub fn set_cop(&mut self, cop: f64) {
+        self.current_cop = cop;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_coupler_default_voltage() {
+        let coupler = ThermalElectricalCoupler::new(1000.0, 5000.0);
+        assert_eq!(coupler.current_voltage_pu, 1.0);
+        assert_eq!(coupler.current_cop, 1.0);
+    }
+
+    #[test]
+    fn test_coupler_with_voltage() {
+        let coupler = ThermalElectricalCoupler::new(1000.0, 5000.0).with_voltage(0.95);
+        assert_eq!(coupler.current_voltage_pu, 0.95);
+    }
+}


### PR DESCRIPTION
Implements voltage feedback adjustment for heat pump COP (issue #2040). Adds fluxion-grid crate with HeatPumpVoltageModel (polynomial COP factor) and ThermalElectricalCoupler. cargo build -p fluxion-grid and cargo test -p fluxion-grid pass.