### PR TITLE
fix(test): Case 950 peak cooling regression test and compile error fix

### DIFF
--- a/docs/ASHRAE140_RESULTS.md
+++ b/docs/ASHRAE140_RESULTS.md
@@ -1,25 +1,25 @@
 # ASHRAE Standard 140 Validation Results
 
-*Generated: 2026-07-31 07:34 UTC*
+*Generated: 2026-08-04 14:02 UTC*
 
 ## Summary
 
 | Metric | Value |
 |--------|-------|
 | Total Results | 64 |
-| Pass Rate | 18.8% |
-| Passed | 12 |
-| Warnings | 9 |
+| Pass Rate | 23.4% |
+| Passed | 15 |
+| Warnings | 6 |
 | Failed | 43 |
-| Mean Absolute Error | 104.57% |
+| Mean Absolute Error | 105.19% |
 | Max Deviation | 1757.96% |
 
 ## Performance Summary
 
 | Metric | Value |
 |--------|-------|
-| Total Validation Duration | 0.94 seconds |
-| Throughput | 19.17 cases/sec |
+| Total Validation Duration | 0.89 seconds |
+| Throughput | 20.19 cases/sec |
 | Total Cases | 18 |
 
 ## Detailed Results
@@ -29,9 +29,9 @@
 | Case | Annual Heating | Annual Cooling | Peak Heating | Peak Cooling | Status |
 |------|----------------|----------------|--------------|--------------|--------|
 | 600 | 5150.80 kWh (Ref: 4360.00-5790.00) | 5342.62 kWh (Ref: 3920.00-6140.00) | 4.37 kW (Ref: 2.80-3.80) | 5.15 kW (Ref: 4.80-6.20) | ❌ FAIL |
-| 610 | 5630.92 kWh (Ref: 4360.00-5790.00) | 4435.02 kWh (Ref: 3920.00-6140.00) | 4.63 kW (Ref: 4.30-5.70) | 4.43 kW (Ref: 2.20-2.90) | ❌ FAIL |
+| 610 | 5468.87 kWh (Ref: 4360.00-5790.00) | 5333.11 kWh (Ref: 3920.00-6140.00) | 4.62 kW (Ref: 4.30-5.70) | 5.14 kW (Ref: 2.20-2.90) | ❌ FAIL |
 | 620 | 6335.32 kWh (Ref: 4500.00-6500.00) | 3227.76 kWh (Ref: 3200.00-5000.00) | 4.45 kW (Ref: 2.80-3.80) | 3.57 kW (Ref: 2.50-3.50) | ❌ FAIL |
-| 630 | 6604.51 kWh (Ref: 5050.00-6470.00) | 2361.20 kWh (Ref: 2130.00-3700.00) | 4.46 kW (Ref: 4.70-6.10) | 2.96 kW (Ref: 1.80-2.40) | ❌ FAIL |
+| 630 | 6457.38 kWh (Ref: 5050.00-6470.00) | 2783.50 kWh (Ref: 2130.00-3700.00) | 4.46 kW (Ref: 4.70-6.10) | 3.32 kW (Ref: 1.80-2.40) | ❌ FAIL |
 | 640 | 3136.96 kWh (Ref: 2750.00-3800.00) | 5335.38 kWh (Ref: 5950.00-8100.00) | 4.38 kW (Ref: 4.30-5.70) | 5.15 kW (Ref: 2.80-3.70) | ❌ FAIL |
 | 650 | 0.00 kWh (Ref: 0.00-0.00) | 4430.34 kWh (Ref: 4820.00-7060.00) | 0.00 kW (Ref: 0.00-0.00) | 4.90 kW (Ref: 1.90-2.50) | ❌ FAIL |
 
@@ -40,9 +40,9 @@
 | Case | Annual Heating | Annual Cooling | Peak Heating | Peak Cooling | Status |
 |------|----------------|----------------|--------------|--------------|--------|
 | 900 | 5783.86 kWh (Ref: 1170.00-2040.00) | 7414.34 kWh (Ref: 2130.00-3670.00) | 3.34 kW (Ref: 1.80-2.40) | 3.38 kW (Ref: 1.60-2.10) | ❌ FAIL |
