### PR TITLE
perf(thermal): resolve #1966 — Pool physics scratch buffers as ThermalModel fields

### DIFF
--- a/src/sim/thermal_model_data.rs
+++ b/src/sim/thermal_model_data.rs
@@ -21,6 +21,7 @@ use crate::sim::occupancy::BuildingType;
 use crate::sim::schedule::DailySchedule;
 use crate::sim::solar::{SolarPosition, WindowProperties};
 use crate::sim::thermal_model_core::DoorGeometry;
+use crate::sim::thermal_model_scratch::PhysicsScratchPool;
 use crate::testing::integration::wiring::WiringTracer;
 use crate::validation::diagnostics::SimulationDiagnostics;
 use crate::weather::HourlyWeatherData;
@@ -301,6 +302,12 @@ pub struct ThermalModelData<T: ContinuousTensor<f64> + Clone> {
     /// Issue #1968 — cached zero vector to eliminate per-timestep `vec![0.0; num_zones]`
     /// allocations in hot loops. Cloned (not borrowed) to avoid borrow conflicts.
     pub zero_vector: VectorField,
+    /// Issue #1966 — pooled physics scratch buffers for per-timestep solvers.
+    ///
+    /// Lazily initialized on first use by `step_physics_*`. The pool is NOT
+    /// cloned on `ThermalModelData::clone()` (clone gets a fresh empty pool);
+    /// cloning is a cold-path operation that does not need pooled scratch reuse.
+    pub scratch_pool: PhysicsScratchPool,
 }
 
 impl<T: ContinuousTensor<f64> + Clone> Clone for ThermalModelData<T> {
@@ -454,6 +461,7 @@ impl<T: ContinuousTensor<f64> + Clone> Clone for ThermalModelData<T> {
             incident_solar_per_surface: self.incident_solar_per_surface.clone(),
             sun_pos_cache: Default::default(), // Issue #1970
             zero_vector: self.zero_vector.clone(),
+            scratch_pool: PhysicsScratchPool::new(), // Fresh pool on clone; scratch is not deep-cloned
         }
     }
 }

--- a/src/sim/thermal_model_physics/physics_impl.rs
+++ b/src/sim/thermal_model_physics/physics_impl.rs
@@ -32,7 +32,7 @@ use crate::sim::thermal_integration::{
 };
 use crate::sim::thermal_model_core::ThermalModel;
 use crate::sim::thermal_model_scratch::{
-    PhysicsScratch5r1c, PhysicsScratch6r2c, PhysicsScratch9r4c,
+    PhysicsScratch5r1c, PhysicsScratch6r2c, PhysicsScratch9r4c, PhysicsScratchPool,
 };
 use crate::sim::ventilation::h_tr_is_ach_multiplier;
 
@@ -213,7 +213,9 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
 
         // Issue #1524: consolidated per-timestep scratch (replaces the six
         // standalone `Vec::with_capacity(num_zones)` allocations below).
-        let mut scratch = PhysicsScratch5r1c::new(self.0.num_zones);
+        // Issue #1966: scratch is now pooled in ThermalModelData::scratch_pool
+        // and reused across timesteps via fill_zero() at end of step.
+        let scratch = self.0.scratch_pool.get_5r1c(self.0.num_zones);
 
         for i in 0..self.0.num_zones {
             let load_w = loads_ref[i] * area_ref[i];
@@ -1451,6 +1453,10 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
             self.0.current_hvac_output = None;
         }
 
+        // Issue #1966: restore pooled scratch buffers for next timestep
+        // (phi_ia, phi_st, phi_m were moved out via mem::take above)
+        self.0.scratch_pool.get_5r1c(self.0.num_zones).fill_zero();
+
         net_hvac_energy_for_step / 3.6e6 // Return kWh
     }
 
@@ -1521,7 +1527,9 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
 
         // Issue #1524: consolidated per-timestep scratch (replaces the eleven
         // standalone `Vec::with_capacity(num_zones)` allocations in 6R2C).
-        let mut scratch = PhysicsScratch6r2c::new(self.0.num_zones);
+        // Issue #1966: scratch is now pooled in ThermalModelData::scratch_pool
+        // and reused across timesteps via fill_zero() at end of step.
+        let scratch = self.0.scratch_pool.get_6r2c(self.0.num_zones);
 
         for i in 0..self.0.num_zones {
             let load_w = loads_ref[i] * area_ref[i];
@@ -2311,6 +2319,10 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
             partition_mass.as_mut()[i] += dtm_partition;
         }
 
+        // Issue #1966: restore pooled scratch buffers for next timestep
+        // (phi_ia, phi_st, phi_m_env, phi_m_int were moved out via mem::take above)
+        self.0.scratch_pool.get_6r2c(self.0.num_zones).fill_zero();
+
         energy
     }
 
@@ -2418,7 +2430,9 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
         // Issue #1524: consolidated per-timestep scratch (replaces the fourteen
         // standalone `Vec::with_capacity(num_zones)` allocations in 9R4C; the
         // seven read-back intermediates share one flat buffer).
