### PR TITLE
fix(ci): resolve dtolnay/rust-toolchain API change in documentation workflow

### DIFF
--- a/.github/workflows/ashrae_validation.yml
+++ b/.github/workflows/ashrae_validation.yml
@@ -163,8 +163,6 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
 
       - name: Cache cargo dependencies
         uses: actions/cache@v4
@@ -372,8 +370,6 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
 
       - name: Cache cargo dependencies
         uses: actions/cache@v4
@@ -596,8 +592,6 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
 
       - name: Cache cargo dependencies
         uses: actions/cache@v4

--- a/.github/workflows/determinism_check.yml
+++ b/.github/workflows/determinism_check.yml
@@ -44,8 +44,6 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ matrix.rust }}
 
       - name: Cache cargo dependencies
         uses: actions/cache@v4

--- a/.github/workflows/performance_dashboard.yml
+++ b/.github/workflows/performance_dashboard.yml
@@ -43,8 +43,6 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
 
       - name: Cache cargo
         uses: actions/cache@v4

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -27,8 +27,6 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
 
       - name: Cache dependencies
         uses: actions/cache@v4


### PR DESCRIPTION
Closes #2210

## Summary by Sourcery

CI:
- Remove explicit toolchain parameters from dtolnay/rust-toolchain usage across multiple workflows to comply with its updated API.