### PR TITLE
fix(docker): add missing workspace member directories to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,9 @@ COPY fluxion-fluid/ ./fluxion-fluid/
 COPY fluxion-grid/ ./fluxion-grid/
 COPY fluxion-behavior/ ./fluxion-behavior/
 COPY fluxion-mcp/ ./fluxion-mcp/
+COPY fluxion-wasm/ ./fluxion-wasm/
 COPY crates/fluxion-toon/ ./crates/fluxion-toon/
+COPY crates/fluxion-twin/ ./crates/fluxion-twin/
 COPY src/ ./src/
 # `Cargo.toml` references a few bench harnesses; copy them so the
 # manifest parses even when we are only building the `fluxion-rest`


### PR DESCRIPTION
The Dockerfile was missing `fluxion-wasm/` and `crates/fluxion-twin/` in the COPY statements, causing the Docker build to fail with:

```
error: failed to load manifest for workspace member `/build/fluxion-wasm`
referenced by workspace at `/build/Cargo.toml`

Caused by:
  failed to read `/build/fluxion-wasm/Cargo.toml`
  No such file or directory (os error 2)
```

This fix adds the missing COPY instructions to match the workspace members defined in `Cargo.toml`.

Note: This is a rebase of PR #2221 onto current develop to resolve the CI failures that were present in the original PR's base commit.