### PR TITLE
docs(workflow): Add PR template to enforce Closes/Fixes keywords

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,8 +202,9 @@ Heavy Linux jobs honour `vars.FLUXION_LINUX_RUNNER` (self-hosted Hetzner fallbac
   - No direct pushes to `main` — branch protection enforces PR-only flow.
   - PRs targeting `main` are **only permitted from the `develop` branch** (enforced by the `protect-main-branch.yml` workflow). Hotfixes targeting `main` directly from a feature branch will be automatically rejected by CI.
   - Releases are cut by merging `develop` → `main` via a release PR.
-- `--no-ff` merges preserve history (CONTRIBUTING.md).
+ - `--no-ff` merges preserve history (CONTRIBUTING.md).
 - Conventional commit messages: `fix(scope): …`, `feat(scope): …`, `refactor(scope): …`, `perf(scope): …`, `test(scope): …`, `docs(scope): …`.
+- **PR body must include `Closes #{{Number}}` or `Fixes #{{Number}}`** — wave orchestration depends on this keyword to auto-close linked issues. PRs without it will fail to close their issues.
 - Never force-push `main` or `develop`. Hotfixes still go through PR review.
 
 ## Key Files

--- a/agent-orchestrator.yaml
+++ b/agent-orchestrator.yaml
@@ -17,6 +17,7 @@ projects:
       Use conventional commits (feat:, fix:, chore:, docs:, refactor:, test:).
       Link issue numbers in commit messages.
       Write clear commit messages that explain WHY, not just WHAT.
+      PR bodies MUST include "Closes #{{Number}}" or "Fixes #{{Number}}" — wave orchestration depends on this keyword to auto-close linked issues.
 
       Follow Python best practices:
 

--- a/fluxion/.github/pull_request_template.md
+++ b/fluxion/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Description
+
+<!-- Briefly describe what this PR does -->
+
+## Issue Reference
+
+<!-- This field is REQUIRED. Must contain "Closes #{{Number}}" or "Fixes #{{Number}}" -->
+Closes #{{Number}}
+
+## Testing
+
+<!-- Describe how this change was tested -->
+
+## Checklist
+
+- [ ] Tests pass
+- [ ] Code is formatted
+- [ ] Clippy passes
+- [ ] Documentation updated (if needed)


### PR DESCRIPTION
Closes #2329

## Summary by Sourcery

Document and enforce the requirement that PR bodies include Closes/Fixes issue keywords, and add a standard PR template to guide contributors.

Documentation:
- Update contributor workflow docs to require PR bodies to include Closes/Fixes issue references for wave orchestration.

Chores:
- Add a repository-wide pull request template that captures description, issue reference with Closes/Fixes keyword, testing notes, and a basic checklist.