### PR TITLE
[fluxion-grid] Resolve architectural gap: optional fluxion dependency

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -544,6 +544,47 @@ The common-wall limit (separation `< 0.01 m`) is the analytical limit `F_AB = A_
 
 ---
 
+### Module N+1: Grid-Edge Electrical Network (`fluxion-grid`)
+
+**Source**: `fluxion-grid/` (standalone crate, workspace member)
+**Purpose**: Grid-edge electrical network components for joint thermal-electrical convergence: battery storage, bus nodes, power flow analysis, and `ThermalElectricalCoupler` for COP-based thermal-to-electrical conversion.
+
+**Crate independence**: `fluxion-grid` has **no default dependency** on the main `fluxion` crate. It ships with its own simplified `ThermalModel` and `ThermalElectricalCoupler` that operate on scalar HVAC state values (`HvacState`, `ElectricalLoad`). This keeps the crate buildable and testable without pulling in the full thermal solver stack.
+
+**Optional `fluxion` integration (Issue #2275)**: When the `fluxion` feature flag is enabled, `fluxion-grid` gains access to `Arc<dyn ThermalModelTrait>` via an optional dependency on the main `fluxion` crate. The `fluxion_bridge::ThermalModelBridge` struct holds both a `ThermalElectricalCoupler` and an `Arc<dyn ThermalModelTrait>`, enabling joint convergence where the grid-side coupler queries the full thermal solver state directly rather than relying on scalar HVAC values.
+
+| Feature | ThermalElectricalCoupler behavior |
+|---------|----------------------------------|
+| Default (no feature) | Works with scalar `HvacState` values, COP-based conversion |
+| `fluxion` feature | Can additionally hold `Arc<dyn ThermalModelTrait>` via `ThermalModelTraitBridge` |
+
+**Key structs** (always available):
+- `ThermalElectricalCoupler` — COP-based coupler between thermal and electrical systems
+- `HvacState` — HVAC operational state for a single building
+- `ElectricalLoad` — Electrical load at a building bus
+- `ThermalModel` — Simplified thermal model for joint convergence (standalone, not `ThermalModelTrait`)
+- `ElectricalNetwork` — Electrical network with bus voltages and power injections
+- `JointConvergenceSolver` — Iterative solver for coupled thermal-electrical systems
+
+**Key structs** (requires `fluxion` feature):
+- `ThermalModelTraitBridge` — Bridge holding `ThermalElectricalCoupler` + `Arc<dyn ThermalModelTrait>`
+
+**Joint convergence pattern** (with `fluxion` feature):
+
+```rust
+use fluxion_grid::{ThermalElectricalCoupler, ElectricalNetwork};
+use fluxion_grid::fluxion_bridge::ThermalModelTraitBridge;
+
+let coupler = ThermalElectricalCoupler::new(3.0);
+let thermal_model: Arc<dyn ThermalModelTrait> = /* from fluxion */;
+let bridge = ThermalModelTraitBridge::new(coupler, thermal_model);
+
+// Query thermal model directly → convert to electrical
+let electrical_power = bridge.hvac_power_to_electrical(timestep, outdoor_temp);
+```
+
+---
+
 ### Module 6: Gauge-Theory Foundation (Phase 1a — #1461)
 
 **Source**: `src/physics/geometry_tensor.rs` (lives alongside the existing CTA `GeometryTensor` types for the Python↔Rust boundary; the two domains are deliberately kept on different storage representations — `Vec<f64>` for the CTA tensors, `nalgebra::{Matrix4, Vector4}` for the gauge-theory manifold, because their consumers diverge).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,6 +1304,7 @@ name = "fluxion-grid"
 version = "0.1.0"
 dependencies = [
  "approx",
+ "fluxion",
  "nalgebra",
  "proptest",
  "serde",

--- a/fluxion-grid/Cargo.toml
+++ b/fluxion-grid/Cargo.toml
@@ -11,11 +11,22 @@ license = "Apache-2.0"
 name = "fluxion_grid"
 path = "src/lib.rs"
 
+[features]
+default = []
+# Enable integration with the main fluxion crate's ThermalModelTrait.
+# When enabled, ThermalElectricalCoupler can hold Arc<dyn ThermalModelTrait>
+# for joint thermal-electrical convergence with the full thermal solver.
+fluxion = ["dep:fluxion"]
+
 [dependencies]
 uuid = { version = "1.0", features = ["serde", "v4"] }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 nalgebra = "0.33"
+
+# Optional dependency on the main fluxion crate for ThermalModelTrait integration.
+# Only available when the "fluxion" feature flag is enabled.
+fluxion = { path = "..", version = "1.0.0", optional = true }
 
 [dev-dependencies]
 approx = "0.5"

--- a/fluxion-grid/src/fluxion_bridge.rs
+++ b/fluxion-grid/src/fluxion_bridge.rs
@@ -32,7 +32,10 @@ pub struct ThermalModelTraitBridge {
 #[cfg(feature = "fluxion")]
 impl ThermalModelTraitBridge {
     /// Create a new bridge with a coupler and thermal model.
-    pub fn new(coupler: crate::ThermalElectricalCoupler, thermal_model: Arc<dyn ThermalModelTrait>) -> Self {
+    pub fn new(
+        coupler: crate::ThermalElectricalCoupler,
+        thermal_model: Arc<dyn ThermalModelTrait>,
+    ) -> Self {
         Self {
             coupler,
             thermal_model,

--- a/fluxion-grid/src/fluxion_bridge.rs
+++ b/fluxion-grid/src/fluxion_bridge.rs
@@ -1,0 +1,69 @@
+//! Bridge module for integrating with the main `fluxion` crate's `ThermalModelTrait`.
+//!
+//! This module is only available when the `fluxion` feature flag is enabled.
+//! It provides a wrapper that allows `ThermalElectricalCoupler` to hold
+//! `Arc<dyn ThermalModelTrait>` for joint thermal-electrical convergence.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use fluxion_grid::thermal_electrical_coupler::ThermalElectricalCoupler;
+//! use fluxion_grid::fluxion_bridge::ThermalModelTraitBridge;
+//!
+//! let coupler = ThermalElectricalCoupler::new(3.0);
+//! let bridge = ThermalModelTraitBridge::new(coupler, thermal_model);
+//! ```
+
+use std::sync::Arc;
+
+#[cfg(feature = "fluxion")]
+use fluxion::ThermalModelTrait;
+
+/// Bridge that holds both a `ThermalElectricalCoupler` and an `Arc<dyn ThermalModelTrait>`.
+///
+/// This enables joint thermal-electrical convergence where the grid-side coupler
+/// can query the full thermal solver state rather than relying on scalar HVAC values.
+#[cfg(feature = "fluxion")]
+pub struct ThermalModelTraitBridge {
+    coupler: crate::ThermalElectricalCoupler,
+    thermal_model: Arc<dyn ThermalModelTrait>,
+}
+
+#[cfg(feature = "fluxion")]
+impl ThermalModelTraitBridge {
+    /// Create a new bridge with a coupler and thermal model.
+    pub fn new(coupler: crate::ThermalElectricalCoupler, thermal_model: Arc<dyn ThermalModelTrait>) -> Self {
+        Self {
+            coupler,
+            thermal_model,
+        }
+    }
+
+    /// Get a reference to the thermal model.
+    pub fn thermal_model(&self) -> &Arc<dyn ThermalModelTrait> {
+        &self.thermal_model
+    }
+
+    /// Get a reference to the coupler.
+    pub fn coupler(&self) -> &crate::ThermalElectricalCoupler {
+        &self.coupler
+    }
+
+    /// Get a mutable reference to the coupler.
+    pub fn coupler_mut(&mut self) -> &mut crate::ThermalElectricalCoupler {
+        &mut self.coupler
+    }
+
+    /// Get HVAC power demand from the thermal model and convert to electrical load.
+    ///
+    /// This queries `hvac_power_demand` from `ThermalModelTrait` and passes
+    /// the result through the `ThermalElectricalCoupler` COP conversion.
+    pub fn hvac_power_to_electrical(&self, timestep: usize, outdoor_temp: f64) -> f64 {
+        let thermal_power = self.thermal_model.hvac_power_demand(timestep, outdoor_temp);
+        self.coupler.thermal_to_electrical_simple(thermal_power)
+    }
+}
+
+/// Tag type indicating the fluxion feature is not enabled.
+#[cfg(not(feature = "fluxion"))]
+pub struct ThermalModelTraitBridge;