-        let mut scratch = PhysicsScratch9r4c::new(self.0.num_zones);
+        // Issue #1966: scratch is now pooled in ThermalModelData::scratch_pool
+        // and reused across timesteps via fill_zero() at end of step.
+        let scratch = self.0.scratch_pool.get_9r4c(self.0.num_zones);
 
         for i in 0..self.0.num_zones {
             let load_w = loads_ref[i] * area_ref[i];
@@ -3493,6 +3507,10 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
             self.0.diagnostics = Some(diag);
             self.0.current_hvac_output = None;
         }
+
+        // Issue #1966: restore pooled scratch buffers for next timestep
+        // (phi_ia, phi_st, phi_m were moved out via mem::take above)
+        self.0.scratch_pool.get_9r4c(self.0.num_zones).fill_zero();
 
         // Return kWh
         hvac_power_watts * dt / 3.6e6

--- a/src/sim/thermal_model_scratch.rs
+++ b/src/sim/thermal_model_scratch.rs
@@ -6,6 +6,7 @@
 //! capacity and just zero-fills in-place.
 
 pub(crate) struct PhysicsScratch5r1c {
+    pub num_zones: usize,
     pub phi_ia: Vec<f64>,
     pub phi_st: Vec<f64>,
     pub phi_m: Vec<f64>,
@@ -19,6 +20,7 @@ pub(crate) struct PhysicsScratch5r1c {
 impl PhysicsScratch5r1c {
     pub fn new(num_zones: usize) -> Self {
         Self {
+            num_zones,
             phi_ia: vec![0.0; num_zones],
             phi_st: vec![0.0; num_zones],
             phi_m: vec![0.0; num_zones],
@@ -32,7 +34,7 @@ impl PhysicsScratch5r1c {
 
     #[allow(dead_code)]
     pub fn fill_zero(&mut self) {
-        let n = self.phi_ia.len();
+        let n = self.num_zones;
         self.phi_ia.resize(n, 0.0);
         self.phi_st.resize(n, 0.0);
         self.phi_m.resize(n, 0.0);
@@ -69,6 +71,7 @@ impl PhysicsScratch5r1c {
 }
 
 pub(crate) struct PhysicsScratch6r2c {
+    pub num_zones: usize,
     pub phi_ia: Vec<f64>,
     pub phi_st: Vec<f64>,
     pub phi_m_env: Vec<f64>,
@@ -85,6 +88,7 @@ pub(crate) struct PhysicsScratch6r2c {
 impl PhysicsScratch6r2c {
     pub fn new(num_zones: usize) -> Self {
         Self {
+            num_zones,
             phi_ia: vec![0.0; num_zones],
             phi_st: vec![0.0; num_zones],
             phi_m_env: vec![0.0; num_zones],
@@ -101,7 +105,7 @@ impl PhysicsScratch6r2c {
 
     #[allow(dead_code)]
     pub fn fill_zero(&mut self) {
-        let n = self.phi_ia.len();
+        let n = self.num_zones;
         self.phi_ia.resize(n, 0.0);
         self.phi_st.resize(n, 0.0);
         self.phi_m_env.resize(n, 0.0);


### PR DESCRIPTION
Closes #1966

Pools the physics scratch buffers (`PhysicsScratch5r1c`, `PhysicsScratch6r2c`, `PhysicsScratch9r4c`) as reusable fields in `ThermalModelData` via `PhysicsScratchPool`, eliminating the per-timestep heap allocations that were occurring in `step_physics_*` functions.

**Changes:**
- Added `num_zones` field to `PhysicsScratch5r1c` and `PhysicsScratch6r2c` (matching the existing pattern in `PhysicsScratch9r4c`)
- Updated `fill_zero()` methods to use the explicit `num_zones` field instead of capturing length via `.len()`, ensuring correct behavior after `mem::take`
- Added `scratch_pool: PhysicsScratchPool` field to `ThermalModelData` (lazily initialized on first use)
- Changed `step_physics_5r1c`, `step_physics_6r2c`, and `step_physics_9r4c` to use pooled scratch and call `fill_zero()` at end of each step

**Note:** Build verification was blocked by a system-level SIGILL in the compiler's LLVM backend during dependency compilation (proc-macro2, quote crates). The issue is reproducible in the upstream repository as well and appears to be an environment/hardware issue rather than a code problem.

## Summary by Sourcery

Pool thermal physics scratch buffers in a reusable structure attached to ThermalModelData to eliminate per-timestep heap allocations in physics stepping routines.

Enhancements:
- Add a PhysicsScratchPool and associated scratch buffer types to reuse thermal model physics scratch allocations across timesteps for 5R1C, 6R2C, and 9R4C solvers.
- Extend ThermalModelData with a lazily-initialized scratch_pool field and ensure clones start with a fresh, empty pool.
- Refactor physics stepping functions to obtain scratch space from the shared pool and reset it between timesteps instead of allocating new buffers each step.