### PR TITLE
feat(quantum): QUBO error handling for ill-conditioned matrices

### DIFF
--- a/src/quantum/qubo_mapping.rs
+++ b/src/quantum/qubo_mapping.rs
@@ -64,6 +64,59 @@
 use crate::physics::geometry_tensor::{ThermalManifold, MANIFOLD_DIM};
 use nalgebra::{Matrix4, Vector4};
 
+/// Power iteration to find the eigenvalue with the largest absolute magnitude.
+///
+/// Runs at most `max_iter` iterations with convergence tolerance `tol` on the
+/// change in eigenvalue estimate. Returns `None` if the matrix is zero or if
+/// convergence is not reached. The matrix is interpreted as row-major `n×n`.
+///
+/// After L2-normalizing v each step (v := Av/||Av||), the eigenvalue estimate
+/// is the Rayleigh quotient λ = v^T A v / v^T v. With ||v|| = 1, this is
+/// simply v^T A v = v · w where w = A v.  The first iteration uses λ = 0 as
+/// the prior estimate, so the convergence check is skipped until the second
+/// iteration (when we have a meaningful prior).
+fn power_iteration_max(a: &[f64], n: usize, max_iter: usize, tol: f64) -> Option<f64> {
+    if n == 0 {
+        return None;
+    }
+    let mut v = vec![1.0_f64; n];
+    let mut lambda = 0.0_f64;
+
+    for _ in 0..max_iter {
+        let mut w = vec![0.0_f64; n];
+        for i in 0..n {
+            let mut row_acc = 0.0_f64;
+            for j in 0..n {
+                row_acc += a[i * n + j] * v[j];
+            }
+            w[i] = row_acc;
+        }
+
+        let w_norm_sq: f64 = w.iter().map(|&x| x * x).sum();
+        let w_norm = w_norm_sq.sqrt();
+        if w_norm < 1e-20 {
+            return Some(0.0);
+        }
+
+        // Rayleigh quotient λ = v^T A v / v^T v for the current (normalized) v.
+        // With v L2-normalized each iteration, v^T v = 1, so λ = v^T A v = v · w.
+        let v_dot_w: f64 = v.iter().zip(w.iter()).map(|(vi, wi)| vi * wi).sum();
+        let lambda_new = v_dot_w;
+
+        // Converged if change is below tolerance AND we have a prior estimate.
+        if lambda != 0.0 && (lambda_new - lambda).abs() < tol {
+            return Some(lambda_new);
+        }
+
+        for j in 0..n {
+            v[j] = w[j] / w_norm;
+        }
+        lambda = lambda_new;
+    }
+
+    Some(lambda)
+}
+
 /// Configuration for the QUBO encoding. The defaults match typical ASHRAE 140
 /// zone temperatures (0..50 °C) at ~0.2 °C LSB resolution with K=8 bits/node.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -142,17 +195,17 @@ impl QuboConfig {
 #[derive(Debug, Clone)]
 pub struct QuboProblem {
     /// Symmetric `N × N` QUBO matrix in row-major order. `N = MANIFOLD_DIM * K`.
-    q_matrix: Vec<f64>,
+    pub q_matrix: Vec<f64>,
     /// Number of binary variables (= side length of `q_matrix`).
-    num_variables: usize,
+    pub num_variables: usize,
     /// Config used to build this QUBO. Retained for round-tripping.
-    config: QuboConfig,
+    pub config: QuboConfig,
     /// Source manifold's metric tensor (cached for diagnostic / verification).
-    source_metric: Matrix4<f64>,
+    pub source_metric: Matrix4<f64>,
     /// Source manifold's scalar field.
-    source_field: Vector4<f64>,
+    pub source_field: Vector4<f64>,
     /// Source manifold's gauge connection.
-    source_gauge: Vector4<f64>,
+    pub source_gauge: Vector4<f64>,
 }
 
 impl QuboProblem {
@@ -198,6 +251,133 @@ impl QuboProblem {
             return self.q_matrix.clone();
         }
         self.q_matrix.iter().map(|&v| v / m).collect()
+    }
+
+    /// Estimate the condition number of the QUBO matrix using power iteration.
+    ///
+    /// Returns `(sigma_max, sigma_min, condition_number)` where `sigma_max` is the
+    /// largest singular value, `sigma_min` is the smallest, and `condition_number`
+    /// is their ratio. For a symmetric QUBO matrix, singular values equal absolute
+    /// eigenvalues, so we use eigenvalue estimation instead of the more expensive SVD.
+    ///
+    /// The algorithm runs power iteration for the largest eigenvalue magnitude and
+    /// inverse power iteration for the smallest, each with up to 100 iterations and
+    /// `1e-10` convergence tolerance. For the 32×32 QUBO (K=8) this is O(N²)
+    /// per iteration and converges in < 20 iterations for well-conditioned matrices.
+    ///
+    /// # Numerical safety
+    ///
+    /// If any eigenvalue is non-finite (NaN/Inf) or exactly zero, returns
+    /// `Err(QuboError::SingularMatrix)` or `Err(QuboError::NumericalOverflow)`.
+    pub fn condition_number_estimate(&self) -> Result<(f64, f64, f64), QuboError> {
+        let n = self.num_variables;
+        if n == 0 {
+            return Err(QuboError::SingularMatrix);
+        }
+
+        // Power iteration for largest eigenvalue magnitude.
+        let lambda_max =
+            power_iteration_max(&self.q_matrix, n, 100, 1e-10).ok_or(QuboError::SingularMatrix)?;
+
+        if !lambda_max.is_finite() || lambda_max.abs() < 1e-20 {
+            return Err(QuboError::SingularMatrix);
+        }
+        if lambda_max.abs() > OVERFLOW_THRESHOLD {
+            return Err(QuboError::NumericalOverflow {
+                max_entry: lambda_max.abs(),
+            });
+        }
+
+        // Inverse power iteration for smallest eigenvalue magnitude.
+        // Shift the matrix by lambda_max so eigenvalues {λ_i} become {λ_i - λ_max},
+        // then the largest of those (in magnitude) is |λ_min - λ_max|.
+        let mut shifted = vec![0.0_f64; n * n];
+        for i in 0..n {
+            for j in 0..n {
+                shifted[i * n + j] = self.q_matrix[i * n + j];
+            }
+            shifted[i * n + i] -= lambda_max;
+        }
+
+        let delta_min =
+            power_iteration_max(&shifted, n, 100, 1e-10).ok_or(QuboError::SingularMatrix)?;
+
+        // λ_min = λ_max - delta_min (where delta_min ≈ |λ_min - λ_max|)
+        // delta_min ≈ 0 (within numerical noise) with a non-zero shifted matrix
+        // means the starting vector landed in the null space of the shifted matrix
+        // — i.e. λ_min = λ_max, which only occurs when the original matrix is
+        // singular.
+        let shifted_has_nonzero = shifted.iter().any(|&x| x != 0.0);
+        if delta_min.abs() < 1e-12 && shifted_has_nonzero {
+            return Err(QuboError::SingularMatrix);
+        }
+
+        let lambda_min = (lambda_max - delta_min).abs();
+
+        if !lambda_min.is_finite() {
+            return Err(QuboError::NumericalOverflow {
+                max_entry: lambda_max.abs(),
+            });
+        }
+
+        let condition_number = if lambda_min.abs() < 1e-20 {
+            return Err(QuboError::SingularMatrix);
+        } else {
+            lambda_max.abs() / lambda_min.abs()
+        };
+
+        Ok((lambda_max.abs(), lambda_min.abs(), condition_number))
+    }
+
+    /// Apply Tikhonov regularization to produce a well-conditioned QUBO matrix.
+    ///
+    /// Adds `alpha * I` to the diagonal of `Q`, raising every eigenvalue by `alpha`.
+    /// This reduces the condition number from `λ_max / λ_min` to approximately
+    /// `λ_max / (λ_min + alpha)`.
+    ///
+    /// # Arguments
+    ///
+    /// * `alpha` — regularization strength. Must be `> 0`. If `None`, uses
+    ///   [`DEFAULT_REGULARIZATION_ALPHA`] (`10^-4`).
+    ///
+    /// # Returns
+    ///
+    /// A new `QuboProblem` with the same geometry as `self` but a regularized
+    /// `q_matrix`. The original is unchanged.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use fluxion::quantum::qubo_mapping::{QuboProblem, QuboError, manifold_to_qubo, QuboConfig};
+    /// # use fluxion::physics::geometry_tensor::ThermalManifold;
+    /// let m = ThermalManifold::from_5r1c_parameters(21.0, 22.0, 0.1, 1000.0, 5000.0);
+    /// let qp = manifold_to_qubo(&m, QuboConfig::default()).unwrap();
+    /// let regularized = qp.regularize(None).unwrap();
+    /// let (max, min, cn) = regularized.condition_number_estimate().unwrap();
+    /// assert!(cn < 1e6, "condition number {} still too large after regularization", cn);
+    /// ```
+    pub fn regularize(&self, alpha: Option<f64>) -> Result<QuboProblem, QuboError> {
+        let alpha = alpha.unwrap_or(DEFAULT_REGULARIZATION_ALPHA);
+        if alpha <= 0.0 {
+            return Err(QuboError::InvalidEncoding(
+                "regularization alpha must be > 0".to_string(),
+            ));
+        }
+
+        let n = self.num_variables;
+        let mut q_reg = self.q_matrix.clone();
+        for i in 0..n {
+            q_reg[i * n + i] += alpha;
+        }
+
+        Ok(QuboProblem {
+            q_matrix: q_reg,
+            num_variables: n,
+            config: self.config,
+            source_metric: self.source_metric,
+            source_field: self.source_field,
+            source_gauge: self.source_gauge,
+        })
     }
 
     /// Convert the QUBO to its Ising form `(h, J, c)` for direct submission
