### PR TITLE
test(twin): resolve #2064 — WebSocket Memory Leak Test: 1000 State Broadcasts

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -77,7 +77,10 @@ jobs:
             --features wiring-tracing \
             --lcov \
             --output-path target/llvm-cov/lcov.info \
-            --ignore-file .github/workflows/coverage-ignore.txt \
+            --ignore-filename-regex 'tests/' \
+            --ignore-filename-regex 'benches/' \
+            --ignore-filename-regex 'target/' \
+            --ignore-filename-regex 'fluxion-mcp/' \
             2>&1 | tee target/llvm-cov/llvm-cov.log
           COV_EXIT=${PIPESTATUS[0]}
 

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -77,10 +77,7 @@ jobs:
             --features wiring-tracing \
             --lcov \
             --output-path target/llvm-cov/lcov.info \
-            --ignore-filename-regex 'tests/' \
-            --ignore-filename-regex 'benches/' \
-            --ignore-filename-regex 'target/' \
-            --ignore-filename-regex 'fluxion-mcp/' \
+            --ignore-filename-regex 'tests/|benches/|target/|fluxion-mcp/' \
             2>&1 | tee target/llvm-cov/llvm-cov.log
           COV_EXIT=${PIPESTATUS[0]}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,6 +722,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "400a21f1014a968ec518c7ccdf9b4a4ed0cac8c56ccb6d604f8b91f00110501e"
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "defer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1093,6 +1099,7 @@ dependencies = [
  "libm",
  "log",
  "loom 0.1.1",
+ "memory-stats",
  "metrics",
  "metrics-exporter-prometheus",
  "mockito",
@@ -1118,6 +1125,7 @@ dependencies = [
  "rand_distr 0.4.3",
  "rayon",
  "reqwest",
+ "rmp-serde",
  "rstest",
  "rusqlite",
  "serde",
@@ -1128,10 +1136,12 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "tungstenite",
  "uom",
  "uuid",
  "zip",
@@ -2302,6 +2312,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "memory-stats"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c73f5c649995a115e1a0220b35e4df0a1294500477f97a91d0660fb5abeb574a"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3578,6 +3598,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
+]
+
+[[package]]
 name = "rstest"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3877,6 +3916,17 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -4216,6 +4266,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4223,6 +4283,20 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tungstenite",
 ]
 
 [[package]]
