### PR TITLE
Fix #2223: Update boiler test assertion to match 8% fan power factor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,9 @@ COPY fluxion-fluid/ ./fluxion-fluid/
 COPY fluxion-grid/ ./fluxion-grid/
 COPY fluxion-behavior/ ./fluxion-behavior/
 COPY fluxion-mcp/ ./fluxion-mcp/
+COPY fluxion-wasm/ ./fluxion-wasm/
 COPY crates/fluxion-toon/ ./crates/fluxion-toon/
+COPY crates/fluxion-twin/ ./crates/fluxion-twin/
 COPY src/ ./src/
 # `Cargo.toml` references a few bench harnesses; copy them so the
 # manifest parses even when we are only building the `fluxion-rest`

--- a/src/sim/hvac/equipment.rs
+++ b/src/sim/hvac/equipment.rs
@@ -749,10 +749,11 @@ mod tests {
 
         // Test power calculation
         // For a gas boiler, total heating fuel power = thermal_load / efficiency + fan power
-        // At PLR=0.5 (50kW load / 100kW capacity), fuel power = 50000/0.85 + 50000*0.01 ≈ 59324W
+        // At PLR=0.5 (50kW load / 100kW capacity), fuel power = 50000/0.85 + 50000*0.08 ≈ 62824W
         // This is the total energy input rate (fuel + parasitic electrical)
+        // Issue #2223: Updated from 0.01 to 0.08 to match BESTEST reference (commit 22029647)
         let power = boiler.calculate_power(50000.0, -5.0, HVACMode::Heating);
-        assert!(power > 59000.0 && power < 60000.0); // ~59324W for 50kW thermal output at 85% efficiency
+        assert!(power > 62000.0 && power < 64000.0); // ~62824W for 50kW thermal output at 85% efficiency with 8% fan power
 
         // Test PLR tracking
         let mut boiler_mut = boiler.clone();


### PR DESCRIPTION
Fixes #2223

## Summary

The boiler electrical_power_factor was changed from 0.01 to 0.08 in commit 22029647 to match BESTEST reference (Issue #2217), but the unit test test_boiler_variable_capacity still expected the old 1% fan power result (~59.3 kW). This caused the test to fail on CI with the actual value of ~62.8 kW.

## Changes

- Updated the test assertion and comment in src/sim/hvac/equipment.rs
- Changed expected power range from 59000-60000W to 62000-64000W to match the correct 8% fan power calculation

## Testing

- All HVAC equipment tests pass (13 tests)
- All integration tests in tests/hvac_equipment.rs pass (9 tests)
- cargo fmt check passes
- cargo clippy passes

## Root Cause

Commit 22029647 updated electrical_power_factor from 0.01 to 0.08 to match BESTEST reference methodology, but the corresponding unit test was not updated.

## See Also

- Issue #2217 (original fix for boiler fan power factor)
- Issue #2223 (this issue - test failure)

## Summary by Sourcery

Align boiler fan power unit test expectations with the updated 8% electrical power factor and ensure Docker build context includes new Fluxion crates.

Bug Fixes:
- Update boiler variable-capacity test assertion and comments to reflect the correct 8% fan power factor and expected power range.

Build:
- Include fluxion-wasm and fluxion-twin crates in the Docker image build context to support their use in containerized builds.