### PR TITLE
fix(ci): Replace --ignore-filename-pattern with --ignore-file for cargo-llvm-cov (#2129)

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -77,7 +77,7 @@ jobs:
             --features wiring-tracing \
             --lcov \
             --output-path target/llvm-cov/lcov.info \
-            --ignore-filename-regex '/tests/|/benches/|/target/|/fluxion-mcp/' \
+            --ignore-file .github/workflows/coverage-ignore.txt \
             2>&1 | tee target/llvm-cov/llvm-cov.log
           COV_EXIT=${PIPESTATUS[0]}
 


### PR DESCRIPTION
This PR merges the resolved rebase of #2129 into develop.

Summary:
- Replaces --ignore-filename-pattern with --ignore-file .github/workflows/coverage-ignore.txt in code-coverage.yml
- The coverage-ignore.txt file was already added in the original PR #2129
- This resolves the conflict that occurred during develop branch rebase

## Summary by Sourcery

CI:
- Switch cargo-llvm-cov configuration in the coverage workflow to use an ignore file instead of an inline filename regex.