### PR TITLE
perf(city): resolve #2034 — Parallel Harness Benchmark Suite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,6 +1181,7 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "serde",
+ "sysinfo",
  "thiserror 1.0.69",
 ]
 
@@ -1883,7 +1884,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2691,6 +2692,15 @@ dependencies = [
  "byteorder",
  "num-bigint",
  "py_literal",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -4216,6 +4226,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+dependencies = [
+ "cfg-if 1.0.4",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "windows",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4951,6 +4976,25 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-core"

--- a/fluxion-city/Cargo.toml
+++ b/fluxion-city/Cargo.toml
@@ -22,3 +22,4 @@ parallel = ["rayon"]
 [dev-dependencies]
 criterion = "0.5"
 rand = "0.8"
+sysinfo = "0.30"

--- a/fluxion-city/benches/parallel_harness.rs
+++ b/fluxion-city/benches/parallel_harness.rs
@@ -121,8 +121,7 @@ fn run_throughput_benchmark(c: &mut Criterion, building_counts: &[usize]) {
                     total_ms += start.elapsed().as_millis();
                 }
                 let avg_ms = total_ms as f64 / iters as f64;
-                let buildings_per_sec = (n as f64 / avg_ms) * 1000.0;
-                black_box(buildings_per_sec)
+                Duration::from_millis(avg_ms as u64)
             });
         });
     }
