### PR TITLE
feat(behavior): resolve #2051 — DynamicInternalGainAdapter Core

### DIFF
--- a/fluxion-behavior/src/internal_gains.rs
+++ b/fluxion-behavior/src/internal_gains.rs
@@ -72,3 +72,229 @@ impl Default for MetabolicRate {
         MetabolicRate::SeatedQuiet
     }
 }
+
+use chrono::{DateTime, Datelike, Timelike, Utc};
+use std::sync::Arc;
+
+use crate::lighting::{LightingModel, OccupantState};
+
+pub trait OccupancyProvider: Send + Sync {
+    fn occupant_state(&self, t: DateTime<Utc>) -> OccupantState;
+    fn occupant_count(&self, t: DateTime<Utc>) -> f64;
+}
+
+pub trait PlugLoadProvider: Send + Sync {
+    fn get_plug_load(&self, t: DateTime<Utc>) -> f64;
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+pub struct InternalGains {
+    pub phi_sensible: f64,
+    pub phi_latent: f64,
+}
+
+impl InternalGains {
+    pub fn new(phi_sensible: f64, phi_latent: f64) -> Self {
+        Self {
+            phi_sensible,
+            phi_latent,
+        }
+    }
+
+    pub fn zero() -> Self {
+        Self::default()
+    }
+}
+
+pub struct DynamicInternalGainAdapter {
+    occupancy: Arc<dyn OccupancyProvider>,
+    plug_loads: Arc<dyn PlugLoadProvider>,
+    lighting: LightingModel,
+    sensible_per_occupant: f64,
+    latent_per_occupant: f64,
+}
+
+impl DynamicInternalGainAdapter {
+    pub fn new(
+        occupancy: Arc<dyn OccupancyProvider>,
+        plug_loads: Arc<dyn PlugLoadProvider>,
+        lighting: LightingModel,
+    ) -> Self {
+        Self {
+            occupancy,
+            plug_loads,
+            lighting,
+            sensible_per_occupant: 70.0,
+            latent_per_occupant: 30.0,
+        }
+    }
+
+    pub fn with_metabolic_rates(
+        mut self,
+        sensible_per_occupant: f64,
+        latent_per_occupant: f64,
+    ) -> Self {
+        self.sensible_per_occupant = sensible_per_occupant;
+        self.latent_per_occupant = latent_per_occupant;
+        self
+    }
+
+    pub fn compute_gains(&self, _zone_id: uuid::Uuid, t: DateTime<Utc>) -> InternalGains {
+        let occupancy_state = self.occupancy.occupant_state(t);
+        let n_occupants = self.occupancy.occupant_count(t);
+        let plug_w = self.plug_loads.get_plug_load(t);
+        let lighting_w = self.lighting.compute(t, occupancy_state);
+
+        let occupant_sensible = n_occupants * self.sensible_per_occupant;
+        let occupant_latent = n_occupants * self.latent_per_occupant;
+
+        InternalGains {
+            phi_sensible: occupant_sensible + plug_w + lighting_w,
+            phi_latent: occupant_latent,
+        }
+    }
+}
+
+impl Default for DynamicInternalGainAdapter {
+    fn default() -> Self {
+        Self {
+            occupancy: Arc::new(ScheduleOccupancyProvider::default()),
+            plug_loads: Arc::new(ConstantPlugLoadProvider::default()),
+            lighting: LightingModel::default(),
+            sensible_per_occupant: 70.0,
+            latent_per_occupant: 30.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ScheduleOccupancyProvider {
+    pub hourly_counts: Vec<f64>,
+}
+
+impl ScheduleOccupancyProvider {
+    pub fn new(hourly_counts: Vec<f64>) -> Self {
+        Self { hourly_counts }
+    }
+}
+
+impl OccupancyProvider for ScheduleOccupancyProvider {
+    fn occupant_state(&self, t: DateTime<Utc>) -> OccupantState {
+        let hour = t.hour() as usize;
+        let count = self.hourly_counts.get(hour % 24).copied().unwrap_or(0.0);
+        if count > 0.0 {
+            OccupantState::PresentActive
+        } else {
+            OccupantState::Absent
+        }
+    }
+
+    fn occupant_count(&self, t: DateTime<Utc>) -> f64 {
+        let hour = t.hour() as usize;
+        self.hourly_counts.get(hour % 24).copied().unwrap_or(0.0)
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ConstantPlugLoadProvider {
+    pub watts: f64,
+}
+
+impl ConstantPlugLoadProvider {
+    pub fn new(watts: f64) -> Self {
+        Self { watts }
+    }
+}
+
+impl PlugLoadProvider for ConstantPlugLoadProvider {
+    fn get_plug_load(&self, _t: DateTime<Utc>) -> f64 {
+        self.watts
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn test_internal_gains_default() {
+        let gains = InternalGains::default();
+        assert!((gains.phi_sensible - 0.0).abs() < 1e-10);
+        assert!((gains.phi_latent - 0.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_internal_gains_new() {
+        let gains = InternalGains::new(100.0, 30.0);
+        assert!((gains.phi_sensible - 100.0).abs() < 1e-10);
+        assert!((gains.phi_latent - 30.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_dynamic_adapter_default() {
+        let adapter = DynamicInternalGainAdapter::default();
+        let t = Utc.with_ymd_and_hms(2024, 7, 15, 10, 0, 0).unwrap();
+        let gains = adapter.compute_gains(uuid::Uuid::new_v4(), t);
+        assert!(gains.phi_sensible >= 0.0);
+        assert!(gains.phi_latent >= 0.0);
+    }
+
+    #[test]
+    fn test_dynamic_adapter_zero_occupancy() {
+        let adapter = DynamicInternalGainAdapter::default();
+        let t = Utc.with_ymd_and_hms(2024, 7, 15, 3, 0, 0).unwrap();
+        let gains = adapter.compute_gains(uuid::Uuid::new_v4(), t);
+        assert!(gains.phi_latent <= 1e-10);
+    }
+
+    #[test]
+    fn test_dynamic_adapter_with_custom_metabolic() {
+        let occupancy = Arc::new(ScheduleOccupancyProvider::new(vec![1.0; 24]));
+        let plug_loads = Arc::new(ConstantPlugLoadProvider::new(100.0));
+        let lighting = LightingModel::default();
+
+        let adapter = DynamicInternalGainAdapter::new(occupancy, plug_loads, lighting)
+            .with_metabolic_rates(60.0, 40.0);
+
+        let t = Utc.with_ymd_and_hms(2024, 7, 15, 10, 0, 0).unwrap();
+        let gains = adapter.compute_gains(uuid::Uuid::new_v4(), t);
+
+        assert!(gains.phi_sensible > 0.0);
+        assert!((gains.phi_latent - 40.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_schedule_occupancy_provider() {
+        let provider = ScheduleOccupancyProvider::new(vec![
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0,
+            3.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        ]);
+        let t_night = Utc.with_ymd_and_hms(2024, 7, 15, 3, 0, 0).unwrap();
+        let t_day = Utc.with_ymd_and_hms(2024, 7, 15, 10, 0, 0).unwrap();
+
+        assert!((provider.occupant_count(t_night) - 0.0).abs() < 1e-10);
+        assert!((provider.occupant_count(t_day) - 5.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_constant_plug_load_provider() {
+        let provider = ConstantPlugLoadProvider::new(200.0);
+        let t = Utc.with_ymd_and_hms(2024, 7, 15, 12, 0, 0).unwrap();
+        assert!((provider.get_plug_load(t) - 200.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_dynamic_adapter_arc_traits() {
+        let occupancy: Arc<dyn OccupancyProvider> = Arc::new(ScheduleOccupancyProvider::default());
+        let plug_loads: Arc<dyn PlugLoadProvider> = Arc::new(ConstantPlugLoadProvider::new(150.0));
+        let lighting = LightingModel::default();
+
+        let adapter = DynamicInternalGainAdapter::new(occupancy, plug_loads, lighting);
+        let t = Utc.with_ymd_and_hms(2024, 7, 15, 14, 0, 0).unwrap();
+        let gains = adapter.compute_gains(uuid::Uuid::new_v4(), t);
+
+        assert!(gains.phi_sensible >= 0.0);
+        assert!(gains.phi_latent >= 0.0);
+    }
+}

--- a/fluxion-behavior/src/lib.rs
+++ b/fluxion-behavior/src/lib.rs
@@ -6,14 +6,22 @@
 //! - #2048: ONNX Model Loading from Environment Variables
 //! - #2049: Mock Plug Load Fallback with Diurnal Gaussian Noise
 //! - #2050: INT8 Quantization for TSFM CPU Inference
+//! - #2051: DynamicInternalGainAdapter Core
 
 pub mod comfort;
+pub mod internal_gains;
+pub mod lighting;
 pub mod triggers;
 
 pub use comfort::{
     AdaptiveComfort, AdaptiveComfortStatus, ComfortError, ComfortMetrics, PmvComfort,
     PmvComfortStatus, TriggerType,
 };
+pub use internal_gains::{
+    ConstantPlugLoadProvider, DynamicInternalGainAdapter, InternalGains, OccupancyProvider,
+    PlugLoadProvider, ScheduleOccupancyProvider,
+};
+pub use lighting::OccupantState;
 pub use triggers::{ComfortTrigger, OccupantComfortTriggers, OccupantComfortTriggersConfig};
 
 use ndarray::Dimension;

--- a/fluxion-behavior/src/lighting.rs
+++ b/fluxion-behavior/src/lighting.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Datelike};
+use chrono::{DateTime, Datelike, Timelike};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
@@ -188,8 +188,8 @@ impl ScheduleLightingModel {
 
     fn default_schedule() -> Vec<f64> {
         vec![
-            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1, 0.3, 0.8, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
-            0.8, 0.5, 0.2, 0.1, 0.0, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1, 0.3, 0.8, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.8,
+            0.5, 0.2, 0.1, 0.0, 0.0, 0.0, 0.0,
         ]
     }
 
@@ -203,17 +203,11 @@ impl ScheduleLightingModel {
         self
     }
 
-    pub fn lighting_power(
-        &self,
-        hour: f64,
-        zone_area: f64,
-        daylight_illuminance: f64,
-    ) -> f64 {
+    pub fn lighting_power(&self, hour: f64, zone_area: f64, daylight_illuminance: f64) -> f64 {
         let schedule_fraction = self.schedule_fraction(hour);
         let base_power = self.power_density * zone_area;
 
-        let daylight_reduction =
-            (daylight_illuminance / 1000.0).min(1.0) * self.daylighting_factor;
+        let daylight_reduction = (daylight_illuminance / 1000.0).min(1.0) * self.daylighting_factor;
 
         base_power * schedule_fraction * (1.0 - daylight_reduction)
     }
@@ -231,21 +225,11 @@ impl ScheduleLightingModel {
         0.3
     }
 
-    pub fn radiative_gain(
-        &self,
-        hour: f64,
-        zone_area: f64,
-        daylight_illuminance: f64,
-    ) -> f64 {
+    pub fn radiative_gain(&self, hour: f64, zone_area: f64, daylight_illuminance: f64) -> f64 {
         self.lighting_power(hour, zone_area, daylight_illuminance) * self.radiative_fraction()
     }
 
-    pub fn convective_gain(
-        &self,
-        hour: f64,
-        zone_area: f64,
-        daylight_illuminance: f64,
-    ) -> f64 {
+    pub fn convective_gain(&self, hour: f64, zone_area: f64, daylight_illuminance: f64) -> f64 {
         self.lighting_power(hour, zone_area, daylight_illuminance) * self.convective_fraction()
     }
 }


### PR DESCRIPTION
Closes #2051

Implements the DynamicInternalGainAdapter core that translates stochastic behavioral signals into thermal heat gains.

## Changes

- OccupancyProvider trait with occupant_state() and occupant_count() methods
- PlugLoadProvider trait with get_plug_load() method  
- InternalGains struct with phi_sensible and phi_latent fields
- DynamicInternalGainAdapter with Arc dyn OccupancyProvider, Arc dyn PlugLoadProvider, and LightingModel
- Default metabolic rates: 70W sensible + 30W latent per occupant
- ScheduleOccupancyProvider and ConstantPlugLoadProvider implementations
- All traits are Send + Sync for thread-safe sharing

## Acceptance Criteria

- [x] DynamicInternalGainAdapter with occupancy, plug loads, lighting
- [x] compute_gains() returns InternalGains { phi_sensible, phi_latent }
- [x] Default occupant heat: 70W sensible + 30W latent per person
- [x] Arc dyn for thread-safe sharing

## Summary by Sourcery

Introduce a dynamic internal gains adapter that converts time-varying occupancy, plug load, and lighting signals into sensible and latent heat gains.

New Features:
- Add OccupancyProvider and PlugLoadProvider traits for providing time-dependent occupancy and plug load data.
- Add InternalGains struct to represent sensible and latent internal heat gains.
- Add DynamicInternalGainAdapter to compute internal gains from occupancy, plug loads, and lighting with configurable per-occupant metabolic rates.
- Add ScheduleOccupancyProvider and ConstantPlugLoadProvider as default implementations for occupancy and plug loads.
- Expose new internal gains and lighting types from the fluxion-behavior crate public API.

Tests:
- Add unit tests covering InternalGains construction, default dynamic adapter behavior, custom metabolic rates, schedule-based occupancy, constant plug loads, and Arc-based trait usage.