### PR TITLE
fix(ci): upgrade sccache-action to fix Node.js 20 deprecation

### DIFF
--- a/.github/actions/setup-rust-env/action.yml
+++ b/.github/actions/setup-rust-env/action.yml
@@ -45,7 +45,7 @@ runs:
     # Caches individual compilation units; no stale-cache issues on Cargo.lock changes.
     - name: Set up sccache
       if: inputs.sccache == 'true'
-      uses: mozilla-actions/sccache-action@v0.0.9
+      uses: mozilla-actions/sccache-action@v0.0.11
 
     - name: Enable sccache as rustc wrapper
       if: inputs.sccache == 'true'


### PR DESCRIPTION
Closes #2179

## Summary by Sourcery

CI:
- Update the sccache GitHub Action used in the Rust CI setup to v0.0.11 to address Node.js 20 deprecation issues.