### PR TITLE
feat(twin): resolve #2057 — Telemetry Backpressure + Out-of-Order Deduplication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1312,6 +1312,9 @@ version = "0.1.0"
 dependencies = [
  "approx",
  "bytes",
+ "chrono",
+ "crossbeam-channel",
+ "log",
  "mockito",
  "nalgebra",
  "rand 0.8.5",
@@ -1321,6 +1324,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/fluxion-toon/src/error.rs
+++ b/crates/fluxion-toon/src/error.rs
@@ -11,17 +11,11 @@ pub enum ToonError {
 
     /// Row count differs from declared length in header.
     #[error("length mismatch: declared {declared} but found {found} rows")]
-    LengthMismatch {
-        declared: usize,
-        found: usize,
-    },
+    LengthMismatch { declared: usize, found: usize },
 
     /// Invalid syntax (line, message) or malformed header/type literal.
     #[error("invalid syntax{line}: {message}")]
-    InvalidSyntax {
-        line: usize,
-        message: String,
-    },
+    InvalidSyntax { line: usize, message: String },
 
     /// Comma-separated values don't match field count in header.
     #[error("malformed row at line {line}: expected {expected} fields but found {found}")]

--- a/crates/fluxion-toon/src/parse.rs
+++ b/crates/fluxion-toon/src/parse.rs
@@ -252,21 +252,21 @@ pub fn parse_line(input: &str) -> Result<ParsedScalar> {
 /// Parse a uniform array header: `name[N]{field1,field2,...}:`
 pub fn parse_uniform_array_header(input: &str) -> Result<ParsedArrayHeader> {
     let input = input.trim().trim_end_matches(':');
-    let (name_part, rest) = input.split_once('[').ok_or_else(|| {
-        ToonError::InvalidSyntax {
+    let (name_part, rest) = input
+        .split_once('[')
+        .ok_or_else(|| ToonError::InvalidSyntax {
             line: 0,
             message: format!("missing '[' in array header: {}", input),
-        }
-    })?;
+        })?;
 
     let name = name_part.trim().to_string();
 
-    let (count_part, fields_part) = rest.split_once("]{").ok_or_else(|| {
-        ToonError::InvalidSyntax {
-            line: 0,
-            message: format!("missing ']{{' in array header: {}", input),
-        }
-    })?;
+    let (count_part, fields_part) =
+        rest.split_once("]{")
+            .ok_or_else(|| ToonError::InvalidSyntax {
+                line: 0,
+                message: format!("missing ']{{' in array header: {}", input),
+            })?;
 
     let count = count_part
         .parse::<usize>()

--- a/crates/fluxion-twin/Cargo.toml
+++ b/crates/fluxion-twin/Cargo.toml
@@ -15,6 +15,10 @@ nalgebra = { version = "0.33", features = ["serde"] }
 tokio = { version = "1.40", features = ["rt-multi-thread", "sync", "time"] }
 rumqttc = "0.25"
 bytes = "1.0"
+uuid = { version = "1.0", features = ["serde", "v4"] }
+chrono = { version = "0.4", features = ["serde"] }
+crossbeam-channel = "0.5"
+log = "0.4"
 
 [dev-dependencies]
 approx = "0.5"

--- a/crates/fluxion-twin/src/lib.rs
+++ b/crates/fluxion-twin/src/lib.rs
@@ -25,7 +25,10 @@ use std::vec::Vec;
 pub mod error;
 pub mod telemetry;
 pub use error::KalmanError;
-pub use telemetry::{MqttTelemetryConsumer, TelemetryError, TelemetryMessage};
+pub use telemetry::{
+    MqttTelemetryConsumer, MqttTelemetryError, MqttTelemetryMessage, Sender, TelemetryConsumer,
+    TelemetryError, TelemetryMsg,
+};
 
 pub trait StateVector: Clone {
     fn zeros() -> Self;
@@ -95,6 +98,7 @@ impl MeasurementVector for Vec<f64> {
     }
 }
 
+#[allow(clippy::type_complexity)]
 pub struct UnscentedKalmanFilter<S, M>
 where
     S: StateVector + Send + Sync,
@@ -234,6 +238,7 @@ where
         Ok(l)
     }
 
+    #[allow(clippy::type_complexity)]
     fn generate_sigma_points(&self) -> Result<(Vec<S>, Vec<f64>, Vec<f64>), KalmanError> {
         let n = self.n as f64;
         let lambda = self.lambda();

--- a/crates/fluxion-twin/src/telemetry/consumer.rs
+++ b/crates/fluxion-twin/src/telemetry/consumer.rs
@@ -1,0 +1,251 @@
+//! Bounded channel consumer with out-of-order packet deduplication.
+//!
+//! Implements:
+//! - Bounded channel (1024 capacity) to prevent memory exhaustion
+//! - Out-of-order buffering per sensor (up to 100 messages)
+//! - Sequence number deduplication per sensor
+//! - Slow consumer warning when queue depth > 900
+
+use crossbeam_channel::{self as channel, Receiver, RecvError, SendError};
+use std::collections::{HashMap, VecDeque};
+use uuid::Uuid;
+
+use super::error::TelemetryError;
+use super::message::TelemetryMsg;
+
+const MAX_CHANNEL_CAPACITY: usize = 1024;
+const SLOW_CONSUMER_THRESHOLD: usize = 900;
+
+pub struct TelemetryConsumer {
+    rx: Receiver<TelemetryMsg>,
+    buffer: HashMap<Uuid, VecDeque<TelemetryMsg>>,
+    last_sequence: HashMap<Uuid, u64>,
+}
+
+impl TelemetryConsumer {
+    pub fn new() -> (Sender<TelemetryMsg>, Self) {
+        let (tx, rx) = channel::bounded(MAX_CHANNEL_CAPACITY);
+        (
+            Sender { inner: tx },
+            Self {
+                rx,
+                buffer: HashMap::new(),
+                last_sequence: HashMap::new(),
+            },
+        )
+    }
+
+    pub fn with_receiver(rx: Receiver<TelemetryMsg>) -> Self {
+        Self {
+            rx,
+            buffer: HashMap::new(),
+            last_sequence: HashMap::new(),
+        }
+    }
+
+    pub fn process_message(&mut self, msg: TelemetryMsg) -> Option<TelemetryMsg> {
+        let sensor_id = msg.sensor_id;
+        let seq = msg.sequence;
+
+        if let Some(&last) = self.last_sequence.get(&sensor_id) {
+            if seq <= last {
+                return None;
+            }
+        }
+
+        self.last_sequence.insert(sensor_id, seq);
+        Some(msg)
+    }
+
+    fn try_drain_buffer(
+        &mut self,
+        sensor_id: Uuid,
+    ) -> Option<Result<TelemetryMsg, TelemetryError>> {
+        let expected_seq = self.last_sequence.get(&sensor_id).copied().unwrap_or(0) + 1;
+
+        if let Some(buf) = self.buffer.get(&sensor_id) {
+            if buf.len() >= 100 {
+                return Some(Err(TelemetryError::BufferFull(sensor_id)));
+            }
+            for (i, msg) in buf.iter().enumerate() {
+                if msg.sequence == expected_seq {
+                    let msg = self.buffer.get_mut(&sensor_id).unwrap().remove(i).unwrap();
+                    return Some(
+                        self.process_message(msg)
+                            .ok_or(TelemetryError::Recv("Channel closed".to_string())),
+                    );
+                }
+            }
+        }
+        None
+    }
+
+    pub fn recv_with_backpressure(&mut self) -> Result<TelemetryMsg, TelemetryError> {
+        let queue_len = self.rx.len();
+        if queue_len > SLOW_CONSUMER_THRESHOLD {
+            log::warn!(
+                "Telemetry channel slow consumer: depth {} / {}",
+                queue_len,
+                MAX_CHANNEL_CAPACITY
+            );
+        }
+
+        match self.rx.recv() {
+            Ok(msg) => {
+                let sensor_id = msg.sensor_id;
+                let expected_seq = self.last_sequence.get(&sensor_id).copied().unwrap_or(0) + 1;
+
+                if msg.sequence == expected_seq {
+                    if let Some(processed) = self.process_message(msg) {
+                        Ok(processed)
+                    } else {
+                        self.recv_with_backpressure()
+                    }
+                } else if msg.sequence > expected_seq {
+                    self.buffer.entry(sensor_id).or_default().push_back(msg);
+                    if let Some(result) = self.try_drain_buffer(sensor_id) {
+                        return result;
+                    }
+                    self.recv_with_backpressure()
+                } else {
+                    self.buffer.entry(sensor_id).or_default().push_back(msg);
+                    self.recv_with_backpressure()
+                }
+            }
+            Err(RecvError) => Err(TelemetryError::Recv("Channel closed".to_string())),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.rx.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.rx.is_empty()
+    }
+}
+
+impl Default for TelemetryConsumer {
+    fn default() -> Self {
+        Self::new().1
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Sender<T> {
+    inner: channel::Sender<T>,
+}
+
+impl<T> Sender<T> {
+    pub fn send(&self, msg: T) -> Result<(), SendError<T>> {
+        self.inner.send(msg)
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.len() == 0
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.inner.capacity().unwrap_or(MAX_CHANNEL_CAPACITY)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    fn create_test_msg(sensor_id: Uuid, sequence: u64) -> TelemetryMsg {
+        TelemetryMsg {
+            sensor_id,
+            sequence,
+            timestamp: chrono::Utc::now(),
+            payload: vec![1.0],
+        }
+    }
+
+    #[test]
+    fn test_duplicate_sequence_dropped() {
+        let (tx, rx) = channel::bounded(10);
+        let mut consumer = TelemetryConsumer::with_receiver(rx);
+        let sensor_id = Uuid::new_v4();
+
+        let msg1 = create_test_msg(sensor_id, 1);
+        tx.send(msg1.clone()).unwrap();
+        let result1 = consumer.recv_with_backpressure();
+        assert!(result1.is_ok());
+
+        let msg2 = create_test_msg(sensor_id, 1);
+        tx.send(msg2).unwrap();
+        let result2 = consumer.recv_with_backpressure();
+        assert!(result2.is_err());
+    }
+
+    #[test]
+    fn test_out_of_order_buffering() {
+        let (tx, rx) = channel::bounded(10);
+        let mut consumer = TelemetryConsumer::with_receiver(rx);
+        let sensor_id = Uuid::new_v4();
+
+        tx.send(create_test_msg(sensor_id, 3)).unwrap();
+        tx.send(create_test_msg(sensor_id, 1)).unwrap();
+        tx.send(create_test_msg(sensor_id, 2)).unwrap();
+
+        let result1 = consumer.recv_with_backpressure();
+        assert!(result1.is_ok());
+        assert_eq!(result1.unwrap().sequence, 1);
+
+        let result2 = consumer.recv_with_backpressure();
+        assert!(result2.is_ok());
+        assert_eq!(result2.unwrap().sequence, 2);
+
+        let result3 = consumer.recv_with_backpressure();
+        assert!(result3.is_ok());
+        assert_eq!(result3.unwrap().sequence, 3);
+    }
+
+    #[test]
+    fn test_old_sequence_dropped() {
+        let (tx, rx) = channel::bounded(10);
+        let mut consumer = TelemetryConsumer::with_receiver(rx);
+        let sensor_id = Uuid::new_v4();
+
+        tx.send(create_test_msg(sensor_id, 5)).unwrap();
+        let result1 = consumer.recv_with_backpressure();
+        assert!(result1.is_ok());
+        assert_eq!(result1.unwrap().sequence, 5);
+
+        tx.send(create_test_msg(sensor_id, 3)).unwrap();
+        let result2 = consumer.recv_with_backpressure();
+        assert!(result2.is_err());
+    }
+
+    #[test]
+    fn test_multi_sensor_deduplication() {
+        let (tx, rx) = channel::bounded(10);
+        let mut consumer = TelemetryConsumer::with_receiver(rx);
+        let sensor_a = Uuid::new_v4();
+        let sensor_b = Uuid::new_v4();
+
+        tx.send(create_test_msg(sensor_a, 1)).unwrap();
+        tx.send(create_test_msg(sensor_b, 1)).unwrap();
+        tx.send(create_test_msg(sensor_a, 1)).unwrap();
+        tx.send(create_test_msg(sensor_b, 1)).unwrap();
+
+        let result1 = consumer.recv_with_backpressure();
+        assert!(result1.is_ok());
+
+        let result2 = consumer.recv_with_backpressure();
+        assert!(result2.is_ok());
+
+        let result3 = consumer.recv_with_backpressure();
+        assert!(result3.is_err());
+
+        let result4 = consumer.recv_with_backpressure();
+        assert!(result4.is_err());
+    }
+}

--- a/crates/fluxion-twin/src/telemetry/error.rs
+++ b/crates/fluxion-twin/src/telemetry/error.rs
@@ -1,0 +1,19 @@
+//! Error types for telemetry backpressure and deduplication.
+
+use thiserror::Error;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, PartialEq, Error)]
+pub enum TelemetryError {
+    #[error("channel receive error: {0}")]
+    Recv(String),
+
+    #[error("channel send error")]
+    Send,
+
+    #[error("backpressure: channel at capacity, slow consumer")]
+    Backpressure,
+
+    #[error("out-of-order buffer full for sensor {0}")]
+    BufferFull(Uuid),
+}

--- a/crates/fluxion-twin/src/telemetry/message.rs
+++ b/crates/fluxion-twin/src/telemetry/message.rs
@@ -1,0 +1,24 @@
+//! Telemetry message definition for backpressure-aware telemetry.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TelemetryMsg {
+    pub sensor_id: Uuid,
+    pub sequence: u64,
+    pub timestamp: DateTime<Utc>,
+    pub payload: Vec<f64>,
+}
+
+impl TelemetryMsg {
+    pub fn new(sensor_id: Uuid, sequence: u64, payload: Vec<f64>) -> Self {
+        Self {
+            sensor_id,
+            sequence,
+            timestamp: Utc::now(),
+            payload,
+        }
+    }
+}

--- a/crates/fluxion-twin/src/telemetry/mod.rs
+++ b/crates/fluxion-twin/src/telemetry/mod.rs
@@ -1,0 +1,18 @@
+//! Telemetry subsystem with backpressure and deduplication.
+//!
+//! # Module Overview
+//!
+//! - [`consumer::TelemetryConsumer`] — Bounded channel consumer with out-of-order deduplication
+//! - [`message::TelemetryMsg`] — Telemetry message with sensor ID, sequence, timestamp, payload
+//! - [`mqtt::MqttTelemetryConsumer`] — MQTT-based telemetry consumer
+//! - [`error::TelemetryError`] — Error types for backpressure and channel operations
+
+pub mod consumer;
+pub mod error;
+pub mod message;
+pub mod mqtt;
+
+pub use consumer::{Sender, TelemetryConsumer};
+pub use error::TelemetryError;
+pub use message::TelemetryMsg;
+pub use mqtt::{MqttTelemetryConsumer, MqttTelemetryError, MqttTelemetryMessage};

--- a/crates/fluxion-twin/src/telemetry/mqtt.rs
+++ b/crates/fluxion-twin/src/telemetry/mqtt.rs
@@ -19,7 +19,7 @@ use thiserror::Error;
 use tokio::sync::mpsc;
 
 #[derive(Error, Debug)]
-pub enum TelemetryError {
+pub enum MqttTelemetryError {
     #[error("MQTT connection error: {0}")]
     Connection(#[from] rumqttc::ConnectionError),
     #[error("MQTT client error: {0}")]
@@ -31,14 +31,14 @@ pub enum TelemetryError {
 }
 
 #[derive(Debug, Clone)]
-pub struct TelemetryMessage {
+pub struct MqttTelemetryMessage {
     pub zone_id: String,
     pub t_air: f64,
     pub rh: f64,
 }
 
-impl TryFrom<&[u8]> for TelemetryMessage {
-    type Error = TelemetryError;
+impl TryFrom<&[u8]> for MqttTelemetryMessage {
+    type Error = MqttTelemetryError;
 
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
         #[derive(Deserialize)]
@@ -48,7 +48,7 @@ impl TryFrom<&[u8]> for TelemetryMessage {
             rh: f64,
         }
         let raw: RawMessage = serde_json::from_slice(bytes)?;
-        Ok(TelemetryMessage {
+        Ok(MqttTelemetryMessage {
             zone_id: raw.zone_id,
             t_air: raw.t_air,
             rh: raw.rh,
@@ -64,7 +64,7 @@ pub struct MqttTelemetryConsumer {
 }
 
 impl MqttTelemetryConsumer {
-    pub async fn connect(broker: &str, topic: &str) -> Result<Self, TelemetryError> {
+    pub async fn connect(broker: &str, topic: &str) -> Result<Self, MqttTelemetryError> {
         let mut mqttoptions = MqttOptions::new("fluxion-twin-consumer", broker, 1883);
         mqttoptions.set_keep_alive(Duration::from_secs(5));
 
@@ -78,12 +78,16 @@ impl MqttTelemetryConsumer {
         })
     }
 
-    pub async fn start(mut self, tx: mpsc::Sender<TelemetryMessage>) -> Result<(), TelemetryError> {
+    #[allow(clippy::type_complexity)]
+    pub async fn start(
+        mut self,
+        tx: mpsc::Sender<MqttTelemetryMessage>,
+    ) -> Result<(), MqttTelemetryError> {
         loop {
             match self.eventloop.poll().await {
                 Ok(Event::Incoming(Packet::Publish(publish))) => {
                     if publish.topic == self.topic {
-                        if let Ok(msg) = TelemetryMessage::try_from(publish.payload.as_ref()) {
+                        if let Ok(msg) = MqttTelemetryMessage::try_from(publish.payload.as_ref()) {
                             if tx.send(msg).await.is_err() {
                                 break;
                             }
@@ -92,7 +96,7 @@ impl MqttTelemetryConsumer {
                 }
                 Ok(_) => {}
                 Err(e) => {
-                    return Err(TelemetryError::Connection(e));
+                    return Err(MqttTelemetryError::Connection(e));
                 }
             }
         }
@@ -107,7 +111,7 @@ mod tests {
     #[test]
     fn test_telemetry_message_try_from_valid_json() {
         let json = br#"{"zone_id": "test-123", "t_air": 22.5, "rh": 0.5}"#;
-        let msg = TelemetryMessage::try_from(json.as_slice()).unwrap();
+        let msg = MqttTelemetryMessage::try_from(json.as_slice()).unwrap();
         assert_eq!(msg.zone_id, "test-123");
         assert!((msg.t_air - 22.5).abs() < 1e-6);
         assert!((msg.rh - 0.5).abs() < 1e-6);
@@ -116,14 +120,14 @@ mod tests {
     #[test]
     fn test_telemetry_message_try_from_invalid_json() {
         let json = b"not valid json";
-        let result = TelemetryMessage::try_from(json.as_slice());
+        let result = MqttTelemetryMessage::try_from(json.as_slice());
         assert!(result.is_err());
     }
 
     #[test]
     fn test_telemetry_message_try_from_missing_fields() {
         let json = br#"{"zone_id": "test-123"}"#;
-        let result = TelemetryMessage::try_from(json.as_slice());
+        let result = MqttTelemetryMessage::try_from(json.as_slice());
         assert!(result.is_err());
     }
 


### PR DESCRIPTION
Closes #2057

Implements bounded channel backpressure and out-of-order packet deduplication for fluxion-twin telemetry.

## Summary by Sourcery

Introduce a backpressure-aware telemetry subsystem with bounded channels and out-of-order packet deduplication, and integrate it with existing MQTT telemetry consumption.

New Features:
- Add a generic telemetry message type carrying sensor ID, sequence number, timestamp, and payload for backpressure-aware ingestion.
- Provide a bounded telemetry consumer with per-sensor buffering, out-of-order handling, and duplicate sequence deduplication, along with a custom Sender wrapper.

Enhancements:
- Refactor telemetry into a dedicated module hierarchy, separating MQTT-specific types from generic telemetry types and re-exporting them from the crate root.
- Extend the MQTT telemetry consumer to use renamed MQTT-specific message and error types for clearer separation of concerns.
- Add slow-consumer logging and capacity awareness to the telemetry channel to surface backpressure conditions.

Build:
- Add chrono, uuid, crossbeam-channel, and log dependencies to support timestamped messages, sensor IDs, bounded channels, and logging.

Tests:
- Add unit tests validating duplicate sequence dropping, out-of-order buffering, and multi-sensor deduplication behaviour in the telemetry consumer.