### PR TITLE
fix(ci): resolve dtolnay/rust-toolchain API change in setup-rust-env action

### DIFF
--- a/.github/actions/setup-rust-env/action.yml
+++ b/.github/actions/setup-rust-env/action.yml
@@ -9,10 +9,6 @@ inputs:
     description: 'Rust components to install (e.g., rustfmt,clippy)'
     required: false
     default: ''
-  toolchain:
-    description: 'Rust toolchain version'
-    required: false
-    default: 'stable'
   sccache:
     description: |
       Enable sccache compiler caching via GHA cache backend.


### PR DESCRIPTION
Closes #2209

## Summary by Sourcery

CI:
- Simplify the setup-rust-env composite action by dropping the configurable Rust toolchain input.