### PR TITLE
fix(validation): resolve #2342 — remove spurious west window from Case 610

### DIFF
--- a/src/validation/ashrae_140_cases.rs
+++ b/src/validation/ashrae_140_cases.rs
@@ -1748,17 +1748,14 @@ impl CaseBuilder {
             .expect("Case 600 should validate")
     }
 
-    /// Case 610 - Low mass with south shading + west window.
+    /// Case 610 - Low mass with south shading only (1m overhang).
     pub fn case_610_south_shading() -> CaseSpec {
         Self::new()
             .with_case_id("610".to_string())
-            .with_description(
-                "Low mass with south shading (1m overhang) + west 3m² window".to_string(),
-            )
+            .with_description("Low mass with south shading (1m overhang)".to_string())
             .with_dimensions(8.0, 6.0, 2.7)
             .low_mass_construction()
             .with_south_window(12.0)
-            .with_window(3.0, Orientation::West)
             .with_window_properties(WindowSpec::double_clear_glass())
             .with_shading(ShadingDevice::overhang(1.0, 2.7))
             .with_internal_loads(InternalLoads::new(200.0, 0.6, 0.4))

--- a/tests/issue_1457_hvac_coefficient.rs
+++ b/tests/issue_1457_hvac_coefficient.rs
@@ -119,7 +119,7 @@ fn test_iso_hvac_coefficient_case_600_is_in_band() {
 
 #[test]
 fn test_iso_hvac_coefficient_case_610_in_band() {
-    // Same check for Case 610 (south shading + west window).
+    // Same check for Case 610 (south shading only — 12 m² south window, no west window).
     let spec = ASHRAE140Case::Case610.spec();
     let model = ThermalModel::<VectorField>::from_spec(&spec);
 
@@ -131,11 +131,11 @@ fn test_iso_hvac_coefficient_case_610_in_band() {
     let h_tr_1 = h_tr_is * h_tr_ms / (h_tr_is + h_tr_ms);
     let h_coeff_iso = h_tr_1 + h_tr_w;
 
-    // Case 610 has 15 m² windows → H_tr,w ≈ 31.5 W/K.
-    // Expected ISO h_coeff total in [115, 150] W/K.
+    // Case 610 has 12 m² south-facing window only → H_tr,w ≈ 25.2 W/K.
+    // Expected ISO h_coeff total in [108, 143] W/K.
     assert!(
-        h_coeff_iso > 115.0 && h_coeff_iso < 150.0,
-        "ISO h_coeff for Case 610 = {h_coeff_iso:.2} W/K outside [115, 150] band \
+        h_coeff_iso > 108.0 && h_coeff_iso < 143.0,
+        "ISO h_coeff for Case 610 = {h_coeff_iso:.2} W/K outside [108, 143] band \
          (h_tr_is={h_tr_is:.2}, h_tr_ms={h_tr_ms:.2}, h_tr_w={h_tr_w:.2})"
     );
 }


### PR DESCRIPTION
Closes #2342

## Summary by Sourcery

Align ASHRAE 140 Case 610 specification and validation tests with the correct geometry by removing the west window and updating the expected HVAC heat transfer coefficient band.

Enhancements:
- Update Case 610 description and geometry to model only a 12 m² south-facing window with south shading, removing the incorrect west window.

Tests:
- Adjust Case 610 HVAC coefficient validation comments and acceptable ISO heat transfer coefficient range to match the corrected window area and configuration.