### PR TITLE
fix(ci): resolve dtolnay/rust-toolchain API change in surrogate-drift workflow

### DIFF
--- a/.github/actions/setup-rust-env/action.yml
+++ b/.github/actions/setup-rust-env/action.yml
@@ -42,6 +42,7 @@ runs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
       with:
+        toolchain: ${{ inputs.toolchain }}
         components: ${{ inputs.components }}
 
     # sccache: content-addressed compiler cache backed by GHA cache API.


### PR DESCRIPTION
Closes #2208

## Summary by Sourcery

Update the Rust setup GitHub Action to pass the configured toolchain to dtolnay/rust-toolchain to keep CI workflows compatible with upstream changes.

Bug Fixes:
- Ensure the CI Rust setup action correctly specifies the toolchain input expected by the updated dtolnay/rust-toolchain action.

CI:
- Adjust the custom setup-rust-env GitHub Action to explicitly forward the toolchain input when invoking dtolnay/rust-toolchain.