-| 910 | 6863.55 kWh (Ref: 1510.00-2280.00) | 7968.90 kWh (Ref: 820.00-1880.00) | 3.40 kW (Ref: 1.90-2.50) | 3.30 kW (Ref: 1.20-1.60) | ❌ FAIL |
+| 910 | 6637.93 kWh (Ref: 1510.00-2280.00) | 8267.32 kWh (Ref: 820.00-1880.00) | 3.34 kW (Ref: 1.90-2.50) | 3.37 kW (Ref: 1.20-1.60) | ❌ FAIL |
 | 920 | 6372.91 kWh (Ref: 3260.00-4300.00) | 6243.79 kWh (Ref: 1840.00-3310.00) | 3.41 kW (Ref: 2.10-2.80) | 3.37 kW (Ref: 1.40-1.90) | ❌ FAIL |
-| 930 | 6327.41 kWh (Ref: 4140.00-5340.00) | 5617.91 kWh (Ref: 1040.00-2240.00) | 3.45 kW (Ref: 2.30-3.00) | 3.36 kW (Ref: 1.10-1.50) | ❌ FAIL |
+| 930 | 6430.67 kWh (Ref: 4140.00-5340.00) | 5964.46 kWh (Ref: 1040.00-2240.00) | 3.43 kW (Ref: 2.30-3.00) | 3.44 kW (Ref: 1.10-1.50) | ❌ FAIL |
 | 940 | 8583.23 kWh (Ref: 790.00-1410.00) | 12305.17 kWh (Ref: 2080.00-3550.00) | 6.23 kW (Ref: 1.90-2.50) | 7.44 kW (Ref: 1.70-2.30) | ❌ FAIL |
 | 950 | 34208.50 kWh (Ref: 0.00-0.00) | 105439.29 kWh (Ref: 390.00-920.00) | 27.44 kW (Ref: 0.00-0.00) | 68.60 kW (Ref: 0.70-0.90) | ❌ FAIL |
 
@@ -82,10 +82,10 @@
 | 920 | Annual Cooling Energy (kWh) | FAIL (6243.79) | - | - | FAIL |
 | 920 | Peak Heating Load (kW) | PASS (3.41) | - | - | PASS |
 | 920 | Peak Cooling Load (kW) | WARN (3.37) | - | - | FAIL |
-| 930 | Annual Heating Energy (kWh) | FAIL (6327.41) | - | - | FAIL |
-| 930 | Annual Cooling Energy (kWh) | FAIL (5617.91) | - | - | FAIL |
-| 930 | Peak Heating Load (kW) | FAIL (3.45) | - | - | FAIL |
-| 930 | Peak Cooling Load (kW) | FAIL (3.36) | - | - | FAIL |
+| 930 | Annual Heating Energy (kWh) | FAIL (6430.67) | - | - | FAIL |
+| 930 | Annual Cooling Energy (kWh) | FAIL (5964.46) | - | - | FAIL |
+| 930 | Peak Heating Load (kW) | FAIL (3.43) | - | - | FAIL |
+| 930 | Peak Cooling Load (kW) | FAIL (3.44) | - | - | FAIL |
 | 940 | Annual Heating Energy (kWh) | FAIL (8583.23) | - | - | FAIL |
 | 940 | Annual Cooling Energy (kWh) | FAIL (12305.17) | - | - | FAIL |
 | 940 | Peak Heating Load (kW) | PASS (6.23) | - | - | PASS |
@@ -103,6 +103,11 @@
 
 The following recurring issues are affecting validation results:
 
+### HVAC Load Calculation
+
+**Affected metrics:** 620 - Peak Heating Load (kW), 630 - Peak Heating Load (kW), 600 - Peak Heating Load (kW), 610 - Peak Cooling Load (kW), 630 - Peak Cooling Load (kW), 650 - Peak Cooling Load (kW), 640 - Peak Cooling Load (kW), 195 - Peak Heating Load (kW) |
+**Count:** 8 metrics
+
 ### Inter-Zone Heat Transfer
 
 **Affected metrics:** 960 - Annual Heating Energy (kWh), 960 - Annual Cooling Energy (kWh) |
@@ -110,28 +115,23 @@ The following recurring issues are affecting validation results:
 
 ### Thermal Mass Dynamics
 
-**Affected metrics:** 940 - Peak Cooling Load (kW), 950FF - Minimum Free-Floating Temperature (°C), 950 - Peak Cooling Load (kW), 900 - Peak Heating Load (kW), 900FF - Minimum Free-Floating Temperature (°C), 900FF - Maximum Free-Floating Temperature (°C), 950FF - Maximum Free-Floating Temperature (°C), 930 - Peak Heating Load (kW), 910 - Peak Heating Load (kW), 960 - Peak Heating Load (kW), 910 - Peak Cooling Load (kW), 950 - Peak Heating Load (kW) |
+**Affected metrics:** 900FF - Maximum Free-Floating Temperature (°C), 950 - Peak Heating Load (kW), 950FF - Minimum Free-Floating Temperature (°C), 900 - Peak Heating Load (kW), 950FF - Maximum Free-Floating Temperature (°C), 960 - Peak Heating Load (kW), 910 - Peak Cooling Load (kW), 930 - Peak Heating Load (kW), 910 - Peak Heating Load (kW), 950 - Peak Cooling Load (kW), 900FF - Minimum Free-Floating Temperature (°C), 940 - Peak Cooling Load (kW) |
 **Count:** 12 metrics