--- a/fluxion-grid/src/lib.rs
+++ b/fluxion-grid/src/lib.rs
@@ -23,6 +23,13 @@ pub mod error;
 pub mod heat_pump_voltage_model;
 pub mod thermal_electrical_coupler;
 
+// === Fluxion Integration Bridge ===
+// Only available when the "fluxion" feature flag is enabled.
+#[cfg(feature = "fluxion")]
+pub mod fluxion_bridge;
+#[cfg(feature = "fluxion")]
+pub use fluxion_bridge::ThermalModelTraitBridge;
+
 pub use error::{GridModelError, GridSolveError};
 pub use heat_pump_voltage_model::HeatPumpVoltageModel;
 pub use thermal_electrical_coupler::VoltageCoupler;

--- a/scripts/check_architecture_drift.py
+++ b/scripts/check_architecture_drift.py
@@ -24,7 +24,11 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 ARCH_FILE = REPO_ROOT / "ARCHITECTURE.md"
 # Scan source directories from all workspace members
-SRC_DIRS = [REPO_ROOT / "src", REPO_ROOT / "fluxion-core" / "src"]
+SRC_DIRS = [
+    REPO_ROOT / "src",
+    REPO_ROOT / "fluxion-core" / "src",
+    REPO_ROOT / "fluxion-grid" / "src",
+]
 
 
 def find_rust_traits(src_dirs: list[Path]) -> dict[str, str]:
