### PR TITLE
[Performance] Reduce ThermalModel clone cost

### DIFF
--- a/src/sim/thermal_model_data.rs
+++ b/src/sim/thermal_model_data.rs
@@ -449,7 +449,7 @@ impl<T: ContinuousTensor<f64> + Clone> Clone for ThermalModelData<T> {
             hourly_temperatures: None,
             nodal_temperatures: None,
             incident_solar_per_surface: self.incident_solar_per_surface.clone(),
-            sun_pos_cache: self.sun_pos_cache.clone(),
+            sun_pos_cache: Default::default(), // Issue #1970: don't clone cache; clone starts fresh
         }
     }
 }


### PR DESCRIPTION
Fixes #1970

## Summary by Sourcery

Enhancements:
- Adjust ThermalModelData cloning behavior so that the sun position cache is reinitialized rather than cloned, avoiding expensive cache copying and ensuring clones recompute their own cache state.