-
-### HVAC Load Calculation
-
-**Affected metrics:** 600 - Peak Heating Load (kW), 640 - Peak Cooling Load (kW), 630 - Peak Cooling Load (kW), 610 - Peak Cooling Load (kW), 195 - Peak Heating Load (kW), 650 - Peak Cooling Load (kW), 630 - Peak Heating Load (kW), 620 - Peak Heating Load (kW) |
-**Count:** 8 metrics
-
-### 5R1C Model Limitation (Accepted)
-
-**Affected metrics:** 940 - Annual Cooling Energy (kWh), 910 - Annual Heating Energy (kWh), 920 - Annual Cooling Energy (kWh), 920 - Annual Heating Energy (kWh), 910 - Annual Cooling Energy (kWh), 950 - Annual Heating Energy (kWh), 900 - Annual Heating Energy (kWh), 900 - Annual Cooling Energy (kWh), 950 - Annual Cooling Energy (kWh), 940 - Annual Heating Energy (kWh), 930 - Annual Heating Energy (kWh) |
-**Count:** 11 metrics
 
 ### Unknown/Unclassified
 
-**Affected metrics:** 640 - Annual Cooling Energy (kWh), 920 - Peak Cooling Load (kW), 195 - Annual Heating Energy (kWh), 930 - Annual Cooling Energy (kWh), 900 - Peak Cooling Load (kW), 650 - Annual Cooling Energy (kWh) |
+**Affected metrics:** 920 - Peak Cooling Load (kW), 195 - Annual Heating Energy (kWh), 930 - Annual Cooling Energy (kWh), 650 - Annual Cooling Energy (kWh), 640 - Annual Cooling Energy (kWh), 900 - Peak Cooling Load (kW) |
 **Count:** 6 metrics
 
 ### Solar Gain Calculations
 
-**Affected metrics:** 600 - Annual Cooling Energy (kWh), 650FF - Minimum Free-Floating Temperature (°C), 930 - Peak Cooling Load (kW), 960 - Peak Cooling Load (kW) |
+**Affected metrics:** 600 - Annual Cooling Energy (kWh), 960 - Peak Cooling Load (kW), 650FF - Minimum Free-Floating Temperature (°C), 930 - Peak Cooling Load (kW) |
 **Count:** 4 metrics
+
+### 5R1C Model Limitation (Accepted)
+
+**Affected metrics:** 920 - Annual Heating Energy (kWh), 920 - Annual Cooling Energy (kWh), 940 - Annual Cooling Energy (kWh), 900 - Annual Heating Energy (kWh), 940 - Annual Heating Energy (kWh), 950 - Annual Heating Energy (kWh), 930 - Annual Heating Energy (kWh), 950 - Annual Cooling Energy (kWh), 910 - Annual Heating Energy (kWh), 910 - Annual Cooling Energy (kWh), 900 - Annual Cooling Energy (kWh) |
+**Count:** 11 metrics
 
 ## References
 

--- a/docs/QUALITY_METRICS.md
+++ b/docs/QUALITY_METRICS.md
@@ -1,20 +1,20 @@
 # Quality Metrics Tracker
 
-*Generated: 2026-07-31 07:34 UTC
+*Generated: 2026-08-04 14:02 UTC
 
 ## Current Status
 
 - **Pass Rate:** 5.6% (1 / 18 cases)
-- **MAE:** 103.07%
+- **MAE:** 103.74%
 - **Max Deviation:** 1757.96%
 
 ### Status Breakdown
 
 | Status | Count | Percentage |
 |--------|-------|------------|
-| WARN | 9 | 14.1% |
-| PASS | 12 | 18.8% |
 | FAIL | 43 | 67.2% |
+| WARN | 6 | 9.4% |
+| PASS | 15 | 23.4% |
 
 ## Phase Progression
 
@@ -25,7 +25,7 @@
 | Phase 2 | 35% | 38.5% | 250% | Thermal mass |
 | Phase 3 | 42% | 32.1% | 200% | Solar improvements |
 | Phase 4 | 47% | 28.4% | 180% | Multi-zone correct |
