### PR TITLE
fix(physics): resolve #2345 — replace 10000 m³/s ventilation_airflow hardcode with actual zone spec

### DIFF
--- a/src/sim/hvac/equipment.rs
+++ b/src/sim/hvac/equipment.rs
@@ -109,6 +109,21 @@ impl VariableCapacityEquipment for AnyEquipment {
     }
 }
 
+impl AnyEquipment {
+    /// Returns the ventilation airflow rate in m³/s for economizer free-cooling calculations.
+    /// For CAV systems this is the design airflow; for VAV terminals this is the maximum airflow.
+    /// Equipment types without ventilation (chillers, boilers) return 0.0.
+    pub fn ventilation_airflow_m3_per_s(&self) -> f64 {
+        match self {
+            AnyEquipment::Chiller(_) => 0.0,
+            AnyEquipment::Boiler(_) => 0.0,
+            AnyEquipment::VAVTerminal(e) => e.max_airflow,
+            AnyEquipment::CAVSystem(e) => e.design_airflow,
+            AnyEquipment::HeatPump(_) => 0.0, // HeatPump doesn't have design_airflow
+        }
+    }
+}
+
 /// Trait for variable-capacity HVAC equipment.
 ///
 /// This trait provides a unified interface for HVAC equipment that can

--- a/src/sim/thermal_model_core.rs
+++ b/src/sim/thermal_model_core.rs
@@ -2240,6 +2240,17 @@ impl ThermalModel<VectorField> {
         // This is required for Cases 800-810 (HVAC equipment cases)
         model.hvac_equipment = spec.hvac_equipment.clone();
 
+        // Issue #2345: Compute ventilation airflow for economizer free-cooling calculations.
+        // Priority: 1) HVAC equipment design airflow, 2) night ventilation fan capacity, 3) 0.0
+        model.ventilation_airflow_m3_per_s = if let Some(ref equipment) = model.hvac_equipment {
+            equipment.ventilation_airflow_m3_per_s()
+        } else if let Some(ref night_vent) = spec.night_ventilation {
+            // Convert from standard m³/h to m³/s
+            night_vent.fan_capacity / 3600.0
+        } else {
+            0.0
+        };
+
         // Initialize IdealLoadsSystem with zone properties from geometry (Issue #521, Issue #532)
         // Create one IdealLoadsSystem per zone with that zone's volume
         let zone_vols = model.zone_volume.as_ref();
@@ -2659,6 +2670,7 @@ impl ThermalModel<VectorField> {
             hvac_system_mode: HvacSystemMode::Controlled,
             night_ventilation: None,
             h_vent_mass: 0.0,
+            ventilation_airflow_m3_per_s: 0.0, // Will be set from hvac_equipment or night_ventilation
             thermal_bridge_coefficient: 0.0,
             convective_fraction: 0.4,
             solar_distribution_to_air: 0.1,

--- a/src/sim/thermal_model_data.rs
+++ b/src/sim/thermal_model_data.rs
@@ -187,6 +187,10 @@ pub struct ThermalModelData<T: ContinuousTensor<f64> + Clone> {
     pub hvac_system_mode: HvacSystemMode,
     pub night_ventilation: Option<NightVentilation>,
     pub h_vent_mass: f64,
+    /// Ventilation airflow rate for economizer free-cooling calculations (m³/s).
+    /// Issue #2345: This replaces the hardcoded 10000.0 m³/s placeholder that was
+    /// corrupting free-cooling capacity calculations.
+    pub ventilation_airflow_m3_per_s: f64,
     pub thermal_bridge_coefficient: f64,
     pub ideal_air_loads_mode: bool,
     pub ideal_loads_system: Vec<Option<IdealLoadsSystem>>,
@@ -401,6 +405,7 @@ impl<T: ContinuousTensor<f64> + Clone> Clone for ThermalModelData<T> {
             hvac_system_mode: self.hvac_system_mode,
             night_ventilation: self.night_ventilation,
             h_vent_mass: self.h_vent_mass,
+            ventilation_airflow_m3_per_s: self.ventilation_airflow_m3_per_s,
             thermal_bridge_coefficient: self.thermal_bridge_coefficient,
             ideal_air_loads_mode: self.ideal_air_loads_mode,
             ideal_loads_system: self.ideal_loads_system.clone(),

--- a/src/sim/thermal_model_physics/physics_impl.rs
+++ b/src/sim/thermal_model_physics/physics_impl.rs
@@ -924,7 +924,7 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
                     calculate_free_cooling_capacity(
                         outdoor_temp,
                         self.0.temperatures.as_ref()[0],
-                        10000.0, // TODO: ventilation_airflow from building spec (m³/s)
+                        self.0.ventilation_airflow_m3_per_s, // Issue #2345: was hardcoded 10000.0
                     ) * 1000.0 // Convert kW to W
                 } else {
                     0.0
@@ -3300,7 +3300,7 @@ impl<T: ContinuousTensor<f64> + From<VectorField> + AsRef<[f64]> + AsMut<[f64]>>
                         calculate_free_cooling_capacity(
                             outdoor_temp,
                             self.0.temperatures.as_ref()[0],
-                            10000.0, // TODO: ventilation_airflow from building spec (m³/s)
+                            self.0.ventilation_airflow_m3_per_s, // Issue #2345: was hardcoded 10000.0
                         ) * 1000.0
                     } else {
                         0.0


### PR DESCRIPTION
Closes #2345

## Summary by Sourcery

Replace hardcoded ventilation airflow in free-cooling physics with airflow derived from HVAC equipment or night ventilation specifications.

Bug Fixes:
- Fix incorrect economizer free-cooling capacity calculations caused by a hardcoded 10000 m³/s ventilation airflow placeholder.

Enhancements:
- Add ventilation airflow accessor on HVAC equipment and propagate the value through thermal model data for use in physics calculations.