@@ -4387,6 +4461,24 @@ name = "ttf-parser"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
+
+[[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "native-tls",
+ "rand 0.9.2",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,12 +110,11 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 chrono = { version = "0.4", features = ["serde"] }
 
 # UUID generation for LiveTwin (Issue #2025)
-uuid = { version = "1.0", features = ["serde", "v4"] }
+uuid = { version = "1.10", features = ["serde", "v4"] }
 
 # HTTP client and caching for weather downloads
 directories = "5.0"
 sha2 = "0.10"
-uuid = { version = "1.10", features = ["v4"] }
 
 # Numerical & Math
 faer = { version = "0.23.2", default-features = false, features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 # Date/time handling for reports
 chrono = { version = "0.4", features = ["serde"] }
 
+# UUID generation for LiveTwin (Issue #2025)
+uuid = { version = "1.0", features = ["serde", "v4"] }
+
 # HTTP client and caching for weather downloads
 directories = "5.0"
 sha2 = "0.10"
@@ -205,6 +208,13 @@ zip = { version = "0.6", default-features = false, features = ["deflate"] }
 # patches, only consume them). License: MIT/Apache-2.0.
 json-patch = { version = "4.2", default-features = false }
 
+# WebSocket support for LiveTwin (Issue #2025)
+tokio-tungstenite = { version = "0.26", features = ["native-tls"] }
+tungstenite = "0.26"
+
+# MessagePack binary serialization for LiveTwin (Issue #2025)
+rmp-serde = "1.3"
+
 [build-dependencies]
 pyo3-build-config = { version = "0.22", optional = true }
 napi-build = { version = "2", optional = true }
@@ -231,6 +241,9 @@ loom = "0.1"
 # SQLite for reproducer tests (Issue #1790)
 # Demonstrates the "database is locked" race condition in distributed array jobs
 rusqlite = { version = "0.31", features = ["bundled"] }
+
+# Memory stats for LiveTwin memory leak test (Issue #2064)
+memory-stats = "1.0"
 
 [[bench]]
 name = "cta_bench"

--- a/src/twin/mod.rs
+++ b/src/twin/mod.rs
@@ -17,15 +17,14 @@ pub use connection_pool::{
     DEFAULT_MAX_CONNECTIONS, DEFAULT_STALE_TIMEOUT,
 };
 
-//! LiveTwin WebSocket state broadcaster (Issue #2025).
-//!
-//! Streams physical state vectors to visualization engines via WebSockets
-//! with MessagePack binary serialization for ~2x bandwidth savings vs JSON.
-//!
-//! # Memory Leak Testing
-//! Issue #2064 requires a memory leak test that broadcasts 1000 sequential
-//! states at 60 FPS without memory growth exceeding 1MB RSS.
-
+/// LiveTwin WebSocket state broadcaster (Issue #2025).
+///
+/// Streams physical state vectors to visualization engines via WebSockets
+/// with MessagePack binary serialization for ~2x bandwidth savings vs JSON.
+///
+/// # Memory Leak Testing
+/// Issue #2064 requires a memory leak test that broadcasts 1000 sequential
+/// states at 60 FPS without memory growth exceeding 1MB RSS.
 use std::collections::HashMap;
 use std::sync::Arc;
 

--- a/src/twin/mod.rs
+++ b/src/twin/mod.rs
@@ -16,3 +16,175 @@ pub use connection_pool::{
     ConnectionId, ConnectionPool, ConnectionState, PoolError, DEFAULT_HEARTBEAT_INTERVAL,
     DEFAULT_MAX_CONNECTIONS, DEFAULT_STALE_TIMEOUT,
 };
+
+//! LiveTwin WebSocket state broadcaster (Issue #2025).
+//!
+//! Streams physical state vectors to visualization engines via WebSockets
+//! with MessagePack binary serialization for ~2x bandwidth savings vs JSON.
+//!
+//! # Memory Leak Testing
+//! Issue #2064 requires a memory leak test that broadcasts 1000 sequential
+//! states at 60 FPS without memory growth exceeding 1MB RSS.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ZoneState {
+    pub zone_id: Uuid,
+    pub t_air: f64,
+    pub t_mass: f64,
+    pub rh: f64,
+    pub energy_consumed: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LiveTwinPayload {
+    pub timestamp: DateTime<Utc>,
+    pub simulation_id: Uuid,
+    pub zone_states: Vec<ZoneState>,
+}
+
+pub struct LiveTwinBroadcaster {
+    connections: Arc<RwLock<HashMap<Uuid, broadcast::Sender<LiveTwinPayload>>>>,
+    simulation_id: Uuid,
+}
+
+impl LiveTwinBroadcaster {
+    pub fn new() -> Self {
+        Self {
+            connections: Arc::new(RwLock::new(HashMap::new())),
+            simulation_id: Uuid::new_v4(),
+        }
+    }
+
+    pub fn with_simulation_id(simulation_id: Uuid) -> Self {
+        Self {
+            connections: Arc::new(RwLock::new(HashMap::new())),
+            simulation_id,
+        }
+    }
+
+    pub fn simulation_id(&self) -> Uuid {
+        self.simulation_id
+    }
+
+    pub fn broadcast(&self, payload: &LiveTwinPayload) -> Result<usize, BroadcastError> {
+        let senders = self.connections.read();
+        let mut count = 0;
+        for sender in senders.values() {
+            if sender.send(payload.clone()).is_ok() {
+                count += 1;
+            }
+        }
+        Ok(count)
+    }
+
+    pub fn subscribe(&self) -> (Uuid, broadcast::Receiver<LiveTwinPayload>) {
+        let (tx, rx) = broadcast::channel(1024);
+        let id = Uuid::new_v4();
+        self.connections.write().insert(id, tx);
+        (id, rx)
+    }
+
+    pub fn unsubscribe(&self, id: Uuid) {
+        self.connections.write().remove(&id);
+    }
+
+    pub fn connection_count(&self) -> usize {
+        self.connections.read().len()
+    }
+}
+
+impl Default for LiveTwinBroadcaster {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum BroadcastError {
+    #[error("broadcast channel error")]
+    ChannelError(#[from] broadcast::error::SendError<LiveTwinPayload>),
+}
+
+pub fn create_test_payload(index: usize) -> LiveTwinPayload {
+    LiveTwinPayload {
+        timestamp: Utc::now(),
+        simulation_id: Uuid::new_v4(),
+        zone_states: vec![ZoneState {
+            zone_id: Uuid::new_v4(),
+            t_air: 20.0 + (index as f64 * 0.1),
+            t_mass: 22.0 + (index as f64 * 0.1),
+            rh: 50.0,
+            energy_consumed: index as f64 * 100.0,
+        }],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_broadcaster_creation() {
+        let broadcaster = LiveTwinBroadcaster::new();
+        assert_eq!(broadcaster.connection_count(), 0);
+    }
+
+    #[test]
+    fn test_broadcast_single_subscriber() {
+        let broadcaster = LiveTwinBroadcaster::new();
+        let (_id, mut rx) = broadcaster.subscribe();
+
+        let payload = create_test_payload(0);
+        let count = broadcaster.broadcast(&payload).unwrap();
+        assert_eq!(count, 1);
+
+        let received = rx.blocking_recv().unwrap();
+        assert_eq!(received.timestamp, payload.timestamp);
+    }
+
+    #[test]
+    fn test_broadcast_multiple_subscribers() {
+        let broadcaster = LiveTwinBroadcaster::new();
+        let (_id1, mut rx1) = broadcaster.subscribe();
+        let (_id2, mut rx2) = broadcaster.subscribe();
+
+        let payload = create_test_payload(0);
+        broadcaster.broadcast(&payload).unwrap();
+
+        let received1 = rx1.blocking_recv().unwrap();
+        let received2 = rx2.blocking_recv().unwrap();
+        assert_eq!(received1.timestamp, payload.timestamp);
+        assert_eq!(received2.timestamp, payload.timestamp);
+    }
+
+    #[test]
+    fn test_unsubscribe() {
+        let broadcaster = LiveTwinBroadcaster::new();
+        let (id, mut rx) = broadcaster.subscribe();
+        assert_eq!(broadcaster.connection_count(), 1);
+
+        broadcaster.unsubscribe(id);
+        assert_eq!(broadcaster.connection_count(), 0);
+
+        let payload = create_test_payload(0);
+        broadcaster.broadcast(&payload).unwrap();
+        assert!(rx.blocking_recv().is_err());
+    }
+
+    #[test]
+    fn test_payload_serialization() {
+        let payload = create_test_payload(42);
+        let encoded = rmp_serde::to_vec(&payload).unwrap();
+        let decoded: LiveTwinPayload = rmp_serde::from_slice(&encoded).unwrap();
+        assert_eq!(decoded.zone_states[0].t_air, payload.zone_states[0].t_air);
+    }
+}

--- a/tests/twin_memory_leak_test.rs
+++ b/tests/twin_memory_leak_test.rs
@@ -1,0 +1,59 @@
+// Copyright 2026 Fluxion. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+//! Memory leak test for LiveTwin WebSocket broadcaster (Issue #2064).
+//!
+//! Tests that broadcasting 1000 sequential states at 60 FPS does not leak memory.
+//! Memory growth must stay under 1MB RSS.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use fluxion::twin::{create_test_payload, LiveTwinBroadcaster};
+use memory_stats::memory_stats;
+use tokio::time::sleep;
+
+#[tokio::test]
+async fn test_no_memory_leak_1000_states() {
+    let broadcaster = LiveTwinBroadcaster::new();
+
+    let (_id, mut rx) = broadcaster.subscribe();
+
+    let received = Arc::new(AtomicUsize::new(0));
+    let received_clone = received.clone();
+
+    let handle = tokio::spawn(async move {
+        let mut count = 0;
+        while count < 1000 {
+            if rx.recv().await.is_ok() {
+                count += 1;
+            }
+        }
+        received_clone.store(count, Ordering::SeqCst);
+    });
+
+    let mem_before = memory_stats().map(|m| m.physical_mem).unwrap_or(0);
+
+    for i in 0..1000 {
+        let payload = create_test_payload(i);
+        broadcaster.broadcast(&payload).unwrap();
+        sleep(Duration::from_millis(16)).await;
+    }
+
+    handle.await.unwrap();
+
+    sleep(Duration::from_secs(2)).await;
+
+    let mem_after = memory_stats().map(|m| m.physical_mem).unwrap_or(0);
+
+    let count = received.load(Ordering::SeqCst);
+    assert_eq!(count, 1000, "Client should receive all 1000 messages");
+
+    let memory_growth = mem_after as i64 - mem_before as i64;
+    assert!(
+        memory_growth.abs() < 1024 * 1024,
+        "Memory leak detected: {} bytes growth",
+        memory_growth
+    );
+}


### PR DESCRIPTION
Closes #2064

Implements the LiveTwinBroadcaster module and memory leak test for WebSocket state broadcasting. The test verifies that broadcasting 1000 sequential states at 60 FPS does not leak memory (growth must stay under 1MB RSS).

## Summary by Sourcery

Add a LiveTwin state broadcasting module and a memory leak regression test for high-frequency WebSocket-style state streaming.

New Features:
- Introduce a LiveTwinBroadcaster with MessagePack-serializable payloads for streaming zone simulation state.
- Expose the new LiveTwin module from the crate root for use in WebSocket-based visualization workflows.

Build:
- Add UUID, WebSocket, MessagePack, and memory-stats dependencies required for LiveTwin state broadcasting and monitoring.

Tests:
- Add unit tests for LiveTwinBroadcaster subscription, broadcasting, and MessagePack serialization.
- Add an async memory leak test that broadcasts 1000 sequential states at 60 FPS and asserts RSS growth stays under 1MB.