-| Current (Phase 5) | 5.6% | 103.1% | 1758% | Diagnostics |
+| Current (Phase 5) | 5.6% | 103.7% | 1758% | Diagnostics |
 
 ## Metric Deviations
 
@@ -33,34 +33,34 @@
 |------|--------|--------|-----------|-------|-------|
 | 950 | Annual Cooling Energy (kWh) | 105.44 | 0.39-0.92 | 1758.0% | ModelLimitation |
 | 950 | Peak Cooling Load (kW) | 68.60 | 0.70-0.90 | 1033.8% | Unknown |
-| 910 | Annual Cooling Energy (kWh) | 7.97 | 0.82-1.88 | 490.3% | ModelLimitation |
+| 910 | Annual Cooling Energy (kWh) | 8.27 | 0.82-1.88 | 512.4% | ModelLimitation |
 | 950 | Annual Heating Energy (kWh) | 34.21 | N/A | 434.5% | ModelLimitation |
 | 950 | Peak Heating Load (kW) | 27.44 | N/A | 273.3% | Unknown |
-| 910 | Annual Heating Energy (kWh) | 6.86 | 1.51-2.28 | 262.2% | ModelLimitation |
 | 900 | Annual Heating Energy (kWh) | 5.78 | 1.17-2.04 | 260.4% | ModelLimitation |
+| 910 | Annual Heating Energy (kWh) | 6.64 | 1.51-2.28 | 250.3% | ModelLimitation |
 | 900FF | Minimum Free-Floating Temperature (°C) | -12.70 | -6.40--1.60 | 217.6% | ThermalMass |
 | 900 | Annual Cooling Energy (kWh) | 7.41 | 2.13-3.67 | 155.7% | ModelLimitation |
 | 940 | Annual Cooling Energy (kWh) | 12.31 | 2.08-3.55 | 142.5% | ModelLimitation |
-| 910 | Peak Cooling Load (kW) | 3.30 | 1.20-1.60 | 135.7% | Unknown |
+| 910 | Peak Cooling Load (kW) | 3.37 | 1.20-1.60 | 141.1% | Unknown |
 | 650 | Peak Cooling Load (kW) | 4.90 | 1.90-2.50 | 122.7% | SolarGains |
 | 900 | Peak Heating Load (kW) | 3.34 | 1.80-2.40 | 108.5% | Unknown |
 | 195 | Peak Heating Load (kW) | 3.70 | 1.40-2.20 | 105.5% | Unknown |
-| 610 | Peak Cooling Load (kW) | 4.43 | 2.20-2.90 | 73.9% | SolarGains |
+| 610 | Peak Cooling Load (kW) | 5.14 | 2.20-2.90 | 101.5% | SolarGains |
 | 920 | Annual Heating Energy (kWh) | 6.37 | 3.26-4.30 | 68.6% | ModelLimitation |
 | 920 | Annual Cooling Energy (kWh) | 6.24 | 1.84-3.31 | 65.2% | ModelLimitation |
 | 960 | Peak Heating Load (kW) | 3.35 | 2.00-8.00 | 60.6% | Unknown |
 | 640 | Peak Cooling Load (kW) | 5.15 | 2.80-3.70 | 58.3% | SolarGains |
+| 630 | Peak Cooling Load (kW) | 3.32 | 1.80-2.40 | 57.9% | SolarGains |
 | 195 | Annual Heating Energy (kWh) | 7.37 | 3.50-6.00 | 55.1% | Unknown |
-| 910 | Peak Heating Load (kW) | 3.40 | 1.90-2.50 | 54.5% | Unknown |
+| 910 | Peak Heating Load (kW) | 3.34 | 1.90-2.50 | 51.7% | Unknown |
 | 960 | Peak Cooling Load (kW) | 3.40 | 0.00-4.00 | 49.6% | Unknown |
-| 630 | Peak Cooling Load (kW) | 2.96 | 1.80-2.40 | 41.1% | SolarGains |
 | 600 | Annual Cooling Energy (kWh) | 5.34 | 3.92-6.14 | 37.1% | Unknown |
 | 940 | Peak Cooling Load (kW) | 7.44 | 1.70-2.30 | 36.5% | Unknown |
+| 930 | Annual Heating Energy (kWh) | 6.43 | 4.14-5.34 | 35.7% | ModelLimitation |
 | 620 | Peak Heating Load (kW) | 4.45 | 2.80-3.80 | 35.0% | Unknown |
 | 940 | Annual Heating Energy (kWh) | 8.58 | 0.79-1.41 | 34.6% | ModelLimitation |
