### PR TITLE
feat(toon): resolve #2072 — Integrate TOON into fluxion-mcp Tool Response Pipelines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1229,6 +1229,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "fluxion",
+ "fluxion-toon",
  "serde",
  "serde_json",
  "tempfile",

--- a/fluxion-mcp/Cargo.toml
+++ b/fluxion-mcp/Cargo.toml
@@ -13,6 +13,9 @@ categories = ["simulation", "scientific", "api-bindings"]
 # Fluxion core
 fluxion = { path = "..", features = ["multi-zone"] }
 
+# TOON serialization (Issue #2072)
+fluxion-toon = { path = "../crates/fluxion-toon" }
+
 # Async runtime
 tokio = { version = "1.40", features = ["full"], default-features = false }
 

--- a/fluxion-mcp/src/main.rs
+++ b/fluxion-mcp/src/main.rs
@@ -119,9 +119,8 @@ fn process_request(request: JsonRpcRequest, state: &RefCell<McpState>) -> JsonRp
                 serde_json::json!({ "_toon": result_str })
             } else {
                 // Parse JSON string back to Value for consistent structure
-                serde_json::from_str(&result_str).unwrap_or_else(|_| {
-                    serde_json::json!({ "raw": result_str })
-                })
+                serde_json::from_str(&result_str)
+                    .unwrap_or_else(|_| serde_json::json!({ "raw": result_str }))
             };
             JsonRpcResponse {
                 jsonrpc: "2.0".into(),

--- a/fluxion-mcp/src/main.rs
+++ b/fluxion-mcp/src/main.rs
@@ -112,11 +112,21 @@ fn process_request(request: JsonRpcRequest, state: &RefCell<McpState>) -> JsonRp
         "tools/call" => {
             let params = request.params.unwrap_or(serde_json::Value::Null);
             let mut state_guard = state.borrow_mut();
-            let result = tools::handle_tool_call(&mut state_guard, params);
+            let result_str = tools::handle_tool_call(&mut state_guard, params);
+            // The result string is already formatted (JSON or TOON)
+            // Wrap it as a JSON Value (String for TOON, Object for JSON parsed back)
+            let result_value: serde_json::Value = if result_str.starts_with("toon:v1") {
+                serde_json::json!({ "_toon": result_str })
+            } else {
+                // Parse JSON string back to Value for consistent structure
+                serde_json::from_str(&result_str).unwrap_or_else(|_| {
+                    serde_json::json!({ "raw": result_str })
+                })
+            };
             JsonRpcResponse {
                 jsonrpc: "2.0".into(),
                 id,
-                result: Some(result),
+                result: Some(result_value),
                 error: None,
             }
         }

--- a/fluxion-mcp/src/tools.rs
+++ b/fluxion-mcp/src/tools.rs
@@ -29,6 +29,16 @@ impl ResponseFormat {
     }
 }
 
+/// Format a serializable value to the specified format string.
+/// TOON format uses `fluxion_toon::to_string()` for compact LLM-friendly output.
+/// Falls back to JSON on serialization error.
+fn format_response<T: serde::Serialize>(value: &T, format: &str) -> String {
+    match format {
+        "toon" => fluxion_toon::to_string(value).unwrap_or_else(|_| serde_json::to_string(value).unwrap()),
+        _ => serde_json::to_string(value).unwrap(),
+    }
+}
+
 /// Serialize JSON value to TOON (compact binary-like format)
 /// TOON uses a compact representation: arrays as comma-separated,
 /// objects as key:value pairs with minimal whitespace
@@ -342,7 +352,7 @@ pub fn list_tools() -> Vec<serde_json::Value> {
     ]
 }
 
-pub fn handle_tool_call(state: &mut McpState, params: Value) -> Value {
+pub fn handle_tool_call(state: &mut McpState, params: Value) -> String {
     let arguments = params.as_object().cloned().unwrap_or_default();
 
     let method = arguments.get("name").and_then(|v| v.as_str()).unwrap_or("");
@@ -383,15 +393,11 @@ pub fn handle_tool_call(state: &mut McpState, params: Value) -> Value {
 }
 
 /// Wrap response with format metadata for content-negotiation
-fn wrap_response(result: &Value, format: ResponseFormat) -> Value {
+fn wrap_response(result: &Value, format: ResponseFormat) -> String {
     match format {
-        ResponseFormat::Json => result.clone(),
+        ResponseFormat::Json => serde_json::to_string(result).unwrap(),
         ResponseFormat::Toon => {
-            serde_json::json!({
-                "format": "application/x-toon",
-                "data": result,
-                "_toon": serialize_to_toon(result)
-            })
+            format_response(result, "toon")
         }
     }
 }

--- a/fluxion-mcp/src/tools.rs
+++ b/fluxion-mcp/src/tools.rs
@@ -34,7 +34,9 @@ impl ResponseFormat {
 /// Falls back to JSON on serialization error.
 fn format_response<T: serde::Serialize>(value: &T, format: &str) -> String {
     match format {
-        "toon" => fluxion_toon::to_string(value).unwrap_or_else(|_| serde_json::to_string(value).unwrap()),
+        "toon" => {
+            fluxion_toon::to_string(value).unwrap_or_else(|_| serde_json::to_string(value).unwrap())
+        }
         _ => serde_json::to_string(value).unwrap(),
     }
 }
@@ -396,9 +398,7 @@ pub fn handle_tool_call(state: &mut McpState, params: Value) -> String {
 fn wrap_response(result: &Value, format: ResponseFormat) -> String {
     match format {
         ResponseFormat::Json => serde_json::to_string(result).unwrap(),
-        ResponseFormat::Toon => {
-            format_response(result, "toon")
-        }
+        ResponseFormat::Toon => format_response(result, "toon"),
     }
 }
 


### PR DESCRIPTION
Closes #2072

Integrates TOON (Token-Oriented Object Notation) encoding into fluxion-mcp tool response pipelines. When a tool is called with format parameter set to 'toon', the response data is encoded using fluxion-toon::to_string() which produces a compact LLM-friendly format with 'toon:v1' header prefix, reducing token usage by 35-50% for simulation result feeds.

Changes:
- Added fluxion-toon as a dependency to fluxion-mcp
- Added format_response() helper function for format-aware serialization
- Updated handle_tool_call() to return String for proper content negotiation
- Updated wrap_response() to use fluxion_toon::to_string() when format is 'toon'
- Updated main.rs to properly handle TOON-formatted responses in JSON-RPC wrapper

## Summary by Sourcery

Integrate TOON encoding into fluxion-mcp tool response handling with format-aware serialization and JSON-RPC wrapping.

New Features:
- Support TOON-formatted tool responses via a new format-aware serialization helper and response wrapper.

Enhancements:
- Change tool call handling to return serialized strings, enabling content negotiation between JSON and TOON formats.
- Update JSON-RPC request processing to correctly wrap and expose TOON-encoded responses in the RPC result envelope.

Build:
- Add fluxion-toon as a dependency for TOON serialization in fluxion-mcp.