### PR TITLE
fix(city): fix parallel_harness bench imports to match actual API (#2254)

### DIFF
--- a/fluxion-city/Cargo.toml
+++ b/fluxion-city/Cargo.toml
@@ -25,3 +25,8 @@ parallel = ["rayon"]
 criterion = "0.5"
 rand = "0.8"
 sysinfo = "0.30"
+
+[[bench]]
+name = "parallel_harness"
+harness = false
+required-features = ["parallel"]


### PR DESCRIPTION
Closes #2254

## Problem

`cargo build -p fluxion-city --benches` failed with `E0432: unresolved imports` — `parallel_harness.rs` imported `BuildingGroup` and `UrbanStepDispatcher` which only exist behind the `parallel` feature gate.

## Fix

The types `BuildingGroup`, `UrbanRadiationSystem`, and `UrbanStepDispatcher` already exist in `fluxion-city/src/parallel/harness.rs` — exported only behind the `parallel` feature. Added explicit `[[bench]]` section in `Cargo.toml` with `required-features = ["parallel"]` and `harness = false`.

## Verification

- `cargo build -p fluxion-city --benches` → exits 0
- `cargo build -p fluxion-city` → exits 0
- `cargo bench -p fluxion-city --features parallel --no-run` → compiles
- `cargo fmt -p fluxion-city -- --check` → clean

## Acceptance Criteria

- [x] `cargo build -p fluxion-city --benches` exits 0