### PR TITLE
feat(behavior): resolve #2049 — Mock Plug Load Fallback with Diurnal Gaussian Noise

### DIFF
--- a/fluxion-behavior/Cargo.toml
+++ b/fluxion-behavior/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/anchapin/fluxion"
 
 [dependencies]
 ort = { version = "2.0.0-rc.10", features = ["download-binaries"], optional = true }
-rand = "0.8"
+rand = { version = "0.8", features = ["small_rng"] }
 rand_distr = "0.4"
 thiserror = "1.0"
 anyhow = "1.0"

--- a/fluxion-behavior/src/lib.rs
+++ b/fluxion-behavior/src/lib.rs
@@ -240,6 +240,9 @@ mod tsfm_engine {
 
 pub use tsfm_engine::TsfmInferenceEngine;
 
+mod plug_loads;
+pub use plug_loads::MockPlugLoadGenerator;
+
 pub struct OnnxModelLoader {
     model_path: Option<PathBuf>,
     backend: String,

--- a/fluxion-behavior/src/plug_loads.rs
+++ b/fluxion-behavior/src/plug_loads.rs
@@ -1,10 +1,16 @@
+use rand::prelude::*;
+use rand::rngs::SmallRng;
+use rand_distr::{Distribution, Normal};
 use serde::{Deserialize, Serialize};
+use std::f64::consts::PI;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[allow(dead_code)]
 pub struct MockPlugLoad {
     pub power_w: f64,
 }
 
+#[allow(dead_code)]
 impl MockPlugLoad {
     pub fn new(power_w: f64) -> Self {
         Self { power_w }
@@ -26,5 +32,151 @@ impl MockPlugLoad {
 impl Default for MockPlugLoad {
     fn default() -> Self {
         Self::new(50.0)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MockPlugLoadGenerator {
+    base_watts: f64,
+    diurnal_amplitude: f64,
+    noise_std: f64,
+    rng: SmallRng,
+}
+
+impl MockPlugLoadGenerator {
+    pub fn new() -> Self {
+        Self {
+            base_watts: 200.0,
+            diurnal_amplitude: 150.0,
+            noise_std: 30.0,
+            rng: SmallRng::from_entropy(),
+        }
+    }
+
+    pub fn with_params(base_watts: f64, diurnal_amplitude: f64, noise_std: f64) -> Self {
+        Self {
+            base_watts,
+            diurnal_amplitude,
+            noise_std,
+            rng: SmallRng::from_entropy(),
+        }
+    }
+
+    pub fn generate_24hr(&mut self, seed: u64) -> Vec<f64> {
+        self.rng = SmallRng::seed_from_u64(seed);
+        (0..24)
+            .map(|hour| {
+                let diurnal = self.diurnal_amplitude * Self::diurnal_factor(hour);
+                let normal = Normal::new(0.0, self.noise_std).unwrap();
+                let noise = normal.sample(&mut self.rng);
+                (self.base_watts + diurnal + noise).max(0.0)
+            })
+            .collect()
+    }
+
+    pub fn generate_at_hour(&mut self, hour: u8, seed: u64) -> f64 {
+        self.rng = SmallRng::seed_from_u64(seed);
+        let diurnal = self.diurnal_amplitude * Self::diurnal_factor(hour);
+        let normal = Normal::new(0.0, self.noise_std).unwrap();
+        let noise = normal.sample(&mut self.rng);
+        (self.base_watts + diurnal + noise).max(0.0)
+    }
+
+    fn diurnal_factor(hour: u8) -> f64 {
+        let peak_hour = 14.0;
+        let phase = (hour as f64 - peak_hour) * PI / 12.0;
+        phase.cos()
+    }
+
+    pub fn base_watts(&self) -> f64 {
+        self.base_watts
+    }
+
+    pub fn diurnal_amplitude(&self) -> f64 {
+        self.diurnal_amplitude
+    }
+
+    pub fn noise_std(&self) -> f64 {
+        self.noise_std
+    }
+}
+
+impl Default for MockPlugLoadGenerator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_diurnal_factor_2pm_peak() {
+        let peak = MockPlugLoadGenerator::diurnal_factor(14);
+        assert!((peak - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_diurnal_factor_4am() {
+        let val = MockPlugLoadGenerator::diurnal_factor(4);
+        let expected = ((4.0 - 14.0) * PI / 12.0).cos();
+        assert!((val - expected).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_diurnal_factor_symmetry() {
+        let peak = MockPlugLoadGenerator::diurnal_factor(14);
+        assert!((peak - 1.0).abs() < 1e-10);
+        let val_at_4 = MockPlugLoadGenerator::diurnal_factor(4);
+        let val_at_24 = MockPlugLoadGenerator::diurnal_factor(24);
+        assert!((val_at_4 - val_at_24).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_generate_24hr_length() {
+        let mut generator = MockPlugLoadGenerator::new();
+        let values = generator.generate_24hr(42);
+        assert_eq!(values.len(), 24);
+    }
+
+    #[test]
+    fn test_generate_24hr_positive() {
+        let mut generator = MockPlugLoadGenerator::new();
+        let values = generator.generate_24hr(42);
+        assert!(values.iter().all(|&v| v >= 0.0));
+    }
+
+    #[test]
+    fn test_generate_24hr_reproducible() {
+        let mut generator1 = MockPlugLoadGenerator::new();
+        let mut generator2 = MockPlugLoadGenerator::new();
+        let values1 = generator1.generate_24hr(12345);
+        let values2 = generator2.generate_24hr(12345);
+        assert_eq!(values1, values2);
+    }
+
+    #[test]
+    fn test_generate_24hr_different_seeds_different_results() {
+        let mut generator1 = MockPlugLoadGenerator::new();
+        let mut generator2 = MockPlugLoadGenerator::new();
+        let values1 = generator1.generate_24hr(111);
+        let values2 = generator2.generate_24hr(222);
+        assert_ne!(values1, values2);
+    }
+
+    #[test]
+    fn test_generate_at_hour() {
+        let mut generator = MockPlugLoadGenerator::new();
+        let power = generator.generate_at_hour(14, 42);
+        assert!(power >= 0.0);
+    }
+
+    #[test]
+    fn test_with_params() {
+        let generator = MockPlugLoadGenerator::with_params(300.0, 100.0, 20.0);
+        assert_eq!(generator.base_watts(), 300.0);
+        assert_eq!(generator.diurnal_amplitude(), 100.0);
+        assert_eq!(generator.noise_std(), 20.0);
     }
 }


### PR DESCRIPTION
Closes #2049

Implements MockPlugLoadGenerator with diurnal Gaussian noise for synthetic plug-load generation when ONNX model is unavailable. Includes: cosine-based diurnal envelope peaking at 2 PM, Gaussian noise with configurable std, reproducible seed-based generation, and always-positive output clamping.

## Summary by Sourcery

Introduce a configurable mock plug-load generator with diurnal Gaussian noise to provide synthetic plug-load profiles when the main inference model is unavailable.

New Features:
- Add MockPlugLoadGenerator for generating 24-hour plug-load profiles with cosine-based diurnal variation peaking at 2 PM and Gaussian noise.
- Expose MockPlugLoadGenerator from the crate for external use with default and parameterized constructors.

Build:
- Enable the rand crate small_rng feature to support SmallRng-based random generation.

Tests:
- Add unit tests covering diurnal envelope shape, reproducibility and variability of seeded noise, positivity of generated loads, and parameter accessors.