### PR TITLE
[Infra] Build environment SIGILL due to disk space exhaustion

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,3 +5,8 @@
 #
 # [target.'cfg(target_os = "windows")']
 # rustflags = ["-C", "link-args=/STACK:16777216"]
+
+# Disk-space-conscious build options:
+# - CARGO_INCREMENTAL=0 disables incremental compilation, reducing disk usage during build
+# - Use ./scripts/disk-space-gate.sh to check available disk space before building
+# - Use ./scripts/cleanup-build.sh to free up space when disk is low

--- a/.github/workflows/disk-space.yml
+++ b/.github/workflows/disk-space.yml
@@ -1,0 +1,40 @@
+name: Disk Space Check
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  disk-space:
+    name: Check disk space
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check disk space
+        run: |
+          AVAILABLE_KB=$(df -k . | awk 'NR==2 {print $4}')
+          AVAILABLE_GB=$(echo "scale=2; $AVAILABLE_KB / 1048576" | bc)
+          echo "Available disk space: ${AVAILABLE_GB} GB"
+          if (( $(echo "$AVAILABLE_GB < 10" | bc -l) )); then
+            echo "ERROR: Less than 10 GB free" >&2
+            exit 1
+          fi
+          echo "Disk space check passed"
+
+  pre-commit-disk-space:
+    name: Pre-commit disk space
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run disk space gate
+        run: |
+          AVAILABLE_KB=$(df -k . | awk 'NR==2 {print $4}')
+          AVAILABLE_GB=$(echo "scale=2; $AVAILABLE_KB / 1048576" | bc)
+          echo "Available disk space: ${AVAILABLE_GB} GB"
+          if (( $(echo "$AVAILABLE_GB < 5" | bc -l) )); then
+            echo "ERROR: Less than 5 GB free — insufficient for pre-commit" >&2
+            exit 2
+          fi
+          echo "Disk space check passed"

--- a/scripts/cleanup-build.sh
+++ b/scripts/cleanup-build.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# cleanup-build.sh — Free disk space by removing build artifacts
+#
+# Usage: ./scripts/cleanup-build.sh [--deep]
+#
+# Options:
+#   --deep    Remove target/ directory entirely (full rebuild)
+#   (default) Remove only incremental build cache, keep target/
+
+set -euo pipefail
+
+DEEP=false
+if [[ "${1:-}" == "--deep" ]]; then
+  DEEP=true
+fi
+
+echo "Cleaning build artifacts..."
+
+if [[ -d "target" ]]; then
+  if $DEEP; then
+    echo "  Removing target/ directory (deep clean)..."
+    rm -rf target/
+  else
+    echo "  Removing incremental build cache..."
+    rm -rf target/.cache 2>/dev/null || true
+    rm -rf target/.rustc_info.json 2>/dev/null || true
+    # Keep the target directory itself to avoid re-creating it
+  fi
+fi
+
+# Clean cargo's incremental build cache in the global cache
+if [[ -d ~/.cargo/.cache ]]; then
+  echo "  Cleaning cargo incremental cache..."
+  rm -rf ~/.cargo/.cache 2>/dev/null || true
+fi
+
+echo "Build cleanup complete."
+
+if $DEEP; then
+  echo ""
+  echo "NOTE: A full rebuild will be required on next build."
+  echo "      To avoid this, run without --deep next time."
+fi

--- a/scripts/disk-space-gate.sh
+++ b/scripts/disk-space-gate.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# disk-space-gate.sh — Warn or exit if disk space is critically low
+#
+# Usage: ./scripts/disk-space-gate.sh [--warn GB] [--exit GB] [--path DIR]
+#
+# Defaults: --warn 10 GB free, --exit 5 GB free, --path .
+#
+# Exit codes: 0 = OK, 1 = warning, 2 = insufficient space (exits)
+
+set -euo pipefail
+
+WARN_GB=10
+EXIT_GB=5
+CHECK_PATH="."
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --warn) WARN_GB="$2"; shift 2 ;;
+    --exit) EXIT_GB="$2"; shift 2 ;;
+    --path) CHECK_PATH="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
+AVAILABLE_KB=$(df -k "$CHECK_PATH" | awk 'NR==2 {print $4}')
+AVAILABLE_GB=$(echo "scale=2; $AVAILABLE_KB / 1048576" | bc)
+
+echo "Available disk space: ${AVAILABLE_GB} GB on $CHECK_PATH"
+
+if (( $(echo "$AVAILABLE_GB < $EXIT_GB" | bc -l) )); then
+  echo "ERROR: Insufficient disk space (${AVAILABLE_GB} GB < ${EXIT_GB} GB minimum)" >&2
+  echo "Please free up disk space before building. Suggestions:" >&2
+  echo "  - Run: ./scripts/cleanup-build.sh" >&2
+  echo "  - Or:  CARGO_INCREMENTAL=0 cargo build" >&2
+  exit 2
+fi
+
+if (( $(echo "$AVAILABLE_GB < $WARN_GB" | bc -l) )); then
+  echo "WARNING: Low disk space (${AVAILABLE_GB} GB < ${WARN_GB} GB recommended)" >&2
+  echo "Consider running: ./scripts/cleanup-build.sh" >&2
+  exit 1
+fi
+
+echo "Disk space check passed (${AVAILABLE_GB} GB available)"
+exit 0


### PR DESCRIPTION
Closes #2178

## Summary by Sourcery

Introduce disk-space safeguards and guidance to prevent build failures due to low disk space.

Enhancements:
- Add disk-space-gate and cleanup-build helper scripts to check available disk and remove build artifacts when space is low.
- Annotate cargo configuration with disk-space-conscious build options for incremental compilation and cleanup workflows.

CI:
- Add GitHub Actions workflow to enforce minimum disk space thresholds for pushes and pull requests, including a stricter pre-commit disk-space check.

Documentation:
- Document disk space requirements, cleanup options, and recommended build settings to avoid SIGILL crashes on low-space machines.