@@ -357,6 +537,25 @@ impl IsingProblem {
     }
 }
 
+/// Threshold above which a QUBO matrix is considered ill-conditioned.
+/// Condition number > `ILL_CONDITIONED_THRESHOLD` triggers `IllConditioned` error.
+/// Chosen to catch real thermal manifolds that approach singularity while
+/// leaving well-conditioned 5R1C / 9R4C matrices untouched.
+pub const ILL_CONDITIONED_THRESHOLD: f64 = 1e6;
+
+/// Threshold below which a QUBO entry is considered numerical overflow for
+/// D-Wave submission. Entries with absolute value > `OVERFLOW_THRESHOLD`
+/// cannot be safely normalized to the D-Wave `h ∈ [-4,4]`, `J ∈ [-2,+1]`
+/// hardware range without catastrophic cancellation.
+pub const OVERFLOW_THRESHOLD: f64 = 1e10;
+
+/// Default Tikhonov regularization parameter. Applied to the diagonal of a
+/// QUBO matrix when it is detected as ill-conditioned, producing a new
+/// well-conditioned matrix `Q' = Q + α·I` where `α` is the `regularization_alpha`.
+/// This raises the smallest eigenvalue by `α`, reducing the condition number
+/// to approximately `λ_max / (λ_min + α)`.
+pub const DEFAULT_REGULARIZATION_ALPHA: f64 = 1e-4;
+
 /// Errors that can arise during QUBO construction.
 #[derive(Debug, Clone, PartialEq)]
 pub enum QuboError {
@@ -369,6 +568,25 @@ pub enum QuboError {
     NonPositiveScale { value: f64 },
     /// The source manifold failed its own `validate()` (NaN/Inf in tensors).
     InvalidManifold(String),
+    /// One of the QUBO encoding parameters is invalid (e.g., negative
+    /// regularization alpha).
+    InvalidEncoding(String),
+    /// The QUBO matrix is ill-conditioned (condition number > `10^6`).
+    /// This usually means the metric tensor is near-singular — e.g. two
+    /// thermal nodes with nearly identical coupling resistances. Annealer
+    /// results are unreliable for such matrices.
+    IllConditioned {
+        /// Estimated condition number (ratio of largest to smallest singular value).
+        condition_number: f64,
+        /// Ratio of largest to smallest eigenvalue magnitude.
+        eigenvalue_ratio: f64,
+    },
+    /// A QUBO matrix entry exceeds the D-Wave hardware range (`±1e10`),
+    /// making safe normalization impossible without catastrophic cancellation.
+    NumericalOverflow { max_entry: f64 },
+    /// The QUBO matrix is exactly singular (zero eigenvalues). No amount of
+    /// regularization can fix this without changing the problem structure.
+    SingularMatrix,
 }
 
 impl std::fmt::Display for QuboError {
@@ -382,6 +600,29 @@ impl std::fmt::Display for QuboError {
                 write!(f, "scale_max_celsius = {value} must be > 0")
             }
             Self::InvalidManifold(msg) => write!(f, "invalid manifold: {msg}"),
+            Self::InvalidEncoding(msg) => write!(f, "invalid encoding: {msg}"),
+            Self::IllConditioned {
+                condition_number,
+                eigenvalue_ratio,
+            } => {
+                write!(
+                    f,
+                    "QUBO matrix is ill-conditioned: condition_number={:.1e}, eigenvalue_ratio={:.1e} (threshold={:.0e}); apply regularize() before submission",
+                    condition_number, eigenvalue_ratio, ILL_CONDITIONED_THRESHOLD
+                )
+            }
+            Self::NumericalOverflow { max_entry } => {
+                write!(
+                    f,
+                    "QUBO entry magnitude {max_entry:.1e} exceeds overflow threshold {OVERFLOW_THRESHOLD:.0e}; normalization would lose precision",
+                )
+            }
+            Self::SingularMatrix => {
+                write!(
+                    f,
+                    "QUBO matrix is singular (zero eigenvalue); regularize() cannot fix this"
+                )
+            }
         }
     }
 }
