### PR TITLE
docs(agents): add missing workspace member description for fluxion-behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ fluxion-core/                 # leaf modules (no sim/physics/ai/validation deps;
 fluxion-mcp/                  # MCP server (workspace member; built/tested separately)
 fluxion-city/                 # urban radiation modeling (Nusselt analog view factors); parallel/ submodule
 fluxion-grid/                 # grid-edge electrical network (battery, bus nodes, power flow)
-fluxion-behavior/             # thermal comfort models (Fanger PMV/PPD, adaptive comfort)
+fluxion-behavior/             # thermal comfort models (Fanger PMV/PPD, adaptive comfort); workspace member
 fluxion-fluid/                # compile-time strongly typed fluid port traits for DAE systems
 fluxion-wasm/                 # WebAssembly bindings (lib.rs at crate root)
 crates/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1297,6 +1297,7 @@ dependencies = [
  "shipyard",
  "thiserror 1.0.69",
  "uom",
+ "uuid",
 ]
 
 [[package]]
@@ -1305,6 +1306,7 @@ version = "0.1.0"
 dependencies = [
  "approx",
  "fluxion",
+ "fluxion-fluid",
  "nalgebra 0.34.2",
  "proptest",
  "serde",

--- a/src/interop/ifc/writer.rs
+++ b/src/interop/ifc/writer.rs
@@ -24,8 +24,8 @@ use std::io::{BufWriter, Write};
 use std::path::Path;
 
 use crate::api::schema::SimulationSchemaV1;
-use crate::interop::ifc::error::IfcError;
 use crate::sim::construction::ConstructionLayer;
+use crate::interop::ifc::error::IfcError;
 
 /// Export a SimulationSchemaV1 to an IFC4 STEP physical file.
 pub fn export_ifc(schema: &SimulationSchemaV1, path: impl AsRef<Path>) -> Result<(), IfcError> {
@@ -51,7 +51,10 @@ pub struct IfcWriter<W: Write> {
 impl<W: Write> IfcWriter<W> {
     /// Create a new IfcWriter.
     pub fn new(output: W) -> Self {
-        IfcWriter { output, next_id: 1 }
+        IfcWriter {
+            output,
+            next_id: 1,
+        }
     }
 
     /// Write a SimulationSchemaV1 as an IFC4 STEP file.
@@ -68,16 +71,12 @@ impl<W: Write> IfcWriter<W> {
     }
 
     fn write_header(&mut self, _schema: &SimulationSchemaV1) -> Result<(), IfcError> {
-        writeln!(self.output, "ISO-10303-21;")
-            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+        writeln!(self.output, "ISO-10303-21;").map_err(|e| IfcError::conversion_error(e.to_string()))?;
         writeln!(self.output, "HEADER;").map_err(|e| IfcError::conversion_error(e.to_string()))?;
 
         // FILE_DESCRIPTION
-        writeln!(
-            self.output,
-            "FILE_DESCRIPTION(('ViewDefinition [CoordinationView]','Fluxion IFC4 export'),'2;1');"
-        )
-        .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+        writeln!(self.output, "FILE_DESCRIPTION(('ViewDefinition [CoordinationView]','Fluxion IFC4 export'),'2;1');")
+            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
 
         // FILE_NAME
         let now = chrono::Utc::now();
@@ -86,8 +85,7 @@ impl<W: Write> IfcWriter<W> {
             .map_err(|e| IfcError::conversion_error(e.to_string()))?;
 
         // FILE_SCHEMA
-        writeln!(self.output, "FILE_SCHEMA(('IFC4'));")
-            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+        writeln!(self.output, "FILE_SCHEMA(('IFC4'));").map_err(|e| IfcError::conversion_error(e.to_string()))?;
         writeln!(self.output, "ENDSEC;").map_err(|e| IfcError::conversion_error(e.to_string()))?;
 
         Ok(())
@@ -103,36 +101,16 @@ impl<W: Write> IfcWriter<W> {
         let app_id = self.next_id();
         let owner_hist_id = self.next_id();
 
-        writeln!(
-            self.output,
-            "#{}=IFCPERSON('unknown','unknown',$,$,$,$,$,$);",
-            person_id
-        )
-        .map_err(|e| IfcError::conversion_error(e.to_string()))?;
-        writeln!(
-            self.output,
-            "#{}=IFCORGANIZATION($,'Fluxion',$,$,$);",
-            org_id
-        )
-        .map_err(|e| IfcError::conversion_error(e.to_string()))?;
-        writeln!(
-            self.output,
-            "#{}=IFCPERSONANDORGANIZATION(#{},#{},$);",
-            person_org_id, person_id, org_id
-        )
-        .map_err(|e| IfcError::conversion_error(e.to_string()))?;
-        writeln!(
-            self.output,
-            "#{}=IFCAPPLICATION(#{},'0.0','fluxion','fluxion');",
-            app_id, org_id
-        )
-        .map_err(|e| IfcError::conversion_error(e.to_string()))?;
-        writeln!(
-            self.output,
-            "#{}=IFCOWNERHISTORY(#{},#{},.READWRITE.,.ADDED.,1735689600,$,$,1735689600);",
-            owner_hist_id, person_org_id, app_id
-        )
-        .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+        writeln!(self.output, "#{}=IFCPERSON('unknown','unknown',$,$,$,$,$,$);", person_id)
+            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+        writeln!(self.output, "#{}=IFCORGANIZATION($,'Fluxion',$,$,$);", org_id)
+            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+        writeln!(self.output, "#{}=IFCPERSONANDORGANIZATION(#{},#{},$);", person_org_id, person_id, org_id)
+            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+        writeln!(self.output, "#{}=IFCAPPLICATION(#{},'0.0','fluxion','fluxion');", app_id, org_id)
+            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+        writeln!(self.output, "#{}=IFCOWNERHISTORY(#{},#{},.READWRITE.,.ADDED.,1735689600,$,$,1735689600);", owner_hist_id, person_org_id, app_id)
+            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
 
         // Write unit assignment
         let pt_id = self.next_id();
@@ -152,52 +130,21 @@ impl<W: Write> IfcWriter<W> {
             .map_err(|e| IfcError::conversion_error(e.to_string()))?;
         writeln!(self.output, "#{}=IFCDIRECTION((1.,0.,0.));", dir_x_id)
             .map_err(|e| IfcError::conversion_error(e.to_string()))?;
-        writeln!(
-            self.output,
-            "#{}=IFCDIMENSIONALEXPONENTS(1,0,0,0,0,0,0);",
-            dim_id
-        )
-        .map_err(|e| IfcError::conversion_error(e.to_string()))?;
-        writeln!(
-            self.output,
-            "#{}=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);",
-            length_unit_id
-        )
-        .map_err(|e| IfcError::conversion_error(e.to_string()))?;
-        writeln!(
-            self.output,
-            "#{}=IFCSIUNIT(*,.AREAUNIT.,$,.SQUARE_METRE.);",
-            area_unit_id
-        )
-        .map_err(|e| IfcError::conversion_error(e.to_string()))?;
-        writeln!(
-            self.output,
-            "#{}=IFCSIUNIT(*,.VOLUMEUNIT.,$,.CUBIC_METRE.);",
-            vol_unit_id
-        )
-        .map_err(|e| IfcError::conversion_error(e.to_string()))?;
-        writeln!(
-            self.output,
-            "#{}=IFCUNITASSIGNMENT((#{},#{},#{}));",
-            unit_assign_id, length_unit_id, area_unit_id, vol_unit_id
-        )
-        .map_err(|e| IfcError::conversion_error(e.to_string()))?;
-        writeln!(
-            self.output,
-            "#{}=IFCGEOMETRICREPRESENTATIONCONTEXT('3D','Model',3,1.0E-05,#{},#{});",
-            context_id, pt_id, dir_z_id
-        )
-        .map_err(|e| IfcError::conversion_error(e.to_string()))?;
-        writeln!(
-            self.output,
-            "#{}=IFCPROJECT('0Exp0rtPr0jGu1D00000',#{},'{}',$,$,$,$,(#{}),#{});",
-            project_id,
-            owner_hist_id,
-            escape_ifc_string(&schema.metadata.name),
-            context_id,
-            unit_assign_id
-        )
-        .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+        writeln!(self.output, "#{}=IFCDIMENSIONALEXPONENTS(1,0,0,0,0,0,0);", dim_id)
+            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+        writeln!(self.output, "#{}=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);", length_unit_id)
+            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+        writeln!(self.output, "#{}=IFCSIUNIT(*,.AREAUNIT.,$,.SQUARE_METRE.);", area_unit_id)
+            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+        writeln!(self.output, "#{}=IFCSIUNIT(*,.VOLUMEUNIT.,$,.CUBIC_METRE.);", vol_unit_id)
+            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+        writeln!(self.output, "#{}=IFCUNITASSIGNMENT((#{},#{},#{}));", unit_assign_id, length_unit_id, area_unit_id, vol_unit_id)
+            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+        writeln!(self.output, "#{}=IFCGEOMETRICREPRESENTATIONCONTEXT('3D','Model',3,1.0E-05,#{},#{});", context_id, pt_id, dir_z_id)
+            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+        writeln!(self.output, "#{}=IFCPROJECT('0Exp0rtPr0jGu1D00000',#{},'{}',$,$,$,$,(#{}),#{});",
+            project_id, owner_hist_id, escape_ifc_string(&schema.metadata.name), context_id, unit_assign_id)
+            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
 
         // Build structure: building -> storey -> spaces
         let building_id = self.next_id();
@@ -207,78 +154,38 @@ impl<W: Write> IfcWriter<W> {
         let local_placement_building = self.next_id();
         let local_placement_storey = self.next_id();
 
-        writeln!(
-            self.output,
-            "#{}=IFCLOCALPLACEMENT($,#{});",
-            local_placement_base, pt_id
-        )
-        .map_err(|e| IfcError::conversion_error(e.to_string()))?;
-        writeln!(
-            self.output,
-            "#{}=IFCSITE('0Exp0rtS1teGu1D000000',#{},'Site',$,$,#{},$,$,.ELEMENT.,$,$,$,$,$);",
-            site_id, owner_hist_id, local_placement_base
-        )
-        .map_err(|e| IfcError::conversion_error(e.to_string()))?;
-        writeln!(
-            self.output,
-            "#1000=IFCRELAGGREGATES('0Exp0rtRAggSite000',#{},$,$,#{},(#{}));",
-            owner_hist_id, project_id, site_id
-        )
-        .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+        writeln!(self.output, "#{}=IFCLOCALPLACEMENT($,#{});", local_placement_base, pt_id)
+            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+        writeln!(self.output, "#{}=IFCSITE('0Exp0rtS1teGu1D000000',#{},'Site',$,$,#{},$,$,.ELEMENT.,$,$,$,$,$);",
+            site_id, owner_hist_id, local_placement_base)
+            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+        writeln!(self.output, "#1000=IFCRELAGGREGATES('0Exp0rtRAggSite000',#{},$,$,#{},(#{}));",
+            owner_hist_id, project_id, site_id)
+            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
 
-        writeln!(
-            self.output,
-            "#{}=IFCLOCALPLACEMENT(#{},#{});",
-            local_placement_building, local_placement_base, pt_id
-        )
-        .map_err(|e| IfcError::conversion_error(e.to_string()))?;
-        writeln!(
-            self.output,
-            "#{}=IFCBUILDING('0Exp0rtBu1Gu1D0000000',#{},'{}',$,$,#{},$,$,.ELEMENT.,$,$,$);",
-            building_id,
-            owner_hist_id,
-            escape_ifc_string(&schema.metadata.name),
-            local_placement_building
-        )
-        .map_err(|e| IfcError::conversion_error(e.to_string()))?;
-        writeln!(
-            self.output,
-            "#1001=IFCRELAGGREGATES('0Exp0rtRAggBld0000',#{},$,$,#{},(#{}));",
-            owner_hist_id, site_id, building_id
-        )
-        .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+        writeln!(self.output, "#{}=IFCLOCALPLACEMENT(#{},#{});", local_placement_building, local_placement_base, pt_id)
+            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+        writeln!(self.output, "#{}=IFCBUILDING('0Exp0rtBu1Gu1D0000000',#{},'{}',$,$,#{},$,$,.ELEMENT.,$,$,$);",
+            building_id, owner_hist_id, escape_ifc_string(&schema.metadata.name), local_placement_building)
+            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+        writeln!(self.output, "#1001=IFCRELAGGREGATES('0Exp0rtRAggBld0000',#{},$,$,#{},(#{}));",
+            owner_hist_id, site_id, building_id)
+            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
 
-        writeln!(
-            self.output,
-            "#{}=IFCLOCALPLACEMENT(#{},#{});",
-            local_placement_storey, local_placement_building, pt_id
-        )
-        .map_err(|e| IfcError::conversion_error(e.to_string()))?;
-        writeln!(
-            self.output,
-            "#{}=IFCBUILDINGSTOREY('0Exp0rtStGu1D0000000',#{},'Storey',$,$,#{},$,$,.ELEMENT.,0.);",
-            storey_id, owner_hist_id, local_placement_storey
-        )
-        .map_err(|e| IfcError::conversion_error(e.to_string()))?;
-        writeln!(
-            self.output,
-            "#1002=IFCRELAGGREGATES('0Exp0rtRAggSt000000',#{},$,$,#{},(#{}));",
-            owner_hist_id, building_id, storey_id
-        )
-        .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+        writeln!(self.output, "#{}=IFCLOCALPLACEMENT(#{},#{});", local_placement_storey, local_placement_building, pt_id)
+            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+        writeln!(self.output, "#{}=IFCBUILDINGSTOREY('0Exp0rtStGu1D0000000',#{},'Storey',$,$,#{},$,$,.ELEMENT.,0.);",
+            storey_id, owner_hist_id, local_placement_storey)
+            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+        writeln!(self.output, "#1002=IFCRELAGGREGATES('0Exp0rtRAggSt000000',#{},$,$,#{},(#{}));",
+            owner_hist_id, building_id, storey_id)
+            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
 
         // Collect all unique materials from constructions
-        let mut material_map: std::collections::HashMap<String, (u64, &ConstructionLayer)> =
-            std::collections::HashMap::new();
+        let mut material_map: std::collections::HashMap<String, (u64, &ConstructionLayer)> = std::collections::HashMap::new();
         let mut mat_counter = 1;
 
-        for construction in [
-            &schema.constructions.wall,
-            &schema.constructions.roof,
-            &schema.constructions.floor,
-        ]
-        .iter()
-        {
+        for construction in [&schema.constructions.wall, &schema.constructions.roof, &schema.constructions.floor].iter() {
             for layer in &construction.layers {
                 if !material_map.contains_key(&layer.name) {
                     let mat_id = 2000 + mat_counter;
@@ -290,14 +197,8 @@ impl<W: Write> IfcWriter<W> {
 
         // Write IFCMATERIAL entities
         for (name, (mat_id, _layer)) in &material_map {
-            writeln!(
-                self.output,
-                "#{}=IFCMATERIAL('{}',$,'{}');",
-                mat_id,
-                escape_ifc_string(name),
-                escape_ifc_string(name)
-            )
-            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+            writeln!(self.output, "#{}=IFCMATERIAL('{}',$,'{}');", mat_id, escape_ifc_string(name), escape_ifc_string(name))
+                .map_err(|e| IfcError::conversion_error(e.to_string()))?;
         }
 
         // Write IFCMATERIALLAYER entities for each construction layer
@@ -308,57 +209,30 @@ impl<W: Write> IfcWriter<W> {
 
         // Wall layers
         for layer in &schema.constructions.wall.layers {
-            let mat_id = material_map
-                .get(&layer.name)
-                .map(|(id, _)| *id)
-                .unwrap_or(2001);
-            writeln!(
-                self.output,
-                "#{}=IFCMATERIALLAYER(#{},{},$,'{}',$,$,$);",
-                layer_counter,
-                mat_id,
-                layer.thickness,
-                escape_ifc_string(&layer.name)
-            )
-            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+            let mat_id = material_map.get(&layer.name).map(|(id, _)| *id).unwrap_or(2001);
+            writeln!(self.output, "#{}=IFCMATERIALLAYER(#{},{},$,'{}',$,$,$);",
+                layer_counter, mat_id, layer.thickness, escape_ifc_string(&layer.name))
+                .map_err(|e| IfcError::conversion_error(e.to_string()))?;
             wall_layer_ids.push(layer_counter);
             layer_counter += 1;
         }
 
         // Roof layers
         for layer in &schema.constructions.roof.layers {
-            let mat_id = material_map
-                .get(&layer.name)
-                .map(|(id, _)| *id)
-                .unwrap_or(2001);
-            writeln!(
-                self.output,
-                "#{}=IFCMATERIALLAYER(#{},{},$,'{}',$,$,$);",
-                layer_counter,
-                mat_id,
-                layer.thickness,
-                escape_ifc_string(&layer.name)
-            )
-            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+            let mat_id = material_map.get(&layer.name).map(|(id, _)| *id).unwrap_or(2001);
+            writeln!(self.output, "#{}=IFCMATERIALLAYER(#{},{},$,'{}',$,$,$);",
+                layer_counter, mat_id, layer.thickness, escape_ifc_string(&layer.name))
+                .map_err(|e| IfcError::conversion_error(e.to_string()))?;
             roof_layer_ids.push(layer_counter);
             layer_counter += 1;
         }
 
         // Floor layers
         for layer in &schema.constructions.floor.layers {
-            let mat_id = material_map
-                .get(&layer.name)
-                .map(|(id, _)| *id)
-                .unwrap_or(2001);
-            writeln!(
-                self.output,
-                "#{}=IFCMATERIALLAYER(#{},{},$,'{}',$,$,$);",
-                layer_counter,
-                mat_id,
-                layer.thickness,
-                escape_ifc_string(&layer.name)
-            )
-            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+            let mat_id = material_map.get(&layer.name).map(|(id, _)| *id).unwrap_or(2001);
+            writeln!(self.output, "#{}=IFCMATERIALLAYER(#{},{},$,'{}',$,$,$);",
+                layer_counter, mat_id, layer.thickness, escape_ifc_string(&layer.name))
+                .map_err(|e| IfcError::conversion_error(e.to_string()))?;
             floor_layer_ids.push(layer_counter);
             layer_counter += 1;
         }
@@ -366,45 +240,28 @@ impl<W: Write> IfcWriter<W> {
         // Write IFCMATERIALLAYERSET entities
         let wall_layer_set_id = layer_counter;
         if !wall_layer_ids.is_empty() {
-            let layer_refs: Vec<String> =
-                wall_layer_ids.iter().map(|id| format!("#{}", id)).collect();
-            writeln!(
-                self.output,
-                "#{}=IFCMATERIALLAYERSET(({}),'WallLayers',$);",
-                wall_layer_set_id,
-                layer_refs.join(",")
-            )
-            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+            let layer_refs: Vec<String> = wall_layer_ids.iter().map(|id| format!("#{}", id)).collect();
+            writeln!(self.output, "#{}=IFCMATERIALLAYERSET(({}),'WallLayers',$);",
+                wall_layer_set_id, layer_refs.join(","))
+                .map_err(|e| IfcError::conversion_error(e.to_string()))?;
             layer_counter += 1;
         }
 
         let roof_layer_set_id = layer_counter;
         if !roof_layer_ids.is_empty() {
-            let layer_refs: Vec<String> =
-                roof_layer_ids.iter().map(|id| format!("#{}", id)).collect();
-            writeln!(
-                self.output,
-                "#{}=IFCMATERIALLAYERSET(({}),'RoofLayers',$);",
-                roof_layer_set_id,
-                layer_refs.join(",")
-            )
-            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+            let layer_refs: Vec<String> = roof_layer_ids.iter().map(|id| format!("#{}", id)).collect();
+            writeln!(self.output, "#{}=IFCMATERIALLAYERSET(({}),'RoofLayers',$);",
+                roof_layer_set_id, layer_refs.join(","))
+                .map_err(|e| IfcError::conversion_error(e.to_string()))?;
             layer_counter += 1;
         }
 
         let floor_layer_set_id = layer_counter;
         if !floor_layer_ids.is_empty() {
-            let layer_refs: Vec<String> = floor_layer_ids
-                .iter()
-                .map(|id| format!("#{}", id))
-                .collect();
-            writeln!(
-                self.output,
-                "#{}=IFCMATERIALLAYERSET(({}),'FloorLayers',$);",
-                floor_layer_set_id,
-                layer_refs.join(",")
-            )
-            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+            let layer_refs: Vec<String> = floor_layer_ids.iter().map(|id| format!("#{}", id)).collect();
+            writeln!(self.output, "#{}=IFCMATERIALLAYERSET(({}),'FloorLayers',$);",
+                floor_layer_set_id, layer_refs.join(","))
+                .map_err(|e| IfcError::conversion_error(e.to_string()))?;
             layer_counter += 1;
         }
 
@@ -415,34 +272,25 @@ impl<W: Write> IfcWriter<W> {
 
         if !wall_layer_ids.is_empty() {
             wall_usage_id = layer_counter;
-            writeln!(
-                self.output,
-                "#{}=IFCMATERIALLAYERSETUSAGE(#{},.AXIS2.,.POSITIVE.,0.,$);",
-                wall_usage_id, wall_layer_set_id
-            )
-            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+            writeln!(self.output, "#{}=IFCMATERIALLAYERSETUSAGE(#{},.AXIS2.,.POSITIVE.,0.,$);",
+                wall_usage_id, wall_layer_set_id)
+                .map_err(|e| IfcError::conversion_error(e.to_string()))?;
             layer_counter += 1;
         }
 
         if !roof_layer_ids.is_empty() {
             roof_usage_id = layer_counter;
-            writeln!(
-                self.output,
-                "#{}=IFCMATERIALLAYERSETUSAGE(#{},.AXIS3.,.POSITIVE.,0.,$);",
-                roof_usage_id, roof_layer_set_id
-            )
-            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+            writeln!(self.output, "#{}=IFCMATERIALLAYERSETUSAGE(#{},.AXIS3.,.POSITIVE.,0.,$);",
+                roof_usage_id, roof_layer_set_id)
+                .map_err(|e| IfcError::conversion_error(e.to_string()))?;
             layer_counter += 1;
         }
 
         if !floor_layer_ids.is_empty() {
             floor_usage_id = layer_counter;
-            writeln!(
-                self.output,
-                "#{}=IFCMATERIALLAYERSETUSAGE(#{},.AXIS3.,.POSITIVE.,0.,$);",
-                floor_usage_id, floor_layer_set_id
-            )
-            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+            writeln!(self.output, "#{}=IFCMATERIALLAYERSETUSAGE(#{},.AXIS3.,.POSITIVE.,0.,$);",
+                floor_usage_id, floor_layer_set_id)
+                .map_err(|e| IfcError::conversion_error(e.to_string()))?;
             layer_counter += 1;
         }
 
@@ -452,27 +300,16 @@ impl<W: Write> IfcWriter<W> {
             let space_local_placement = self.next_id();
             let space_id = self.next_id();
 
-            writeln!(
-                self.output,
-                "#{}=IFCLOCALPLACEMENT(#{},#{});",
-                space_local_placement, local_placement_storey, pt_id
-            )
-            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+            writeln!(self.output, "#{}=IFCLOCALPLACEMENT(#{},#{});", space_local_placement, local_placement_storey, pt_id)
+                .map_err(|e| IfcError::conversion_error(e.to_string()))?;
             writeln!(self.output, "#{}=IFCSPACE('0Exp0rtSp{{}}Gu1D000000',#{},'{}','{}',$,#{},$,$,.ELEMENT.,.INTERNAL.,$);",
                 space_id, owner_hist_id, escape_ifc_string(&zone.name), escape_ifc_string(&zone.name), space_local_placement)
                 .map_err(|e| IfcError::conversion_error(e.to_string()))?;
             space_ids.push(space_id);
 
-            writeln!(
-                self.output,
-                "#{}000=IFCRELAGGREGATES('0Exp0rtRAggZ{}000000',#{},$,$,#{},(#{}));",
-                1000 + idx,
-                idx,
-                owner_hist_id,
-                storey_id,
-                space_id
-            )
-            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+            writeln!(self.output, "#{}000=IFCRELAGGREGATES('0Exp0rtRAggZ{}000000',#{},$,$,#{},(#{}));",
+                1000 + idx, idx, owner_hist_id, storey_id, space_id)
+                .map_err(|e| IfcError::conversion_error(e.to_string()))?;
         }
 
         // Write building elements (walls as IfcBuildingElementProxy)
@@ -481,12 +318,8 @@ impl<W: Write> IfcWriter<W> {
         let mut roof_ids: Vec<u64> = Vec::new();
 
         let placement_for_elements = self.next_id();
-        writeln!(
-            self.output,
-            "#{}=IFCLOCALPLACEMENT(#{},#{});",
-            placement_for_elements, local_placement_storey, pt_id
-        )
-        .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+        writeln!(self.output, "#{}=IFCLOCALPLACEMENT(#{},#{});", placement_for_elements, local_placement_storey, pt_id)
+            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
 
         // Write wall elements
         for (idx, _) in schema.geometry.zones.iter().enumerate() {
@@ -526,65 +359,40 @@ impl<W: Write> IfcWriter<W> {
         // Write material associations for walls
         if !wall_ids.is_empty() && wall_usage_id != 0 {
             let wall_refs: Vec<String> = wall_ids.iter().map(|id| format!("#{}", id)).collect();
-            writeln!(
-                self.output,
-                "#4000=IFCRELASSOCIATESMATERIAL('0Exp0rtWMat000000000',#{},$,$,({}),#{});",
-                owner_hist_id,
-                wall_refs.join(","),
-                wall_usage_id
-            )
-            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+            writeln!(self.output, "#4000=IFCRELASSOCIATESMATERIAL('0Exp0rtWMat000000000',#{},$,$,({}),#{});",
+                owner_hist_id, wall_refs.join(","), wall_usage_id)
+                .map_err(|e| IfcError::conversion_error(e.to_string()))?;
         }
 
         // Write material associations for roofs
         if !roof_ids.is_empty() && roof_usage_id != 0 {
             let roof_refs: Vec<String> = roof_ids.iter().map(|id| format!("#{}", id)).collect();
-            writeln!(
-                self.output,
-                "#4001=IFCRELASSOCIATESMATERIAL('0Exp0rtRMat000000000',#{},$,$,({}),#{});",
-                owner_hist_id,
-                roof_refs.join(","),
-                roof_usage_id
-            )
-            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+            writeln!(self.output, "#4001=IFCRELASSOCIATESMATERIAL('0Exp0rtRMat000000000',#{},$,$,({}),#{});",
+                owner_hist_id, roof_refs.join(","), roof_usage_id)
+                .map_err(|e| IfcError::conversion_error(e.to_string()))?;
         }
 
         // Write material associations for slabs
         if !slab_ids.is_empty() && floor_usage_id != 0 {
             let slab_refs: Vec<String> = slab_ids.iter().map(|id| format!("#{}", id)).collect();
-            writeln!(
-                self.output,
-                "#4002=IFCRELASSOCIATESMATERIAL('0Exp0rtSMat000000000',#{},$,$,({}),#{});",
-                owner_hist_id,
-                slab_refs.join(","),
-                floor_usage_id
-            )
-            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+            writeln!(self.output, "#4002=IFCRELASSOCIATESMATERIAL('0Exp0rtSMat000000000',#{},$,$,({}),#{});",
+                owner_hist_id, slab_refs.join(","), floor_usage_id)
+                .map_err(|e| IfcError::conversion_error(e.to_string()))?;
         }
 
         // Write spatial containment for all elements
-        let all_element_ids: Vec<String> = wall_ids
-            .iter()
-            .chain(slab_ids.iter())
-            .chain(roof_ids.iter())
-            .map(|id| format!("#{}", id))
-            .collect();
+        let all_element_ids: Vec<String> = wall_ids.iter().chain(slab_ids.iter()).chain(roof_ids.iter())
+            .map(|id| format!("#{}", id)).collect();
         if !all_element_ids.is_empty() && !space_ids.is_empty() {
             // Contain all elements in the first space for simplicity
             let space_ref = space_ids[0];
-            writeln!(
-                self.output,
-                "#5000=IFCRELCONTAINEDINSPATIALSTRUCTURE('0Exp0rtRCont00000000',#{},$,$,({}),#{});",
-                owner_hist_id,
-                all_element_ids.join(","),
-                space_ref
-            )
-            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+            writeln!(self.output, "#5000=IFCRELCONTAINEDINSPATIALSTRUCTURE('0Exp0rtRCont00000000',#{},$,$,({}),#{});",
+                owner_hist_id, all_element_ids.join(","), space_ref)
+                .map_err(|e| IfcError::conversion_error(e.to_string()))?;
         }
 
         writeln!(self.output, "ENDSEC;").map_err(|e| IfcError::conversion_error(e.to_string()))?;
-        writeln!(self.output, "END-ISO-10303-21;")
-            .map_err(|e| IfcError::conversion_error(e.to_string()))?;
+        writeln!(self.output, "END-ISO-10303-21;").map_err(|e| IfcError::conversion_error(e.to_string()))?;
 
         Ok(())
     }

--- a/src/interop/mod.rs
+++ b/src/interop/mod.rs
@@ -68,8 +68,5 @@ pub use fmi::{
     FmuOutputs, ImportedFmu, ImportedModelDescription, ImportedScalarVariable, ZoneVariables,
 };
 pub use gbxml::{export_gbxml, import_gbxml, GbXmlError, GbXmlReader, GbXmlWriter};
-pub use ifc::{
-    export_ifc, import_ifc, IfcError, IfcGeometryParser, IfcModel, IfcParser, IfcToSchema,
-    IfcWriter,
-};
+pub use ifc::{export_ifc, import_ifc, IfcError, IfcGeometryParser, IfcModel, IfcParser, IfcToSchema, IfcWriter};
 pub use osm::{export_osm, import_osm, OsmError, OsmReader, OsmWriter};


### PR DESCRIPTION
Add missing workspace member description for `fluxion-behavior` in the workspace structure tree. No other content changes.

## Summary by Sourcery

Clarify workspace membership for the fluxion-behavior crate and apply minor formatting cleanups to IFC interop code exports.

Enhancements:
- Tidy IFC writer and interop module code formatting without changing behavior.

Documentation:
- Document that fluxion-behavior is a workspace member in the agents/workspace structure overview.