### PR TITLE
fix(physics): Replace debug_assert! with runtime check for First Law violation (#2127)

### DIFF
--- a/src/physics/multi_node_solver.rs
+++ b/src/physics/multi_node_solver.rs
@@ -44,6 +44,7 @@ use crate::sim::per_surface_conduction::{PerSurfaceConductionSolver, SurfaceKind
 use crate::sim::sky_radiation::STEFAN_BOLTZMANN;
 // Issue #1349 (Phase 2 crate split): multi-node thermal mass types moved to `fluxion_core::multi_node`.
 use fluxion_core::multi_node::{MassAirCouplingMode, MultiNodeThermalMass, ThermalMassNode};
+use log;
 
 /// Series combination of two conductances (Issue #1281, parallel-resistance
 /// coupling network for 9R4C).
@@ -603,10 +604,14 @@ impl MultiNodeSolver {
         // here since the caller is better positioned to handle that failure.
         let residual = (q_net - delta_e_rate).abs();
         let scale = q_net.abs().max(delta_e_rate.abs()).max(1.0);
-        debug_assert!(
-            !residual.is_finite() || residual < 1e-9 * scale,
-            "First Law violation: net heat ({q_net} W) != change in storage rate ({delta_e_rate} W) | residual={residual} W",
-        );
+        // Issue #2127: Replace debug_assert! with runtime check.
+        // Non-finite residuals (inf/nan) are skipped silently per Issue #2128.
+        // Finite but large residuals emit a warning instead of panicking.
+        if residual.is_finite() && residual >= 1e-9 * scale {
+            log::warn!(
+                "First Law violation: net heat ({q_net} W) != change in storage rate ({delta_e_rate} W) | residual={residual} W",
+            );
+        }
     }
 
     // ── Issue #871: Air Balance API Methods ───────────────────────────


### PR DESCRIPTION
## Summary

Replace the debug_assert at multi_node_solver.rs with a proper runtime check that uses relative tolerance, skips non-finite residuals, and logs warnings instead of panicking.

## Changes

1. Added use log import
2. Replaced debug_assert with runtime check using log::warn

## Testing

- ASHRAE 140 validation tests: PASS
- Multi-node tests: PASS

Note: Pre-existing test failures in zone_balance_eplus_isolation (Cases 600/900) are tracked in Issue #2128.

## Related Issues
- Fixes #2127
- Related to #2128

## Summary by Sourcery

Replace a debug-only First Law consistency assertion with a runtime warning and adjust code coverage workflow configuration to use an external ignore-file list.

Bug Fixes:
- Prevent panics from First Law consistency checks in the multi-node solver by replacing a debug assertion with a tolerant runtime warning.

CI:
- Update code coverage workflow to read ignore patterns from a dedicated coverage-ignore.txt file instead of an inline pattern.