@@ -396,6 +637,16 @@ impl std::error::Error for QuboError {}
 /// # Errors
 /// Returns [`QuboError::InvalidManifold`] if the manifold fails `validate()`,
 /// or any [`QuboConfig::validate`] failure.
+///
+/// Returns [`QuboError::IllConditioned`] if the QUBO condition number exceeds
+/// `10^6` (detected before submission so the caller can apply
+/// [`QuboProblem::regularize`] as a fallback).
+///
+/// Returns [`QuboError::NumericalOverflow`] if any QUBO entry exceeds `10^10`
+/// in magnitude (normalization to D-Wave hardware range would lose precision).
+///
+/// Use [`QuboProblem::condition_number_estimate`] to diagnose the matrix, and
+/// [`QuboProblem::regularize`] to obtain a well-conditioned fallback.
 pub fn manifold_to_qubo(
     manifold: &ThermalManifold,
     config: QuboConfig,
@@ -451,14 +702,32 @@ pub fn manifold_to_qubo(
         }
     }
 
-    Ok(QuboProblem {
+    let qp = QuboProblem {
         q_matrix: q,
         num_variables: n,
         config,
         source_metric: manifold.metric_tensor,
         source_field: manifold.scalar_field,
         source_gauge: manifold.gauge_connection,
-    })
+    };
+
+    // Check for numerical overflow in QUBO entries.
+    let max_entry = qp.max_abs();
+    if max_entry > OVERFLOW_THRESHOLD {
+        return Err(QuboError::NumericalOverflow { max_entry });
+    }
+
+    // Check condition number — ill-conditioned matrices degrade annealer quality.
+    if let Ok((_, eigenvalue_ratio, cond)) = qp.condition_number_estimate() {
+        if cond > ILL_CONDITIONED_THRESHOLD {
+            return Err(QuboError::IllConditioned {
+                condition_number: cond,
+                eigenvalue_ratio,
+            });
+        }
+    }
+
+    Ok(qp)
 }
 
 /// Encode a temperature vector into the canonical binary solution vector.

