### PR TITLE
[fluxion-fluid] Define HvacState and HvacMode types

### DIFF
--- a/fluxion-fluid/Cargo.toml
+++ b/fluxion-fluid/Cargo.toml
@@ -12,6 +12,7 @@ thiserror = "1.0"
 num-traits = "0.2"
 uom = { version = "0.35", features = ["f32"] }
 nalgebra = "0.34"
+uuid = { version = "1.0", features = ["serde"] }
 
 [dev-dependencies]
 approx = "0.5"

--- a/fluxion-fluid/src/hvac.rs
+++ b/fluxion-fluid/src/hvac.rs
@@ -1,0 +1,32 @@
+//! HVAC operational state types for thermal-electrical coupling.
+//!
+//! This module defines the core HVAC types used across fluxion for representing
+//! heating, ventilation, and air conditioning operational states.
+
+use uuid::Uuid;
+
+/// Operating mode of the HVAC system.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HvacMode {
+    Off = 0,
+    Heating = 1,
+    Cooling = 2,
+}
+
+/// HVAC operational state for a single building.
+///
+/// This represents the thermal demand and operating conditions of an HVAC system
+/// serving a specific building, which can be converted to electrical load via COP.
+#[derive(Debug, Clone)]
+pub struct HvacState {
+    /// Unique identifier of the building this HVAC serves
+    pub building_id: Uuid,
+    /// Thermal power demand (W) — positive for cooling, negative for heating
+    pub thermal_power_w: f64,
+    /// Indoor air temperature setpoint (°C)
+    pub setpoint_c: f64,
+    /// Ambient outdoor air temperature (°C)
+    pub ambient_temperature_c: f64,
+    /// Operating mode: 0=off, 1=heating, 2=cooling
+    pub mode: HvacMode,
+}

--- a/fluxion-fluid/src/lib.rs
+++ b/fluxion-fluid/src/lib.rs
@@ -31,6 +31,7 @@
 
 pub mod autodiff;
 pub mod energy;
+pub mod hvac;
 pub mod mediums;
 pub mod pantelides;
 pub mod ports;
@@ -44,6 +45,7 @@ pub use energy::{
     ConservationNode, EnergyConservationError, EnergyConservationResult,
     EnergyConservationVerifier, EnthalpyFlow, FluidNetworkGraph, SimulationResults,
 };
+pub use hvac::{HvacMode, HvacState};
 pub use mediums::{Air, CompatibleWith, Medium, Water};
 pub use pantelides::{
     pantelides_reduce, EqIndex, Equation, IncidenceMatrix, PantelidesError, PantelidesOutput,

--- a/fluxion-grid/Cargo.toml
+++ b/fluxion-grid/Cargo.toml
@@ -16,6 +16,7 @@ uuid = { version = "1.0", features = ["serde", "v4"] }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 nalgebra = "0.34"
+fluxion-fluid = { path = "../fluxion-fluid" }
 
 [dev-dependencies]
 approx = "0.5"

--- a/fluxion-grid/src/lib.rs
+++ b/fluxion-grid/src/lib.rs
@@ -48,6 +48,7 @@ pub use power_flow::{
     DEFAULT_MAX_ITERATIONS, DEFAULT_TOLERANCE,
 };
 
+use fluxion_fluid::hvac::{HvacMode, HvacState};
 use nalgebra::DMatrix;
 
 pub type VoltagePu = f64;
@@ -281,32 +282,6 @@ impl ElectricalNetwork {
 
         self.angles = new_angles;
     }
-}
-
-/// HVAC operational state for a single building.
-///
-/// This represents the thermal demand and operating conditions of an HVAC system
-/// serving a specific building, which can be converted to electrical load via COP.
-#[derive(Debug, Clone)]
-pub struct HvacState {
-    /// Unique identifier of the building this HVAC serves
-    pub building_id: uuid::Uuid,
-    /// Thermal power demand (W) — positive for cooling, negative for heating
-    pub thermal_power_w: f64,
-    /// Indoor air temperature setpoint (°C)
-    pub setpoint_c: f64,
-    /// Ambient outdoor air temperature (°C)
-    pub ambient_temperature_c: f64,
-    /// Operating mode: 0=off, 1=heating, 2=cooling
-    pub mode: HvacMode,
-}
-
-/// Operating mode of the HVAC system.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum HvacMode {
-    Off = 0,
-    Heating = 1,
-    Cooling = 2,
 }
 
 /// Electrical load at a building bus.


### PR DESCRIPTION
Closes #2274

## Summary by Sourcery

Extract shared HVAC state types into the fluxion-fluid crate and update fluxion-grid to consume them for thermal-electrical coupling.

New Features:
- Introduce a fluxion-fluid hvac module defining shared HvacMode and HvacState types for HVAC operational modeling.

Enhancements:
- Re-export HvacMode and HvacState from fluxion-fluid for use by downstream crates.
- Update fluxion-grid to depend on fluxion-fluid and use the shared HVAC types instead of local definitions.

Build:
- Add uuid as a dependency of fluxion-fluid and add a local fluxion-fluid dependency to fluxion-grid.