@@ -141,7 +140,6 @@ fn run_speedup_benchmark(c: &mut Criterion, building_counts: &[usize]) {
 
     for &n in building_counts {
         group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
-            let mut buildings_seq = make_buildings(n);
             let buildings_par = make_buildings(n);
             let mut dispatcher = UrbanStepDispatcher::with_buildings(buildings_par);
 

--- a/fluxion-city/src/lib.rs
+++ b/fluxion-city/src/lib.rs
@@ -1096,358 +1096,356 @@ mod tests {
         }
     }
 
+    // === Energy Conservation Tests (from #2031) ===
+    const STEFAN_BOLTZMANN: f64 = 5.67e-8;
 
-// === Energy Conservation Tests (from #2031) ===
-const STEFAN_BOLTZMANN: f64 = 5.67e-8;
-
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-pub struct BuildingConfig {
-    pub length: f64,
-    pub width: f64,
-    pub height: f64,
-    pub emissivity: f64,
-    pub absorptivity: f64,
-    pub thermal_conductance: f64,
-}
-
-impl BuildingConfig {
-    pub fn new(
-        length: f64,
-        width: f64,
-        height: f64,
-        emissivity: f64,
-        absorptivity: f64,
-        thermal_conductance: f64,
-    ) -> Self {
-        Self {
-            length,
-            width,
-            height,
-            emissivity,
-            absorptivity,
-            thermal_conductance,
-        }
+    #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+    pub struct BuildingConfig {
+        pub length: f64,
+        pub width: f64,
+        pub height: f64,
+        pub emissivity: f64,
+        pub absorptivity: f64,
+        pub thermal_conductance: f64,
     }
 
-    pub fn surface_area(&self) -> f64 {
-        2.0 * (self.length * self.width + self.length * self.height + self.width * self.height)
-    }
-
-    pub fn wall_area(&self) -> f64 {
-        2.0 * (self.length * self.height + self.width * self.height)
-    }
-
-    pub fn roof_area(&self) -> f64 {
-        self.length * self.width
-    }
-
-    pub fn floor_area(&self) -> f64 {
-        self.length * self.width
-    }
-}
-
-impl Default for BuildingConfig {
-    fn default() -> Self {
-        Self {
-            length: 10.0,
-            width: 10.0,
-            height: 3.0,
-            emissivity: 0.9,
-            absorptivity: 0.7,
-            thermal_conductance: 0.45,
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct SurfaceRadiation {
-    pub absorbed: f64,
-    pub emitted: f64,
-    pub transmitted: f64,
-    pub reflected: f64,
-}
-
-impl SurfaceRadiation {
-    pub fn new(absorbed: f64, emitted: f64, transmitted: f64, reflected: f64) -> Self {
-        Self {
-            absorbed,
-            emitted,
-            transmitted,
-            reflected,
-        }
-    }
-
-    pub fn net_radiation(&self) -> f64 {
-        self.absorbed - self.emitted - self.transmitted - self.reflected
-    }
-
-    pub fn is_conserved(&self, tolerance: f64) -> bool {
-        self.net_radiation().abs() < tolerance
-    }
-}
-
-pub struct EnergyConservationTest {
-    pub buildings: Vec<BuildingConfig>,
-    pub ambient_temperature: f64,
-    pub solar_irradiance: f64,
-    pub sky_temperature: f64,
-}
-
-impl Default for EnergyConservationTest {
-    fn default() -> Self {
-        Self {
-            buildings: Vec::new(),
-            ambient_temperature: 293.15,
-            solar_irradiance: 0.0,
-            sky_temperature: 270.0,
-        }
-    }
-}
-
-impl EnergyConservationTest {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn with_buildings(mut self, buildings: Vec<BuildingConfig>) -> Self {
-        self.buildings = buildings;
-        self
-    }
-
-    pub fn with_ambient_temperature(mut self, temperature: f64) -> Self {
-        self.ambient_temperature = temperature;
-        self
-    }
-
-    pub fn with_solar_irradiance(mut self, irradiance: f64) -> Self {
-        self.solar_irradiance = irradiance;
-        self
-    }
-
-    pub fn with_sky_temperature(mut self, temperature: f64) -> Self {
-        self.sky_temperature = temperature;
-        self
-    }
-
-    pub fn create_5_building_config() -> Self {
-        let building1 = BuildingConfig {
-            length: 10.0,
-            width: 10.0,
-            height: 3.0,
-            emissivity: 0.9,
-            absorptivity: 0.7,
-            thermal_conductance: 0.45,
-        };
-        let building2 = BuildingConfig {
-            length: 8.0,
-            width: 8.0,
-            height: 4.0,
-            emissivity: 0.85,
-            absorptivity: 0.6,
-            thermal_conductance: 0.40,
-        };
-        let building3 = BuildingConfig {
-            length: 12.0,
-            width: 6.0,
-            height: 3.5,
-            emissivity: 0.9,
-            absorptivity: 0.75,
-            thermal_conductance: 0.50,
-        };
-        let building4 = BuildingConfig {
-            length: 7.0,
-            width: 7.0,
-            height: 5.0,
-            emissivity: 0.88,
-            absorptivity: 0.65,
-            thermal_conductance: 0.42,
-        };
-        let building5 = BuildingConfig {
-            length: 9.0,
-            width: 11.0,
-            height: 3.0,
-            emissivity: 0.92,
-            absorptivity: 0.70,
-            thermal_conductance: 0.48,
-        };
-
-        Self {
-            buildings: vec![building1, building2, building3, building4, building5],
-            ambient_temperature: 293.15,
-            solar_irradiance: 500.0,
-            sky_temperature: 270.0,
-        }
-    }
-
-    fn net_balance_at_temperature(&self, building: &BuildingConfig, t_surface: f64) -> f64 {
-        let wall_area = building.wall_area();
-        let roof_area = building.roof_area();
-        let total_area = building.surface_area();
-
-        let absorbed_solar =
-            building.absorptivity * self.solar_irradiance * (wall_area + roof_area);
-
-        let emitted = building.emissivity * STEFAN_BOLTZMANN * total_area * t_surface.powi(4);
-
-        let transmitted =
-            building.thermal_conductance * total_area * (t_surface - self.ambient_temperature);
-
-        let sky_radiation = building.emissivity
-            * STEFAN_BOLTZMANN
-            * total_area
-            * (t_surface.powi(4) - self.sky_temperature.powi(4));
-
-        absorbed_solar - emitted - transmitted - sky_radiation
-    }
-
-    fn find_equilibrium_temperature(&self, building: &BuildingConfig) -> f64 {
-        let t_min = 200.0;
-        let t_max = 400.0;
-        let balance_tolerance = 1e-12;
-        let t_tolerance = 1e-14;
-        let max_iterations = 500;
-
-        let mut t_low = t_min;
-        let mut t_high = t_max;
-        let mut balance_low = self.net_balance_at_temperature(building, t_low);
-        let balance_high = self.net_balance_at_temperature(building, t_high);
-
-        if balance_low * balance_high > 0.0 {
-            if balance_low > 0.0 {
-                return t_min;
-            } else {
-                return t_max;
+    impl BuildingConfig {
+        pub fn new(
+            length: f64,
+            width: f64,
+            height: f64,
+            emissivity: f64,
+            absorptivity: f64,
+            thermal_conductance: f64,
+        ) -> Self {
+            Self {
+                length,
+                width,
+                height,
+                emissivity,
+                absorptivity,
+                thermal_conductance,
             }
         }
 
-        for _ in 0..max_iterations {
-            let t_mid = (t_low + t_high) / 2.0;
-            let balance_mid = self.net_balance_at_temperature(building, t_mid);
+        pub fn surface_area(&self) -> f64 {
+            2.0 * (self.length * self.width + self.length * self.height + self.width * self.height)
+        }
 
-            if balance_mid.abs() < balance_tolerance {
-                return t_mid;
+        pub fn wall_area(&self) -> f64 {
+            2.0 * (self.length * self.height + self.width * self.height)
+        }
+
+        pub fn roof_area(&self) -> f64 {
+            self.length * self.width
+        }
+
+        pub fn floor_area(&self) -> f64 {
+            self.length * self.width
+        }
+    }
+
+    impl Default for BuildingConfig {
+        fn default() -> Self {
+            Self {
+                length: 10.0,
+                width: 10.0,
+                height: 3.0,
+                emissivity: 0.9,
+                absorptivity: 0.7,
+                thermal_conductance: 0.45,
             }
+        }
+    }
 
-            if (t_high - t_low) < t_tolerance * t_low {
-                return t_mid;
-            }
+    #[derive(Debug, Clone)]
+    pub struct SurfaceRadiation {
+        pub absorbed: f64,
+        pub emitted: f64,
+        pub transmitted: f64,
+        pub reflected: f64,
+    }
 
-            if balance_low * balance_mid <= 0.0 {
-                t_high = t_mid;
-            } else {
-                t_low = t_mid;
-                balance_low = balance_mid;
+    impl SurfaceRadiation {
+        pub fn new(absorbed: f64, emitted: f64, transmitted: f64, reflected: f64) -> Self {
+            Self {
+                absorbed,
+                emitted,
+                transmitted,
+                reflected,
             }
         }
 
-        (t_low + t_high) / 2.0
+        pub fn net_radiation(&self) -> f64 {
+            self.absorbed - self.emitted - self.transmitted - self.reflected
+        }
+
+        pub fn is_conserved(&self, tolerance: f64) -> bool {
+            self.net_radiation().abs() < tolerance
+        }
     }
 
-    pub fn surface_radiation_balance(&self, building_index: usize) -> Option<SurfaceRadiation> {
-        let building = self.buildings.get(building_index)?;
-
-        let wall_area = building.wall_area();
-        let roof_area = building.roof_area();
-        let total_area = building.surface_area();
-
-        let absorbed_solar =
-            building.absorptivity * self.solar_irradiance * (wall_area + roof_area);
-
-        let t_eq = self.find_equilibrium_temperature(building);
-
-        let emitted = building.emissivity * STEFAN_BOLTZMANN * total_area * t_eq.powi(4);
-
-        let transmitted =
-            building.thermal_conductance * total_area * (t_eq - self.ambient_temperature);
-
-        let sky_radiation = building.emissivity
-            * STEFAN_BOLTZMANN
-            * total_area
-            * (t_eq.powi(4) - self.sky_temperature.powi(4));
-
-        Some(SurfaceRadiation::new(
-            absorbed_solar,
-            emitted + sky_radiation,
-            transmitted,
-            0.0,
-        ))
+    pub struct EnergyConservationTest {
+        pub buildings: Vec<BuildingConfig>,
+        pub ambient_temperature: f64,
+        pub solar_irradiance: f64,
+        pub sky_temperature: f64,
     }
 
-    pub fn verify_conservation(&self) -> bool {
-        let imbalance = self.max_imbalance();
-        imbalance < 1e-6
+    impl Default for EnergyConservationTest {
+        fn default() -> Self {
+            Self {
+                buildings: Vec::new(),
+                ambient_temperature: 293.15,
+                solar_irradiance: 0.0,
+                sky_temperature: 270.0,
+            }
+        }
     }
 
-    pub fn max_imbalance(&self) -> f64 {
-        let mut max_imbalance = 0.0f64;
+    impl EnergyConservationTest {
+        pub fn new() -> Self {
+            Self::default()
+        }
 
-        for building in &self.buildings {
-            if let Some(radiation) = self.surface_radiation_balance_for_building(building) {
-                let imbalance = radiation.net_radiation().abs();
-                if imbalance > max_imbalance {
-                    max_imbalance = imbalance;
+        pub fn with_buildings(mut self, buildings: Vec<BuildingConfig>) -> Self {
+            self.buildings = buildings;
+            self
+        }
+
+        pub fn with_ambient_temperature(mut self, temperature: f64) -> Self {
+            self.ambient_temperature = temperature;
+            self
+        }
+
+        pub fn with_solar_irradiance(mut self, irradiance: f64) -> Self {
+            self.solar_irradiance = irradiance;
+            self
+        }
+
+        pub fn with_sky_temperature(mut self, temperature: f64) -> Self {
+            self.sky_temperature = temperature;
+            self
+        }
+
+        pub fn create_5_building_config() -> Self {
+            let building1 = BuildingConfig {
+                length: 10.0,
+                width: 10.0,
+                height: 3.0,
+                emissivity: 0.9,
+                absorptivity: 0.7,
+                thermal_conductance: 0.45,
+            };
+            let building2 = BuildingConfig {
+                length: 8.0,
+                width: 8.0,
+                height: 4.0,
+                emissivity: 0.85,
+                absorptivity: 0.6,
+                thermal_conductance: 0.40,
+            };
+            let building3 = BuildingConfig {
+                length: 12.0,
+                width: 6.0,
+                height: 3.5,
+                emissivity: 0.9,
+                absorptivity: 0.75,
+                thermal_conductance: 0.50,
+            };
+            let building4 = BuildingConfig {
+                length: 7.0,
+                width: 7.0,
+                height: 5.0,
+                emissivity: 0.88,
+                absorptivity: 0.65,
+                thermal_conductance: 0.42,
+            };
+            let building5 = BuildingConfig {
+                length: 9.0,
+                width: 11.0,
+                height: 3.0,
+                emissivity: 0.92,
+                absorptivity: 0.70,
+                thermal_conductance: 0.48,
+            };
+
+            Self {
+                buildings: vec![building1, building2, building3, building4, building5],
+                ambient_temperature: 293.15,
+                solar_irradiance: 500.0,
+                sky_temperature: 270.0,
+            }
+        }
+
+        fn net_balance_at_temperature(&self, building: &BuildingConfig, t_surface: f64) -> f64 {
+            let wall_area = building.wall_area();
+            let roof_area = building.roof_area();
+            let total_area = building.surface_area();
+
+            let absorbed_solar =
+                building.absorptivity * self.solar_irradiance * (wall_area + roof_area);
+
+            let emitted = building.emissivity * STEFAN_BOLTZMANN * total_area * t_surface.powi(4);
+
+            let transmitted =
+                building.thermal_conductance * total_area * (t_surface - self.ambient_temperature);
+
+            let sky_radiation = building.emissivity
+                * STEFAN_BOLTZMANN
+                * total_area
+                * (t_surface.powi(4) - self.sky_temperature.powi(4));
+
+            absorbed_solar - emitted - transmitted - sky_radiation
+        }
+
+        fn find_equilibrium_temperature(&self, building: &BuildingConfig) -> f64 {
+            let t_min = 200.0;
+            let t_max = 400.0;
+            let balance_tolerance = 1e-12;
+            let t_tolerance = 1e-14;
+            let max_iterations = 500;
+
+            let mut t_low = t_min;
+            let mut t_high = t_max;
+            let mut balance_low = self.net_balance_at_temperature(building, t_low);
+            let balance_high = self.net_balance_at_temperature(building, t_high);
+
+            if balance_low * balance_high > 0.0 {
+                if balance_low > 0.0 {
+                    return t_min;
+                } else {
+                    return t_max;
                 }
             }
-        }
 
-        max_imbalance
-    }
+            for _ in 0..max_iterations {
+                let t_mid = (t_low + t_high) / 2.0;
+                let balance_mid = self.net_balance_at_temperature(building, t_mid);
 
-    pub fn all_surfaces_balanced(&self, tolerance: f64) -> bool {
-        for (i, _) in self.buildings.iter().enumerate() {
-            if let Some(radiation) = self.surface_radiation_balance(i) {
-                if !radiation.is_conserved(tolerance) {
-                    return false;
+                if balance_mid.abs() < balance_tolerance {
+                    return t_mid;
+                }
+
+                if (t_high - t_low) < t_tolerance * t_low {
+                    return t_mid;
+                }
+
+                if balance_low * balance_mid <= 0.0 {
+                    t_high = t_mid;
+                } else {
+                    t_low = t_mid;
+                    balance_low = balance_mid;
                 }
             }
+
+            (t_low + t_high) / 2.0
         }
-        true
-    }
 
-    pub fn net_radiation_for_enclosed_surfaces(&self) -> f64 {
-        let mut total_net = 0.0;
+        pub fn surface_radiation_balance(&self, building_index: usize) -> Option<SurfaceRadiation> {
+            let building = self.buildings.get(building_index)?;
 
-        for building in &self.buildings {
-            if let Some(radiation) = self.surface_radiation_balance_for_building(building) {
-                total_net += radiation.net_radiation();
+            let wall_area = building.wall_area();
+            let roof_area = building.roof_area();
+            let total_area = building.surface_area();
+
+            let absorbed_solar =
+                building.absorptivity * self.solar_irradiance * (wall_area + roof_area);
+
+            let t_eq = self.find_equilibrium_temperature(building);
+
+            let emitted = building.emissivity * STEFAN_BOLTZMANN * total_area * t_eq.powi(4);
+
+            let transmitted =
+                building.thermal_conductance * total_area * (t_eq - self.ambient_temperature);
+
+            let sky_radiation = building.emissivity
+                * STEFAN_BOLTZMANN
+                * total_area
+                * (t_eq.powi(4) - self.sky_temperature.powi(4));
+
+            Some(SurfaceRadiation::new(
+                absorbed_solar,
+                emitted + sky_radiation,
+                transmitted,
+                0.0,
+            ))
+        }
+
+        pub fn verify_conservation(&self) -> bool {
+            let imbalance = self.max_imbalance();
+            imbalance < 1e-6
+        }
+
+        pub fn max_imbalance(&self) -> f64 {
+            let mut max_imbalance = 0.0f64;
+
+            for building in &self.buildings {
+                if let Some(radiation) = self.surface_radiation_balance_for_building(building) {
+                    let imbalance = radiation.net_radiation().abs();
+                    if imbalance > max_imbalance {
+                        max_imbalance = imbalance;
+                    }
+                }
             }
+
+            max_imbalance
         }
 
-        total_net
+        pub fn all_surfaces_balanced(&self, tolerance: f64) -> bool {
+            for (i, _) in self.buildings.iter().enumerate() {
+                if let Some(radiation) = self.surface_radiation_balance(i) {
+                    if !radiation.is_conserved(tolerance) {
+                        return false;
+                    }
+                }
+            }
+            true
+        }
+
+        pub fn net_radiation_for_enclosed_surfaces(&self) -> f64 {
+            let mut total_net = 0.0;
+
+            for building in &self.buildings {
+                if let Some(radiation) = self.surface_radiation_balance_for_building(building) {
+                    total_net += radiation.net_radiation();
+                }
+            }
+
+            total_net
+        }
+
+        fn surface_radiation_balance_for_building(
+            &self,
+            building: &BuildingConfig,
+        ) -> Option<SurfaceRadiation> {
+            let wall_area = building.wall_area();
+            let roof_area = building.roof_area();
+            let total_area = building.surface_area();
+
+            let absorbed_solar =
+                building.absorptivity * self.solar_irradiance * (wall_area + roof_area);
+
+            let t_eq = self.find_equilibrium_temperature(building);
+
+            let emitted = building.emissivity * STEFAN_BOLTZMANN * total_area * t_eq.powi(4);
+
+            let transmitted =
+                building.thermal_conductance * total_area * (t_eq - self.ambient_temperature);
+
+            let sky_radiation = building.emissivity
+                * STEFAN_BOLTZMANN
+                * total_area
+                * (t_eq.powi(4) - self.sky_temperature.powi(4));
+
+            Some(SurfaceRadiation::new(
+                absorbed_solar,
+                emitted + sky_radiation,
+                transmitted,
+                0.0,
+            ))
+        }
     }
-
-    fn surface_radiation_balance_for_building(
-        &self,
-        building: &BuildingConfig,
-    ) -> Option<SurfaceRadiation> {
-        let wall_area = building.wall_area();
-        let roof_area = building.roof_area();
-        let total_area = building.surface_area();
-
-        let absorbed_solar =
-            building.absorptivity * self.solar_irradiance * (wall_area + roof_area);
-
-        let t_eq = self.find_equilibrium_temperature(building);
-
-        let emitted = building.emissivity * STEFAN_BOLTZMANN * total_area * t_eq.powi(4);
-
-        let transmitted =
-            building.thermal_conductance * total_area * (t_eq - self.ambient_temperature);
-
-        let sky_radiation = building.emissivity
-            * STEFAN_BOLTZMANN
-            * total_area
-            * (t_eq.powi(4) - self.sky_temperature.powi(4));
-
-        Some(SurfaceRadiation::new(
-            absorbed_solar,
-            emitted + sky_radiation,
-            transmitted,
-            0.0,
-        ))
-    }
-}
-
 
     #[test]
     fn test_5_building_energy_conservation() {

--- a/fluxion-city/src/lib.rs
+++ b/fluxion-city/src/lib.rs
@@ -16,6 +16,7 @@
 //! This crate uses sparse matrix representations for efficient computation with
 //! urban radiation with many surfaces.
 
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -865,6 +866,13 @@ pub use nusselt::{
 };
 pub use sparse::{create_sparse_from_urban_canyon, SparseViewFactorMatrix, UrbanRadiationSolver};
 
+#[cfg(feature = "parallel")]
+pub mod parallel {
+    pub mod harness;
+}
+#[cfg(feature = "parallel")]
+pub use parallel::harness::{BuildingGroup, UrbanRadiationSystem, UrbanStepDispatcher};
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1087,7 +1095,7 @@ mod tests {
             assert!((row_sum - 1.0).abs() < 1e-10);
         }
     }
-}
+
 
 // === Energy Conservation Tests (from #2031) ===
 const STEFAN_BOLTZMANN: f64 = 5.67e-8;
@@ -1440,9 +1448,6 @@ impl EnergyConservationTest {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
 
     #[test]
     fn test_5_building_energy_conservation() {

--- a/fluxion-city/src/parallel/harness.rs
+++ b/fluxion-city/src/parallel/harness.rs
@@ -1,0 +1,288 @@
+//! Parallel Harness for Urban Building Simulation (Issue #2034)
+//!
+//! Thread-safe parallel execution of urban radiation/thermal simulations
+//! with configurable worker threads and memory-efficient building management.
+
+use std::time::Duration;
+
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
+
+const STEFAN_BOLTZMANN: f64 = 5.67e-8;
+
+#[derive(Debug, Clone)]
+pub struct BuildingGroup {
+    pub id: u32,
+    pub area: f64,
+    pub u_wall: f64,
+    pub u_roof: f64,
+    pub u_floor: f64,
+    pub temperature: f64,
+    pub outdoor_temperature: f64,
+    pub absorbed_solar: f64,
+    pub emitted_longwave: f64,
+}
+
+impl BuildingGroup {
+    pub fn new(id: u32) -> Self {
+        Self {
+            id,
+            area: 100.0,
+            u_wall: 0.5,
+            u_roof: 0.3,
+            u_floor: 2.0,
+            temperature: 293.15,
+            outdoor_temperature: 293.15,
+            absorbed_solar: 0.0,
+            emitted_longwave: 0.0,
+        }
+    }
+
+    pub fn with_area(mut self, area: f64) -> Self {
+        self.area = area;
+        self
+    }
+
+    pub fn with_u_values(mut self, u_wall: f64, u_roof: f64, u_floor: f64) -> Self {
+        self.u_wall = u_wall;
+        self.u_roof = u_roof;
+        self.u_floor = u_floor;
+        self
+    }
+
+    pub fn step(&mut self, dt: &Duration, radiation: &UrbanRadiationSystem, outdoor_temp: f64) {
+        let dt_hours = dt.as_secs_f64() / 3600.0;
+        let surface_area = self.area * 4.0;
+        let wall_area = surface_area * 0.8;
+        let roof_area = surface_area * 0.2;
+
+        let q_solar = radiation.solar_irradiance * self.area * radiation.absorptivity;
+        let q_sky = radiation.sky_temperature.powi(4) - self.temperature.powi(4);
+        let q_longwave = radiation.emissivity * STEFAN_BOLTZMANN * wall_area * q_sky;
+        let q_conduction_wall = self.u_wall * wall_area * (outdoor_temp - self.temperature);
+        let q_conduction_roof = self.u_roof * roof_area * (outdoor_temp - self.temperature);
+        let q_conduction_floor =
+            self.u_floor * (self.area * 0.1) * (self.outdoor_temperature - self.temperature);
+
+        let net_gain =
+            q_solar + q_longwave + q_conduction_wall + q_conduction_roof + q_conduction_floor;
+        let heat_capacity = self.area * 500.0 * 1005.0;
+
+        self.temperature += (net_gain / heat_capacity) * dt_hours;
+        self.temperature = self.temperature.max(200.0).min(400.0);
+        self.absorbed_solar = q_solar;
+        self.emitted_longwave = q_longwave;
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct UrbanRadiationSystem {
+    pub solar_irradiance: f64,
+    pub sky_temperature: f64,
+    pub emissivity: f64,
+    pub absorptivity: f64,
+    pub latitude: f64,
+    pub longitude: f64,
+}
+
+impl UrbanRadiationSystem {
+    pub fn new(
+        solar_irradiance: f64,
+        sky_temperature: f64,
+        emissivity: f64,
+        absorptivity: f64,
+        latitude: f64,
+        longitude: f64,
+    ) -> Self {
+        Self {
+            solar_irradiance,
+            sky_temperature,
+            emissivity,
+            absorptivity,
+            latitude,
+            longitude,
+        }
+    }
+}
+
+#[cfg(feature = "parallel")]
+#[derive(Debug, Clone)]
+pub struct UrbanStepDispatcher {
+    buildings: Vec<BuildingGroup>,
+    num_threads: usize,
+}
+
+#[cfg(feature = "parallel")]
+impl UrbanStepDispatcher {
+    pub fn with_buildings(buildings: Vec<BuildingGroup>) -> Self {
+        Self {
+            buildings,
+            num_threads: rayon::current_num_threads(),
+        }
+    }
+
+    pub fn with_threads(mut self, num_threads: usize) -> Self {
+        self.num_threads = num_threads;
+        self
+    }
+
+    pub fn num_buildings(&self) -> usize {
+        self.buildings.len()
+    }
+
+    pub fn step_all(&mut self, dt: Duration, radiation: &UrbanRadiationSystem, outdoor_temp: f64) {
+        let num_threads = self.num_threads;
+        let chunk_size = (self.buildings.len() / num_threads).max(1);
+
+        self.buildings.par_chunks_mut(chunk_size).for_each(|chunk| {
+            for building in chunk.iter_mut() {
+                building.step(&dt, radiation, outdoor_temp);
+            }
+        });
+    }
+
+    pub fn step_sequential(
+        &mut self,
+        dt: &Duration,
+        radiation: &UrbanRadiationSystem,
+        outdoor_temp: f64,
+    ) {
+        for building in self.buildings.iter_mut() {
+            building.step(dt, radiation, outdoor_temp);
+        }
+    }
+
+    pub fn get_buildings(&self) -> &[BuildingGroup] {
+        &self.buildings
+    }
+
+    pub fn set_num_threads(&mut self, num_threads: usize) {
+        self.num_threads = num_threads;
+    }
+}
+
+#[cfg(not(feature = "parallel"))]
+#[derive(Debug, Clone)]
+pub struct UrbanStepDispatcher {
+    buildings: Vec<BuildingGroup>,
+}
+
+#[cfg(not(feature = "parallel"))]
+impl UrbanStepDispatcher {
+    pub fn with_buildings(buildings: Vec<BuildingGroup>) -> Self {
+        Self { buildings }
+    }
+
+    pub fn with_threads(mut self, _num_threads: usize) -> Self {
+        self
+    }
+
+    pub fn num_buildings(&self) -> usize {
+        self.buildings.len()
+    }
+
+    pub fn step_all(&mut self, dt: Duration, radiation: &UrbanRadiationSystem, outdoor_temp: f64) {
+        for building in self.buildings.iter_mut() {
+            building.step(&dt, radiation, outdoor_temp);
+        }
+    }
+
+    pub fn step_sequential(
+        &mut self,
+        dt: &Duration,
+        radiation: &UrbanRadiationSystem,
+        outdoor_temp: f64,
+    ) {
+        self.step_all(dt, radiation, outdoor_temp);
+    }
+
+    pub fn get_buildings(&self) -> &[BuildingGroup] {
+        &self.buildings
+    }
+
+    pub fn set_num_threads(&mut self, _num_threads: usize) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_building_group_creation() {
+        let building = BuildingGroup::new(1);
+        assert_eq!(building.id, 1);
+        assert_eq!(building.area, 100.0);
+    }
+
+    #[test]
+    fn test_building_group_with_area() {
+        let building = BuildingGroup::new(1).with_area(200.0);
+        assert_eq!(building.area, 200.0);
+    }
+
+    #[test]
+    fn test_building_group_with_u_values() {
+        let building = BuildingGroup::new(1).with_u_values(0.3, 0.2, 1.5);
+        assert_eq!(building.u_wall, 0.3);
+        assert_eq!(building.u_roof, 0.2);
+        assert_eq!(building.u_floor, 1.5);
+    }
+
+    #[test]
+    fn test_building_step() {
+        let mut building = BuildingGroup::new(1);
+        let radiation = UrbanRadiationSystem::new(500.0, 270.0, 0.9, 0.7, 45.0, 0.0);
+        let dt = Duration::from_secs(3600);
+        let initial_temp = building.temperature;
+
+        building.step(&dt, &radiation, 300.0);
+        assert_ne!(building.temperature, initial_temp);
+    }
+
+    #[test]
+    fn test_urban_radiation_system_creation() {
+        let radiation = UrbanRadiationSystem::new(800.0, 120.0, 0.2, 0.85, 0.1, 2.0);
+        assert_eq!(radiation.solar_irradiance, 800.0);
+        assert_eq!(radiation.sky_temperature, 120.0);
+    }
+
+    #[test]
+    fn test_urban_step_dispatcher_creation() {
+        let buildings: Vec<BuildingGroup> = (0..5).map(|i| BuildingGroup::new(i as u32)).collect();
+        let dispatcher = UrbanStepDispatcher::with_buildings(buildings);
+        assert_eq!(dispatcher.num_buildings(), 5);
+    }
+
+    #[test]
+    fn test_urban_step_dispatcher_step() {
+        let buildings: Vec<BuildingGroup> = (0..10).map(|i| BuildingGroup::new(i as u32)).collect();
+        let mut dispatcher = UrbanStepDispatcher::with_buildings(buildings);
+        let radiation = UrbanRadiationSystem::new(500.0, 270.0, 0.9, 0.7, 45.0, 0.0);
+        let dt = Duration::from_secs(3600);
+
+        dispatcher.step_all(dt, &radiation, 300.0);
+        assert_eq!(dispatcher.num_buildings(), 10);
+    }
+
+    #[test]
+    fn test_sequential_vs_parallel_consistency() {
+        let buildings: Vec<BuildingGroup> = (0..20)
+            .map(|i| BuildingGroup::new(i as u32).with_area(100.0 + i as f64))
+            .collect();
+        let mut dispatcher_seq = UrbanStepDispatcher::with_buildings(buildings.clone());
+        let mut dispatcher_par = UrbanStepDispatcher::with_buildings(buildings.clone());
+
+        let radiation = UrbanRadiationSystem::new(500.0, 270.0, 0.9, 0.7, 45.0, 0.0);
+        let dt = Duration::from_secs(3600);
+
+        dispatcher_seq.step_sequential(&dt, &radiation, 300.0);
+        dispatcher_par.step_all(dt, &radiation, 300.0);
+
+        let seq_buildings = dispatcher_seq.get_buildings();
+        let par_buildings = dispatcher_par.get_buildings();
+
+        for (seq, par) in seq_buildings.iter().zip(par_buildings.iter()) {
+            approx::assert_abs_diff_eq!(seq.temperature, par.temperature, epsilon = 1e-10);
+        }
+    }
+}

--- a/fluxion-city/src/parallel/mod.rs
+++ b/fluxion-city/src/parallel/mod.rs
@@ -1,0 +1,5 @@
+//! Parallel module for fluxion-city
+//!
+//! This module provides parallel execution primitives for urban building simulations.
+
+pub mod harness;


### PR DESCRIPTION
Closes #2034

Implements the parallel harness benchmark suite for fluxion-city including:
- Parallel module with BuildingGroup, UrbanRadiationSystem, UrbanStepDispatcher
- Benchmarks with Rayon parallel iteration
- Full test suite passing

## Summary by Sourcery

Introduce a parallel harness module for urban building simulations and expose its types for benchmarking and external use.

New Features:
- Add BuildingGroup, UrbanRadiationSystem, and UrbanStepDispatcher abstractions for modeling and stepping urban buildings in parallel or sequentially.
- Expose a parallel module and harness types behind the `parallel` feature flag for use by consumers and benchmarks.

Enhancements:
- Refine parallel benchmark harness to report timing via Duration and simplify benchmark setup.
- Enable serde support in the core crate and adjust test module layout for energy conservation tests.

Build:
- Add sysinfo as a dev-dependency to support benchmarking and diagnostics in the fluxion-city crate.

Tests:
- Add unit tests covering building initialization, stepping dynamics, dispatcher behavior, and consistency between sequential and parallel execution paths.