### PR TITLE
[Grid] HeatPumpVoltageModel - COP voltage feedback adjustment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,6 +1195,7 @@ dependencies = [
 name = "fluxion-grid"
 version = "0.1.0"
 dependencies = [
+ "approx",
  "nalgebra",
  "proptest",
  "serde",

--- a/fluxion-grid/Cargo.toml
+++ b/fluxion-grid/Cargo.toml
@@ -3,7 +3,7 @@ name = "fluxion-grid"
 version = "0.1.0"
 edition = "2021"
 authors = ["Dr. Aris Thorne <aris.thorne@fluxion.org>"]
-description = "Grid-edge components for Fluxion: BatteryStorageNode and related electrical network models."
+description = "Grid-edge electrical network components for Fluxion: battery storage, bus nodes, power flow, and joint thermal-electrical convergence."
 repository = "https://github.com/anchapin/fluxion"
 license = "Apache-2.0"
 
@@ -18,4 +18,5 @@ thiserror = "1.0"
 nalgebra = "0.33"
 
 [dev-dependencies]
+approx = "0.5"
 proptest = "1.5"

--- a/fluxion-grid/src/error.rs
+++ b/fluxion-grid/src/error.rs
@@ -1,0 +1,13 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum GridModelError {
+    #[error("voltage {voltage:.3} pu is outside valid range [0.5, 1.5]")]
+    VoltageOutOfRange { voltage: f64 },
+
+    #[error("coupler thermal mass is zero — cannot apply voltage adjustment")]
+    ZeroThermalMass,
+
+    #[error("negative COP adjustment factor {factor:.4} would increase COP")]
+    NegativeAdjustment { factor: f64 },
+}

--- a/fluxion-grid/src/heat_pump_voltage_model.rs
+++ b/fluxion-grid/src/heat_pump_voltage_model.rs
@@ -41,7 +41,7 @@ impl HeatPumpVoltageModel {
             return Err(GridModelError::NegativeAdjustment { factor });
         }
         coupler.current_voltage_pu = voltage_pu;
-        coupler.current_cop *= factor;
+        coupler.current_cop = (coupler.current_cop * factor).max(1.0);
         Ok(())
     }
 }

