### PR TITLE
fix(hvac): correct heat pump cooling COP assertion (4.5 -> 3.0)

### DIFF
--- a/src/sim/hvac/equipment.rs
+++ b/src/sim/hvac/equipment.rs
@@ -943,7 +943,7 @@ mod tests {
         // HP cooling uses constant COP = rated COP
         let eff_cooling = hp.calculate_efficiency(0.5, 35.0, HVACMode::Cooling);
         assert!(eff_cooling > 0.0);
-        assert!((eff_cooling - 4.5).abs() < 0.1); // Constant COP at rated
+        assert!((eff_cooling - 3.0).abs() < 0.1); // Constant COP at rated
         assert!(eff_cooling.is_finite()); // Must be a valid number
 
         // Test calculate_power for heating


### PR DESCRIPTION
PR #2202 added normalization to HeatPump::calculate_efficiency for cooling mode, but the test assertion was not updated to match. The normalized result equals the rated cooling COP (3.0), not the raw polynomial output (4.5).

Fixes test failure introduced in PR #2202.

## Summary by Sourcery

Bug Fixes:
- Correct the cooling COP assertion in the heat pump efficiency test to match the normalized rated COP.