@@ -144,6 +148,7 @@ def check_drift() -> list[str]:
         "CTFSolverWrapper",  # struct implementing HeatConductionSolver
         "FDSolverWrapper",  # struct implementing HeatConductionSolver
         "MultiNodeSolver",  # struct in physics/multi_node_solver.rs
+        "JointConvergenceSolver",  # struct in fluxion-grid/src/lib.rs
     }
 
     # Traits documented as planned-but-not-yet-implemented in the multi-phase


### PR DESCRIPTION
## Summary

Implements Option 2 from issue #2275: adds an optional `fluxion` feature flag to `fluxion-grid` that enables integration with the main crate's `ThermalModelTrait`.

## Changes

- **fluxion-grid/Cargo.toml**: Added `fluxion` feature flag with optional dependency on the main `fluxion` crate
- **fluxion-grid/src/fluxion_bridge.rs** (new): `ThermalModelTraitBridge` struct that holds both `ThermalElectricalCoupler` and `Arc<dyn ThermalModelTrait>`
- **fluxion-grid/src/lib.rs**: Conditional module export for `fluxion_bridge`
- **ARCHITECTURE.md**: Documented the architectural decision

## Decision Rationale

Chose **Option 2** (optional dependency) because:

1. **Preserves crate independence**: Default build remains fully standalone
2. **Enables deeper integration**: When `fluxion` feature is enabled, `ThermalElectricalCoupler` can query `ThermalModelTrait` directly
3. **Follows existing patterns**: The workspace already uses optional dependencies (e.g., `fluxion-fluid`)
4. **No migration required**: Existing code using scalar `HvacState` values continues to work unchanged

## Verification

- `cargo build -p fluxion-grid` passes (default, no feature)
- `cargo build -p fluxion-grid --features fluxion` passes

Closes #2275

## Summary by Sourcery

Add an optional integration path between the fluxion-grid crate and the main fluxion thermal solver via a feature-gated bridge type.

New Features:
- Introduce a fluxion feature flag in fluxion-grid that enables an optional dependency on the main fluxion crate and exposes a ThermalModelTraitBridge type for joint thermal-electrical convergence.

Enhancements:
- Document the fluxion-grid module architecture and its optional integration with the main fluxion crate in ARCHITECTURE.md, including usage patterns and feature behavior.