--- a/fluxion-grid/src/heat_pump_voltage_model.rs
+++ b/fluxion-grid/src/heat_pump_voltage_model.rs
@@ -1,0 +1,120 @@
+use crate::{GridModelError, VoltageCoupler, VoltagePu};
+
+#[derive(Debug, Clone, Default)]
+pub struct HeatPumpVoltageModel {
+    pub a: f64,
+    pub b: f64,
+    pub c: f64,
+    pub voltage_nominal: f64,
+}
+
+impl HeatPumpVoltageModel {
+    pub fn new(a: f64, b: f64, c: f64, voltage_nominal: f64) -> Self {
+        Self {
+            a,
+            b,
+            c,
+            voltage_nominal,
+        }
+    }
+
+    pub fn cop_adjustment_factor(&self, voltage_pu: VoltagePu) -> Result<f64, GridModelError> {
+        if !(0.5..=1.5).contains(&voltage_pu) {
+            return Err(GridModelError::VoltageOutOfRange {
+                voltage: voltage_pu,
+            });
+        }
+        let factor = self.a + self.b * voltage_pu + self.c * voltage_pu * voltage_pu;
+        Ok(factor)
+    }
+
+    pub fn apply_to_coupler(
+        &self,
+        coupler: &mut VoltageCoupler,
+        voltage_pu: VoltagePu,
+    ) -> Result<(), GridModelError> {
+        if coupler.thermal_mass_j_per_k <= 0.0 {
+            return Err(GridModelError::ZeroThermalMass);
+        }
+        let factor = self.cop_adjustment_factor(voltage_pu)?;
+        if factor < 0.0 {
+            return Err(GridModelError::NegativeAdjustment { factor });
+        }
+        coupler.current_voltage_pu = voltage_pu;
+        coupler.current_cop *= factor;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    fn default_model() -> HeatPumpVoltageModel {
+        HeatPumpVoltageModel::new(0.85, 0.30, -0.15, 230.0)
+    }
+
+    #[test]
+    fn test_cop_at_nominal_is_unity() {
+        let model = default_model();
+        let factor = model.cop_adjustment_factor(1.0).unwrap();
+        assert_relative_eq!(factor, 1.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn test_cop_at_09pu_less_than_cop_at_10pu() {
+        let model = default_model();
+        let f_09 = model.cop_adjustment_factor(0.9).unwrap();
+        let f_10 = model.cop_adjustment_factor(1.0).unwrap();
+        assert!(
+            f_09 < f_10,
+            "COP at 0.9 pu ({f_09}) should be less than COP at 1.0 pu ({f_10})"
+        );
+    }
+
+    #[test]
+    fn test_cop_polynomial_values() {
+        let model = default_model();
+        let f_10 = model.cop_adjustment_factor(1.0).unwrap();
+        let f_09 = model.cop_adjustment_factor(0.9).unwrap();
+        let f_05 = model.cop_adjustment_factor(1.05).unwrap();
+        assert_relative_eq!(f_10, 1.0, epsilon = 1e-10);
+        assert!(f_09 < 1.0, "f(0.9) = {f_09} should be < 1.0");
+        assert!(
+            f_05 < 1.0 && f_05 > f_09,
+            "f(1.05) = {f_05} should be < 1.0 but > f(0.9)"
+        );
+    }
+
+    #[test]
+    fn test_voltage_out_of_range() {
+        let model = default_model();
+        let result = model.cop_adjustment_factor(1.6);
+        assert!(result.is_err());
+        let result = model.cop_adjustment_factor(0.4);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_apply_to_coupler() {
+        let model = default_model();
+        let mut coupler = VoltageCoupler::new(1000.0, 5000.0);
+        coupler.set_cop(3.5);
+
+        model.apply_to_coupler(&mut coupler, 0.9).unwrap();
+
+        let expected_factor = model.cop_adjustment_factor(0.9).unwrap();
+        let expected_cop = 3.5 * expected_factor;
+        assert_relative_eq!(coupler.current_cop, expected_cop, epsilon = 1e-10);
+        assert_eq!(coupler.current_voltage_pu, 0.9);
+    }
+
+    #[test]
+    fn test_apply_zero_thermal_mass() {
+        let model = default_model();
+        let mut coupler = VoltageCoupler::new(1000.0, 0.0);
+        let result = model.apply_to_coupler(&mut coupler, 0.9);
+        assert!(result.is_err());
+    }
+}

--- a/fluxion-grid/src/lib.rs
+++ b/fluxion-grid/src/lib.rs
@@ -1,15 +1,15 @@
-//! # fluxion-grid
-//!
-//! Grid-edge electrical network components for Fluxion building energy modeling.
-//!
-//! This crate provides battery storage node models with state-of-charge (SoC) tracking
-//! and electrical characteristics for integration with building energy simulations.
-//!
-//! ## Contents
-//!
-//! | Module | Description |
-//! |--------|-------------|
-//! | `battery_storage_node` | `BatteryStorageNode` — single-cell battery model with SoC, terminal voltage, and C-rate dynamics |
+// # fluxion-grid
+//
+// Grid-edge electrical network components for Fluxion building energy modeling.
+//
+// This crate provides battery storage node models with state-of-charge (SoC) tracking
+// and electrical characteristics for integration with building energy simulations.
+//
+// ## Contents
+//
+// | Module | Description |
+// |--------|-------------|
+// | `battery_storage_node` | `BatteryStorageNode` — single-cell battery model with SoC, terminal voltage, and C-rate dynamics |
 
 #![allow(nonstandard_style)]
 #![allow(clippy::all)]
@@ -18,14 +18,24 @@ pub mod battery_storage_node;
 
 pub use battery_storage_node::BatteryStorageNode;
 
+// === Heat Pump Voltage Model ===
+pub mod error;
+pub mod thermal_electrical_coupler;
+pub mod heat_pump_voltage_model;
+
+pub use error::GridModelError;
+pub use thermal_electrical_coupler::VoltageCoupler;
+pub use heat_pump_voltage_model::HeatPumpVoltageModel;
+
+
 // === Joint Thermal-Electrical Convergence Solver ===
-//! fluxion-grid: Electrical grid modeling with bus node types for power flow analysis.
-//!
-//! This crate provides foundational types for electrical bus modeling including:
-//! - Bus node types (Slack, PV, PQ)
-//! - Electrical bus structures with voltage, angle, and power attributes
-//! - Battery bus with State of Charge (SoC) tracking
-//! - Joint thermal-electrical convergence solver for grid-interactive buildings
+// fluxion-grid: Electrical grid modeling with bus node types for power flow analysis.
+//
+// This crate provides foundational types for electrical bus modeling including:
+// - Bus node types (Slack, PV, PQ)
+// - Electrical bus structures with voltage, angle, and power attributes
+// - Battery bus with State of Charge (SoC) tracking
+// - Joint thermal-electrical convergence solver for grid-interactive buildings
 
 pub mod bus;
 pub mod battery;
@@ -36,6 +46,8 @@ pub use battery::BatteryBus;
 pub use power_flow::PowerFlowState;
 
 use nalgebra::DMatrix;
+use serde::{Serialize, Deserialize};
+pub type VoltagePu = f64;
 
 /// Result of the joint convergence solve.
 #[derive(Debug, Clone)]

--- a/fluxion-grid/src/lib.rs
+++ b/fluxion-grid/src/lib.rs
@@ -46,7 +46,7 @@ pub use battery::BatteryBus;
 pub use power_flow::PowerFlowState;
 
 use nalgebra::DMatrix;
-use serde::{Serialize, Deserialize};
+
 pub type VoltagePu = f64;
 
 /// Result of the joint convergence solve.

--- a/fluxion-grid/src/thermal_electrical_coupler.rs
+++ b/fluxion-grid/src/thermal_electrical_coupler.rs
@@ -1,0 +1,49 @@
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct VoltageCoupler {
+    pub compressor_power_demand_w: f64,
+    pub thermal_mass_j_per_k: f64,
+    pub current_cop: f64,
+    pub nominal_voltage_v: f64,
+    pub current_voltage_pu: f64,
+}
+
+impl VoltageCoupler {
+    pub fn new(compressor_power_demand_w: f64, thermal_mass_j_per_k: f64) -> Self {
+        Self {
+            compressor_power_demand_w,
+            thermal_mass_j_per_k,
+            current_cop: 1.0,
+            nominal_voltage_v: 230.0,
+            current_voltage_pu: 1.0,
+        }
+    }
+
+    pub fn with_voltage(mut self, voltage_pu: f64) -> Self {
+        self.current_voltage_pu = voltage_pu;
+        self
+    }
+
+    pub fn set_cop(&mut self, cop: f64) {
+        self.current_cop = cop;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_coupler_default_voltage() {
+        let coupler = VoltageCoupler::new(1000.0, 5000.0);
+        assert_eq!(coupler.current_voltage_pu, 1.0);
+        assert_eq!(coupler.current_cop, 1.0);
+    }
+
+    #[test]
+    fn test_coupler_with_voltage() {
+        let coupler = VoltageCoupler::new(1000.0, 5000.0).with_voltage(0.95);
+        assert_eq!(coupler.current_voltage_pu, 0.95);
+    }
+}


### PR DESCRIPTION
Fixes #2040

## Summary by Sourcery

Add voltage-dependent COP feedback modeling for heat pumps by introducing a dedicated thermal-electrical coupler, a heat pump voltage adjustment model with validation, and associated error handling and tests.

New Features:
- Introduce a thermal-electrical coupler data model for heat pump compressor power, thermal mass, COP, and voltage state.
- Add a heat pump voltage feedback model that adjusts COP based on per-unit bus voltage via a polynomial relationship and validates operating bounds.

Bug Fixes:
- Guard against invalid voltage ranges, zero thermal mass, and negative COP adjustment factors when applying voltage-based COP feedback to the coupler.

Enhancements:
- Extend the grid crate API to expose the new heat pump voltage model and grid error types, and document voltage-based COP feedback in the crate-level docs.

Build:
- Add nalgebra as a dependency to support new grid modeling capabilities.

Tests:
- Add unit tests covering the new coupler defaults and voltage handling, COP adjustment behavior over different voltages, and error conditions for invalid inputs.