### PR TITLE
feat(city): resolve #2007 — Initialize Crate & UrbanGraph Spatial Topology

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -124,7 +124,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -528,7 +528,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -842,7 +842,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -993,7 +993,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1095,6 +1095,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fixedbitset"
@@ -1235,11 +1241,13 @@ dependencies = [
  "criterion",
  "faer",
  "num-traits",
+ "petgraph",
  "rand 0.8.5",
  "rayon",
  "serde",
  "sysinfo",
  "thiserror 1.0.69",
+ "uuid",
 ]
 
 [[package]]
@@ -2142,7 +2150,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2787,7 +2795,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3092,6 +3100,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
 dependencies = [
  "pest",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset 0.4.2",
+ "indexmap",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -3827,7 +3847,7 @@ version = "0.25.1"
 source = "git+https://github.com/anchapin/rumqtt?branch=fix%2Frustsec-2026-webpki#07a524e6c8358747492cbbd154bc34befad3672b"
 dependencies = [
  "bytes",
- "fixedbitset",
+ "fixedbitset 0.5.7",
  "flume",
  "futures-util",
  "log",
@@ -3892,7 +3912,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4234,7 +4254,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4384,10 +4404,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5110,7 +5130,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/fluxion-toon/src/error.rs
+++ b/crates/fluxion-toon/src/error.rs
@@ -11,17 +11,11 @@ pub enum ToonError {
 
     /// Row count differs from declared length in header.
     #[error("length mismatch: declared {declared} but found {found} rows")]
-    LengthMismatch {
-        declared: usize,
-        found: usize,
-    },
+    LengthMismatch { declared: usize, found: usize },
 
     /// Invalid syntax (line, message) or malformed header/type literal.
     #[error("invalid syntax{line}: {message}")]
-    InvalidSyntax {
-        line: usize,
-        message: String,
-    },
+    InvalidSyntax { line: usize, message: String },
 
     /// Comma-separated values don't match field count in header.
     #[error("malformed row at line {line}: expected {expected} fields but found {found}")]

--- a/crates/fluxion-toon/src/parse.rs
+++ b/crates/fluxion-toon/src/parse.rs
@@ -252,21 +252,21 @@ pub fn parse_line(input: &str) -> Result<ParsedScalar> {
 /// Parse a uniform array header: `name[N]{field1,field2,...}:`
 pub fn parse_uniform_array_header(input: &str) -> Result<ParsedArrayHeader> {
     let input = input.trim().trim_end_matches(':');
-    let (name_part, rest) = input.split_once('[').ok_or_else(|| {
-        ToonError::InvalidSyntax {
+    let (name_part, rest) = input
+        .split_once('[')
+        .ok_or_else(|| ToonError::InvalidSyntax {
             line: 0,
             message: format!("missing '[' in array header: {}", input),
-        }
-    })?;
+        })?;
 
     let name = name_part.trim().to_string();
 
-    let (count_part, fields_part) = rest.split_once("]{").ok_or_else(|| {
-        ToonError::InvalidSyntax {
-            line: 0,
-            message: format!("missing ']{{' in array header: {}", input),
-        }
-    })?;
+    let (count_part, fields_part) =
+        rest.split_once("]{")
+            .ok_or_else(|| ToonError::InvalidSyntax {
+                line: 0,
+                message: format!("missing ']{{' in array header: {}", input),
+            })?;
 
     let count = count_part
         .parse::<usize>()

--- a/fluxion-city/Cargo.toml
+++ b/fluxion-city/Cargo.toml
@@ -14,6 +14,8 @@ approx = "0.5"
 faer = "0.23"
 num-traits = "0.2"
 rayon = { version = "1.8", optional = true }
+petgraph = { version = "0.6", features = ["serde-1"] }
+uuid = { version = "1.0", features = ["v4", "serde"] }
 
 [features]
 default = []

--- a/fluxion-city/src/lib.rs
+++ b/fluxion-city/src/lib.rs
@@ -15,6 +15,12 @@
 //!
 //! This crate uses sparse matrix representations for efficient computation with
 //! urban radiation with many surfaces.
+//!
+//! ## UrbanGraph Spatial Topology
+//!
+//! The `UrbanGraph` module provides spatial graph representation for city-scale
+//! building energy modeling where nodes represent building envelopes and edges
+//! represent spatial adjacency.
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -857,6 +863,295 @@ pub mod ashrae140 {
     }
 }
 
+pub mod urban_graph {
+    use petgraph::Graph;
+    use petgraph::Undirected;
+    use serde::{Deserialize, Serialize};
+    use uuid::Uuid;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+    pub enum AdjacencyType {
+        WindowToWindow,
+        WallToWall,
+        WallToWindow,
+        RoofToRoof,
+    }
+
+    #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+    pub struct BoundingBox3D {
+        pub min_x: f64,
+        pub min_y: f64,
+        pub min_z: f64,
+        pub max_x: f64,
+        pub max_y: f64,
+        pub max_z: f64,
+    }
+
+    impl BoundingBox3D {
+        pub fn new(min_x: f64, min_y: f64, min_z: f64, max_x: f64, max_y: f64, max_z: f64) -> Self {
+            Self {
+                min_x,
+                min_y,
+                min_z,
+                max_x,
+                max_y,
+                max_z,
+            }
+        }
+
+        pub fn center(&self) -> (f64, f64, f64) {
+            (
+                (self.min_x + self.max_x) / 2.0,
+                (self.min_y + self.max_y) / 2.0,
+                (self.min_z + self.max_z) / 2.0,
+            )
+        }
+
+        pub fn distance_to(&self, other: &BoundingBox3D) -> f64 {
+            let (cx1, cy1, cz1) = self.center();
+            let (cx2, cy2, cz2) = other.center();
+            ((cx2 - cx1).powi(2) + (cy2 - cy1).powi(2) + (cz2 - cz1).powi(2)).sqrt()
+        }
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct BuildingNode {
+        pub id: Uuid,
+        pub envelope: (),
+        pub bounding_box: BoundingBox3D,
+    }
+
+    impl BuildingNode {
+        pub fn new(id: Uuid, bounding_box: BoundingBox3D) -> Self {
+            Self {
+                id,
+                envelope: (),
+                bounding_box,
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+    pub struct SpatialEdge {
+        pub distance_m: f64,
+        pub adjacency_type: AdjacencyType,
+    }
+
+    impl SpatialEdge {
+        pub fn new(distance_m: f64, adjacency_type: AdjacencyType) -> Self {
+            Self {
+                distance_m,
+                adjacency_type,
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct UrbanGraph<N, E> {
+        graph: Graph<N, E, Undirected>,
+        node_ids: Vec<Uuid>,
+    }
+
+    impl<N, E> UrbanGraph<N, E> {
+        pub fn new() -> Self {
+            Self {
+                graph: Graph::new_undirected(),
+                node_ids: Vec::new(),
+            }
+        }
+
+        pub fn node_count(&self) -> usize {
+            self.graph.node_count()
+        }
+
+        pub fn edge_count(&self) -> usize {
+            self.graph.edge_count()
+        }
+
+        pub fn contains_node(&self, id: Uuid) -> bool {
+            self.node_ids.contains(&id)
+        }
+
+        fn node_index(&self, id: Uuid) -> Option<petgraph::graph::NodeIndex> {
+            self.node_ids
+                .iter()
+                .position(|&node_id| node_id == id)
+                .map(petgraph::graph::NodeIndex::new)
+        }
+
+        pub fn node(&self, id: Uuid) -> Option<&N> {
+            self.node_index(id)
+                .and_then(|idx| self.graph.node_weight(idx))
+        }
+
+        pub fn nodes(&self) -> impl Iterator<Item = &N> {
+            self.graph.node_weights()
+        }
+
+        pub fn edges(&self) -> impl Iterator<Item = &E> {
+            self.graph.edge_weights()
+        }
+    }
+
+    impl<N, E> Default for UrbanGraph<N, E> {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl UrbanGraph<BuildingNode, SpatialEdge> {
+        pub fn add_building(&mut self, node: BuildingNode) -> Uuid {
+            let id = node.id;
+            self.graph.add_node(node);
+            self.node_ids.push(id);
+            id
+        }
+
+        pub fn add_spatial_edge(
+            &mut self,
+            source_id: Uuid,
+            target_id: Uuid,
+            edge: SpatialEdge,
+        ) -> Option<petgraph::graph::EdgeIndex> {
+            let source_idx = self.node_index(source_id)?;
+            let target_idx = self.node_index(target_id)?;
+            Some(self.graph.add_edge(source_idx, target_idx, edge))
+        }
+
+        pub fn nearest_neighbors(&self, node_id: Uuid, radius_m: f64) -> Vec<Uuid> {
+            let source_idx = match self.node_index(node_id) {
+                Some(idx) => idx,
+                None => return Vec::new(),
+            };
+
+            let source_node = match self.graph.node_weight(source_idx) {
+                Some(node) => node,
+                None => return Vec::new(),
+            };
+
+            let mut neighbors = Vec::new();
+
+            for (target_idx, target_node) in
+                self.graph.node_indices().zip(self.graph.node_weights())
+            {
+                if target_idx == source_idx {
+                    continue;
+                }
+
+                let distance = source_node
+                    .bounding_box
+                    .distance_to(&target_node.bounding_box);
+
+                if distance <= radius_m {
+                    neighbors.push(target_node.id);
+                }
+            }
+
+            neighbors
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        fn create_test_buildings() -> (BoundingBox3D, BoundingBox3D, BoundingBox3D) {
+            let building_a = BoundingBox3D::new(0.0, 0.0, 0.0, 10.0, 10.0, 30.0);
+            let building_b = BoundingBox3D::new(15.0, 5.0, 0.0, 25.0, 15.0, 30.0);
+            let building_c = BoundingBox3D::new(100.0, 100.0, 0.0, 110.0, 110.0, 30.0);
+            (building_a, building_b, building_c)
+        }
+
+        #[test]
+        fn test_bounding_box_distance() {
+            let bb1 = BoundingBox3D::new(0.0, 0.0, 0.0, 10.0, 10.0, 10.0);
+            let bb2 = BoundingBox3D::new(20.0, 0.0, 0.0, 30.0, 10.0, 10.0);
+            let distance = bb1.distance_to(&bb2);
+            assert!((distance - 20.0).abs() < 1e-6);
+        }
+
+        #[test]
+        fn test_3_building_graph_nearest_neighbors() {
+            let (building_a, building_b, building_c) = create_test_buildings();
+
+            let id_a = Uuid::new_v4();
+            let id_b = Uuid::new_v4();
+            let id_c = Uuid::new_v4();
+
+            let mut graph: UrbanGraph<BuildingNode, SpatialEdge> = UrbanGraph::new();
+
+            graph.add_building(BuildingNode::new(id_a, building_a));
+            graph.add_building(BuildingNode::new(id_b, building_b));
+            graph.add_building(BuildingNode::new(id_c, building_c));
+
+            let neighbors_a = graph.nearest_neighbors(id_a, 50.0);
+            assert_eq!(neighbors_a.len(), 1);
+            assert!(neighbors_a.contains(&id_b));
+            assert!(!neighbors_a.contains(&id_c));
+
+            let neighbors_b = graph.nearest_neighbors(id_b, 50.0);
+            assert_eq!(neighbors_b.len(), 1);
+            assert!(neighbors_b.contains(&id_a));
+            assert!(!neighbors_b.contains(&id_c));
+
+            let neighbors_c = graph.nearest_neighbors(id_c, 50.0);
+            assert!(neighbors_c.is_empty());
+
+            let neighbors_c_200 = graph.nearest_neighbors(id_c, 200.0);
+            assert_eq!(neighbors_c_200.len(), 2);
+            assert!(neighbors_c_200.contains(&id_a));
+            assert!(neighbors_c_200.contains(&id_b));
+        }
+
+        #[test]
+        fn test_urban_graph_add_edge() {
+            let (building_a, building_b, _) = create_test_buildings();
+
+            let id_a = Uuid::new_v4();
+            let id_b = Uuid::new_v4();
+
+            let mut graph: UrbanGraph<BuildingNode, SpatialEdge> = UrbanGraph::new();
+            graph.add_building(BuildingNode::new(id_a, building_a));
+            graph.add_building(BuildingNode::new(id_b, building_b));
+
+            let edge = SpatialEdge::new(15.0, AdjacencyType::WallToWall);
+            let edge_idx = graph.add_spatial_edge(id_a, id_b, edge);
+
+            assert!(edge_idx.is_some());
+            assert_eq!(graph.edge_count(), 1);
+        }
+
+        #[test]
+        fn test_urban_graph_node_lookup() {
+            let building = BoundingBox3D::new(0.0, 0.0, 0.0, 10.0, 10.0, 30.0);
+            let id = Uuid::new_v4();
+
+            let mut graph: UrbanGraph<BuildingNode, SpatialEdge> = UrbanGraph::new();
+            assert!(!graph.contains_node(id));
+
+            graph.add_building(BuildingNode::new(id, building));
+            assert!(graph.contains_node(id));
+            assert_eq!(graph.node_count(), 1);
+        }
+
+        #[test]
+        fn test_urban_graph_default() {
+            let graph: UrbanGraph<BuildingNode, SpatialEdge> = UrbanGraph::default();
+            assert_eq!(graph.node_count(), 0);
+            assert_eq!(graph.edge_count(), 0);
+        }
+
+        #[test]
+        fn test_bounding_box_center() {
+            let bb = BoundingBox3D::new(0.0, 0.0, 0.0, 10.0, 20.0, 30.0);
+            let (cx, cy, cz) = bb.center();
+            assert!((cx - 5.0).abs() < 1e-6);
+            assert!((cy - 10.0).abs() < 1e-6);
+            assert!((cz - 15.0).abs() < 1e-6);
+        }
+    }
+}
+
 pub use ashrae140::{ashrae140, verify_ashrae_case};
 pub use geometry::{GroundPlane, RectSurface, SurfaceType, UrbanCanopySurface, VerticalSurface};
 pub use nusselt::{
@@ -865,6 +1160,7 @@ pub use nusselt::{
     ViewFactorMatrix,
 };
 pub use sparse::{create_sparse_from_urban_canyon, SparseViewFactorMatrix, UrbanRadiationSolver};
+pub use urban_graph::{AdjacencyType, BoundingBox3D, BuildingNode, SpatialEdge, UrbanGraph};
 
 #[cfg(feature = "parallel")]
 pub mod parallel {
@@ -1447,6 +1743,7 @@ mod tests {
         }
     }
 
+
     #[test]
     fn test_5_building_energy_conservation() {
         let test = EnergyConservationTest::create_5_building_config();
@@ -1542,7 +1839,7 @@ mod tests {
     fn test_longwave_equilibrium() {
         let test = EnergyConservationTest::create_5_building_config();
 
-        for (i, building) in test.buildings.iter().enumerate() {
+        for (i, _building) in test.buildings.iter().enumerate() {
             let radiation = test.surface_radiation_balance(i);
             assert!(
                 radiation.is_some(),

--- a/fluxion-city/src/lib.rs
+++ b/fluxion-city/src/lib.rs
@@ -1743,7 +1743,6 @@ mod tests {
         }
     }
 
-
     #[test]
     fn test_5_building_energy_conservation() {
         let test = EnergyConservationTest::create_5_building_config();


### PR DESCRIPTION
Closes #2007

Implements the UrbanGraph spatial topology for city-scale building energy modeling.

## Summary by Sourcery

Introduce an UrbanGraph-based spatial topology for representing building adjacency at city scale and expose it from the fluxion-city crate.

New Features:
- Add an UrbanGraph module modeling building nodes, spatial edges, and adjacency types using bounding boxes and UUIDs.
- Expose UrbanGraph types (AdjacencyType, BoundingBox3D, BuildingNode, SpatialEdge, UrbanGraph) in the crate public API.
- Provide nearest-neighbor queries over buildings based on 3D bounding box distances.

Enhancements:
- Document the UrbanGraph spatial topology in the crate-level docs and reorganize an existing test module name for clarity.

Build:
- Add petgraph and uuid dependencies with serde support to the fluxion-city crate.

Tests:
- Add unit tests covering UrbanGraph construction, node/edge management, bounding box utilities, and nearest-neighbor behavior.