--- a/tests/qubo_error_handling.rs
+++ b/tests/qubo_error_handling.rs
@@ -1,0 +1,265 @@
+// Copyright 2026 Fluxion. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+//! Error handling tests for QUBO matrices (issue #1775).
+//!
+//! Covers:
+//! - Condition-number estimation for QUBO matrices
+//! - Detection of numerical overflow in QUBO entries
+//! - Tikhonov regularization as a documented fallback path
+//! - Integration with `manifold_to_qubo` validation
+
+use fluxion::physics::geometry_tensor::ThermalManifold;
+use fluxion::quantum::qubo_mapping::{
+    manifold_to_qubo, QuboConfig, QuboError, QuboProblem, DEFAULT_REGULARIZATION_ALPHA,
+    ILL_CONDITIONED_THRESHOLD, OVERFLOW_THRESHOLD,
+};
+
+fn approx_eq(a: f64, b: f64, tol: f64) -> bool {
+    (a - b).abs() <= tol
+}
+
+// ---------------------------------------------------------------------------
+// Well-conditioned manifold (baseline)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_well_conditioned_5r1c_passes_condition_check() {
+    let m = ThermalManifold::from_5r1c_parameters(21.0, 22.0, 0.1, 1000.0, 5000.0);
+    let result = manifold_to_qubo(&m, QuboConfig::default());
+    assert!(
+        result.is_ok(),
+        "well-conditioned 5R1C manifold should not error, got: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_well_conditioned_9r4c_passes_condition_check() {
+    let m = ThermalManifold::from_9r4c_parameters(
+        [22.0, 20.0, 23.0, 18.0],
+        [1000.0, 5000.0, 3000.0, 8000.0],
+        [50.0, 30.0, 20.0],
+        Some([5.0, 3.0, 2.0]),
+    );
+    let result = manifold_to_qubo(&m, QuboConfig::default());
+    assert!(
+        result.is_ok(),
+        "9R4C manifold should build QUBO without error"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Zero / singular QUBO detection
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_zero_qubo_matrix_is_singular() {
+    // A 4×4 diagonal matrix with all zeros → exactly singular.
+    let q_matrix = vec![0.0; 16];
+    let qp = QuboProblem {
+        q_matrix,
+        num_variables: 4,
+        config: QuboConfig::default(),
+        source_metric: nalgebra::Matrix4::identity(),
+        source_field: nalgebra::Vector4::zeros(),
+        source_gauge: nalgebra::Vector4::zeros(),
+    };
+    let err = qp.condition_number_estimate().unwrap_err();
+    assert!(
+        matches!(err, QuboError::SingularMatrix),
+        "zero matrix should return SingularMatrix, got: {:?}",
+        err
+    );
+}
+
+#[test]
+fn test_rank_one_matrix_is_singular() {
+    // A 2×2 matrix [[1, 1], [1, 1]] has eigenvalues {2, 0} — singular.
+    let q_matrix = vec![1.0, 1.0, 1.0, 1.0];
+    let qp = QuboProblem {
+        q_matrix,
+        num_variables: 2,
+        config: QuboConfig::default(),
+        source_metric: nalgebra::Matrix4::identity(),
+        source_field: nalgebra::Vector4::zeros(),
+        source_gauge: nalgebra::Vector4::zeros(),
+    };
+    let err = qp.condition_number_estimate().unwrap_err();
+    assert!(
+        matches!(err, QuboError::SingularMatrix),
+        "rank-1 matrix [[1,1],[1,1]] should be SingularMatrix, got: {:?}",
+        err
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Condition number estimation correctness (identity matrix)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_condition_number_estimate_identity_matrix() {
+    // Identity matrix: all eigenvalues = 1, condition number = 1.
+    let n = 4;
+    let mut q_matrix = vec![0.0; n * n];
+    for i in 0..n {
+        q_matrix[i * n + i] = 1.0;
+    }
+    let qp = QuboProblem {
+        q_matrix,
+        num_variables: n,
+        config: QuboConfig::default(),
+        source_metric: nalgebra::Matrix4::identity(),
+        source_field: nalgebra::Vector4::zeros(),
+        source_gauge: nalgebra::Vector4::zeros(),
+    };
+    let (lambda_max, lambda_min, cond) = qp.condition_number_estimate().expect("should estimate");
+    assert!(
+        cond > 0.0 && cond < 10.0,
+        "identity cond {} should be near 1",
+        cond
+    );
+    assert!(
+        lambda_max >= lambda_min,
+        "lambda_max {} should be >= lambda_min {}",
+        lambda_max,
+        lambda_min
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Regularization
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_regularization_with_custom_alpha() {
+    let m = ThermalManifold::from_5r1c_parameters(21.0, 22.0, 0.1, 1000.0, 5000.0);
+    let qp = manifold_to_qubo(&m, QuboConfig::default()).expect("well-conditioned");
+    let qp_reg = qp.regularize(Some(0.1)).expect("regularize should succeed");
+    let (_, _, cond) = qp_reg.condition_number_estimate().expect("should estimate");
+    assert!(
+        cond < 1e8,
+        "with alpha=0.1, condition number {} should be bounded",
+        cond
+    );
+
+    let n = qp.num_variables();
+    let orig_m = qp.q_matrix();
+    let reg_m = qp_reg.q_matrix();
+    for i in 0..n {
+        let orig_diag = orig_m[i * n + i];
+        let reg_diag = reg_m[i * n + i];
+        assert!(
+            approx_eq(reg_diag - orig_diag, 0.1, 1e-12),
+            "diagonal shift should be exactly alpha=0.1"
+        );
+    }
+}
+
+#[test]
+fn test_regularization_rejects_non_positive_alpha() {
+    let m = ThermalManifold::from_5r1c_parameters(21.0, 22.0, 0.1, 1000.0, 5000.0);
+    let qp = manifold_to_qubo(&m, QuboConfig::default()).unwrap();
+
+    let err = qp.regularize(Some(0.0)).unwrap_err();
+    assert!(matches!(err, QuboError::InvalidEncoding(_)));
+
+    let err = qp.regularize(Some(-1.0)).unwrap_err();
+    assert!(matches!(err, QuboError::InvalidEncoding(_)));
+}
+
+#[test]
+fn test_regularized_preserves_solution_energy_structure() {
+    let m = ThermalManifold::from_5r1c_parameters(21.0, 22.0, 0.1, 1000.0, 5000.0);
+    let cfg = QuboConfig::default();
+    let qp = manifold_to_qubo(&m, cfg).expect("well-conditioned");
+    let qp_reg = qp
+        .regularize(Some(1e-4))
+        .expect("regularize should succeed");
+
+    let x_canon = qp.encode_manifold_solution();
+    let e_original = qp.evaluate(&x_canon);
+    let e_regularized = qp_reg.evaluate(&x_canon);
+
+    let alpha = 1e-4;
+    let expected_delta = alpha * x_canon.iter().filter(|&&b| b != 0).count() as f64;
+    assert!(
+        approx_eq(e_regularized - e_original, expected_delta, 1e-9),
+        "regularized energy {} - original {} should ≈ {}",
+        e_regularized,
+        e_original,
+        expected_delta
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Overflow detection
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_overflow_detected_in_qubo_entries() {
+    // A manifold with huge metric entries will produce QUBO entries > 1e10.
+    let mut m = ThermalManifold::new_flat();
+    m.metric_tensor = nalgebra::Matrix4::from_row_slice(&[
+        1e12_f64, 0.0, 0.0, 0.0, //
+        0.0, 1e12_f64, 0.0, 0.0, //
+        0.0, 0.0, 1e12_f64, 0.0, //
+        0.0, 0.0, 0.0, 1e12_f64, //
+    ]);
+    m.scalar_field = nalgebra::Vector4::new(20.0, 21.0, 22.0, 19.0);
+    let result = manifold_to_qubo(&m, QuboConfig::default());
+    let err = result.expect_err("overflow manifold should return error");
+    assert!(
+        matches!(err, QuboError::NumericalOverflow { .. }),
+        "expected NumericalOverflow error, got: {:?}",
+        err
+    );
+    if let QuboError::NumericalOverflow { max_entry } = err {
+        assert!(
+            max_entry > OVERFLOW_THRESHOLD,
+            "max_entry {} should exceed {}",
+            max_entry,
+            OVERFLOW_THRESHOLD
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Constants and Display
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_overflow_threshold_constant() {
+    assert_eq!(OVERFLOW_THRESHOLD, 1e10);
+    assert!(ILL_CONDITIONED_THRESHOLD > 0.0);
+    assert!(DEFAULT_REGULARIZATION_ALPHA > 0.0);
+}
+
+#[test]
+fn test_qubo_error_display_ill_conditioned() {
+    let err = QuboError::IllConditioned {
+        condition_number: 1.5e7,
+        eigenvalue_ratio: 2.0e7,
+    };
+    let s = err.to_string();
+    assert!(
+        s.contains("ill-conditioned"),
+        "display should mention 'ill-conditioned'"
+    );
+    assert!(s.contains("1.5"), "display should contain condition number");
+}
+
+#[test]
+fn test_qubo_error_display_overflow() {
+    let err = QuboError::NumericalOverflow { max_entry: 2.5e11 };
+    let s = err.to_string();
+    assert!(s.contains("overflow"), "display should mention 'overflow'");
+    assert!(s.contains("2.5"), "display should contain max_entry");
+}
+
+#[test]
+fn test_qubo_error_display_singular() {
+    let err = QuboError::SingularMatrix;
+    let s = err.to_string();
+    assert!(s.contains("singular"), "display should mention 'singular'");
+}

--- a/tests/surrogate_drift_gate.rs
+++ b/tests/surrogate_drift_gate.rs
@@ -161,7 +161,7 @@ fn assert_drift_within_gate(result: &DriftResult, context: &str) {
     }
 
     eprintln!(
-        "[surrogate_drift_gate:{context}] mode={} max_drift={:.4}% tolerance={:.1}%",
+        "\n[surrogate_drift_gate:{context}] mode={} max_drift={:.4}% tolerance={:.1}%",
         if surrogates.model_loaded {
             "onnx"
         } else {


### PR DESCRIPTION
Closes #1775

Implements graceful degradation for ill-conditioned QUBO matrices.

Condition number detection via power iteration with threshold 1e6.
Regularization fallback via diagonal augmentation alpha*I.
13 new tests.

## Summary by Sourcery

Add condition number estimation and regularization support for QUBO matrices, with explicit errors for ill-conditioned, singular, or overflowing matrices and corresponding tests.

New Features:
- Expose QUBOProblem internals needed for diagnostics and regularization.
- Provide a power-iteration-based condition number estimator and Tikhonov regularization helper on QUBOProblem.
- Introduce configurable thresholds and defaults for ill-conditioning, overflow, and regularization strength.

Enhancements:
- Extend QuboError with variants and Display messages for invalid encodings, ill-conditioned matrices, numerical overflow, and singular matrices.
- Validate generated QUBO matrices in manifold_to_qubo for overflow and ill-conditioning before returning them.

Tests:
- Add a dedicated qubo_error_handling test suite covering condition-number estimation, regularization behavior, overflow detection, and QuboError formatting.