### PR TITLE
fix(ci): add required-features for fluid integration test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -449,6 +449,7 @@ harness = true
 name = "integration-fluid-energy-conservation"
 path = "tests/integration/test_fluid_energy_conservation.rs"
 harness = true
+required-features = ["fluid"]
 
 [[test]]
 name = "solar_gain_unit_tests"


### PR DESCRIPTION
This PR fixes a pre-existing CI issue where the integration-fluid-energy-conservation test was being compiled without the 'fluid' feature enabled, causing test failures across multiple PRs.

The fix adds `required-features = ["fluid"]` to the test definition in Cargo.toml.