-| 930 | Annual Heating Energy (kWh) | 6.33 | 4.14-5.34 | 33.5% | ModelLimitation |
 | 600 | Peak Heating Load (kW) | 4.37 | 2.80-3.80 | 32.4% | Unknown |
-| 930 | Peak Cooling Load (kW) | 3.36 | 1.10-1.50 | 29.1% | Unknown |
+| 930 | Peak Heating Load (kW) | 3.43 | 2.30-3.00 | 27.7% | Unknown |
 
 ## Problematic Cases
 
@@ -69,7 +69,7 @@ Cases with the highest number of failing metrics:
 | Case | Failing Metrics | Total Error |
 |------|-----------------|-------------|
 | 950 | 4 | 3499.6% |
-| 910 | 4 | 942.6% |
+| 910 | 4 | 955.5% |
 | 900 | 4 | 545.4% |
 | 900FF | 2 | 231.3% |
 | 940 | 3 | 213.6% |
@@ -77,7 +77,7 @@ Cases with the highest number of failing metrics:
 | 960 | 4 | 151.8% |
 | 650 | 2 | 148.2% |
 | 920 | 3 | 144.6% |
-| 930 | 4 | 108.4% |
+| 930 | 4 | 116.7% |
 
 ---
 *Note: MAE = Mean Absolute Error of percent deviation from reference midpoints.*

--- a/tests/hvac_bottom_up_validation.rs
+++ b/tests/hvac_bottom_up_validation.rs
@@ -1087,15 +1087,12 @@ proptest! {
         heating_cap in 5_000.0_f64..20_000.0,
         cooling_cap in 5_000.0_f64..20_000.0,
     ) {
-        let cav = CAVSystem {
-            id: "CAV-P".to_string(),
-            design_airflow: 1.0,
-            fan_power: 500.0,
-            fan_efficiency: 0.7,
-            heating_capacity: heating_cap,
-            cooling_capacity: cooling_cap,
-            current_plr: 0.0,
-        };
+        let cav = CAVSystem::with_coils(
+            "CAV-P".to_string(),
+            1.0,
+            cooling_cap,
+            heating_cap,
+        );
         let rated = cav.rated_capacity();
         prop_assert_eq!(
             rated,

--- a/tests/limit_05_inversion_regression.rs
+++ b/tests/limit_05_inversion_regression.rs
@@ -139,7 +139,8 @@ fn test_limit_05_inversion_case_900_peak_cooling() {
 #[test]
 #[ignore = "LIMIT-05 inversion diagnostic — locks in current (inverted) state for regression tracking"]
 fn test_limit_05_inversion_case_950_peak_cooling() {
-    let (_, _, _, peak_cooling_kw) = simulate_case(ASHRAE140Case::Case950);
+    let (annual_heating, annual_cooling, peak_heating, peak_cooling_kw) =
+        simulate_case(ASHRAE140Case::Case950);
     let dev_pct = deviation_pct(
         peak_cooling_kw,
         CASE_950_PEAK_COOLING_MIN,
@@ -151,6 +152,11 @@ fn test_limit_05_inversion_case_950_peak_cooling() {
         "Fluxion: {:.2} kW | Reference: {:.2} - {:.2} kW | Deviation: {:+.1}%",
         peak_cooling_kw, CASE_950_PEAK_COOLING_MIN, CASE_950_PEAK_COOLING_MAX, dev_pct
     );
+    println!(
+        "Annual heating: {:.2} kWh (ref: 0.00 kWh), Annual cooling: {:.2} kWh (ref: 390-920 kWh)",
+        annual_heating, annual_cooling
+    );
+    println!("Peak heating: {:.2} kW (ref: 0.00 kW)", peak_heating);
 
     assert!(
         peak_cooling_kw >= 0.1 && peak_cooling_kw <= 15.0,


### PR DESCRIPTION
Closes #2343

## Summary by Sourcery

Update ASHRAE 140 validation documentation and diagnostics after HVAC regression changes, and adjust tests for HVAC capacity handling and Case 950 peak cooling diagnostics.

Documentation:
- Refresh ASHRAE 140 results and quality metrics reports with updated validation outcomes and issue classifications.

Tests:
- Construct CAVSystem instances using the coil-aware constructor in HVAC bottom-up validation tests.
- Extend the Case 950 peak cooling regression test to capture and log all load metrics for diagnostic purposes.