### PR TITLE
feat(grid): complete fluxion-grid optional integration with fluxion feature — resolve #2381

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,10 @@ fluxion-city = ["dep:fluxion-city"]
 # Enables dhat allocation tracking for memory profiling of large simulations.
 # Run with: cargo build --features dhat
 dhat = ["dep:dhat"]
+# Stub feature to allow fluxion-grid to depend on this crate with a fluxion feature.
+# fluxion-grid uses dep:fluxion to reference this crate, and this feature exists
+# to satisfy the feature resolution when --features fluxion is used at workspace level.
+fluxion = []
 
 [lints.rust]
 unexpected_cfgs = { level = "allow", check-cfg = ["cfg(docsrs,test)", "cfg(gil_refs)"] }

--- a/fluxion-grid/Cargo.toml
+++ b/fluxion-grid/Cargo.toml
@@ -16,6 +16,9 @@ default = []
 # Enable integration with the main fluxion crate's ThermalModelTrait.
 # When enabled, ThermalElectricalCoupler can hold Arc<dyn ThermalModelTrait>
 # for joint thermal-electrical convergence with the full thermal solver.
+fluxion-integration = ["dep:fluxion"]
+# Backward-compatible alias for fluxion-integration.
+# Deprecated: use fluxion-integration instead.
 fluxion = ["dep:fluxion"]
 
 [dependencies]
@@ -26,7 +29,7 @@ nalgebra = "0.34"
 fluxion-fluid = { path = "../fluxion-fluid" }
 
 # Optional dependency on the main fluxion crate for ThermalModelTrait integration.
-# Only available when the "fluxion" feature flag is enabled.
+# Only available when the "fluxion-integration" feature flag is enabled.
 fluxion = { path = "..", version = "1.0.0", optional = true }
 
 [dev-dependencies]

--- a/fluxion-grid/src/fluxion_bridge.rs
+++ b/fluxion-grid/src/fluxion_bridge.rs
@@ -1,6 +1,6 @@
 //! Bridge module for integrating with the main `fluxion` crate's `ThermalModelTrait`.
 //!
-//! This module is only available when the `fluxion` feature flag is enabled.
+//! This module is only available when the `fluxion-integration` feature flag is enabled.
 //! It provides a wrapper that allows `ThermalElectricalCoupler` to hold
 //! `Arc<dyn ThermalModelTrait>` for joint thermal-electrical convergence.
 //!
@@ -16,20 +16,20 @@
 
 use std::sync::Arc;
 
-#[cfg(feature = "fluxion")]
+#[cfg(feature = "fluxion-integration")]
 use fluxion::ThermalModelTrait;
 
 /// Bridge that holds both a `ThermalElectricalCoupler` and an `Arc<dyn ThermalModelTrait>`.
 ///
 /// This enables joint thermal-electrical convergence where the grid-side coupler
 /// can query the full thermal solver state rather than relying on scalar HVAC values.
-#[cfg(feature = "fluxion")]
+#[cfg(feature = "fluxion-integration")]
 pub struct ThermalModelTraitBridge {
     coupler: crate::ThermalElectricalCoupler,
     thermal_model: Arc<dyn ThermalModelTrait>,
 }
 
-#[cfg(feature = "fluxion")]
+#[cfg(feature = "fluxion-integration")]
 impl ThermalModelTraitBridge {
     /// Create a new bridge with a coupler and thermal model.
     pub fn new(
@@ -67,6 +67,147 @@ impl ThermalModelTraitBridge {
     }
 }
 
-/// Tag type indicating the fluxion feature is not enabled.
-#[cfg(not(feature = "fluxion"))]
+/// Tag type indicating the fluxion-integration feature is not enabled.
+#[cfg(not(feature = "fluxion-integration"))]
 pub struct ThermalModelTraitBridge;
+
+#[cfg(feature = "fluxion-integration")]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ThermalElectricalCoupler;
+
+    /// Mock thermal model implementing ThermalModelTrait for testing.
+    #[cfg(feature = "fluxion-integration")]
+    struct MockThermalModelForTest {
+        num_zones: usize,
+        temperatures: Vec<f64>,
+        heating_setpoint: f64,
+        cooling_setpoint: f64,
+        zone_area: f64,
+        fixed_hvac_power: f64,
+    }
+
+    #[cfg(feature = "fluxion-integration")]
+    impl MockThermalModelForTest {
+        fn new(num_zones: usize, hvac_power: f64) -> Self {
+            Self {
+                num_zones,
+                temperatures: vec![20.0; num_zones],
+                heating_setpoint: 20.0,
+                cooling_setpoint: 24.0,
+                zone_area: 100.0,
+                fixed_hvac_power: hvac_power,
+            }
+        }
+    }
+
+    #[cfg(feature = "fluxion-integration")]
+    impl ThermalModelTrait for MockThermalModelForTest {
+        fn num_zones(&self) -> usize {
+            self.num_zones
+        }
+
+        fn get_temperatures(&self) -> Vec<f64> {
+            self.temperatures.clone()
+        }
+
+        fn set_temperatures(&mut self, temperatures: &[f64]) {
+            self.temperatures = temperatures.to_vec();
+        }
+
+        fn mode(&self) -> fluxion::sim::thermal_model::ThermalModelMode {
+            fluxion::sim::thermal_model::ThermalModelMode::Physics
+        }
+
+        fn set_mode(&mut self, _mode: fluxion::sim::thermal_model::ThermalModelMode) {}
+
+        fn solve_timesteps(
+            &mut self,
+            _steps: usize,
+            _surrogates: &fluxion::ai::surrogate::SurrogateManager,
+            _use_surrogates: bool,
+        ) -> f64 {
+            0.0
+        }
+
+        fn apply_parameters(&mut self, _params: &[f64]) {}
+
+        fn zone_area(&self) -> f64 {
+            self.zone_area
+        }
+
+        fn heating_setpoint(&self) -> f64 {
+            self.heating_setpoint
+        }
+
+        fn cooling_setpoint(&self) -> f64 {
+            self.cooling_setpoint
+        }
+
+        fn hvac_power_demand(&self, _timestep: usize, _outdoor_temp: f64) -> f64 {
+            self.fixed_hvac_power
+        }
+
+        fn is_valid(&self) -> bool {
+            true
+        }
+    }
+
+    #[test]
+    fn test_thermal_model_trait_bridge_creation() {
+        let coupler = ThermalElectricalCoupler::new(3.0);
+        let mock_model = MockThermalModelForTest::new(3, 3000.0);
+        let thermal_model = Arc::new(mock_model);
+        let bridge = ThermalModelTraitBridge::new(coupler, thermal_model.clone());
+
+        assert!(bridge.thermal_model().num_zones() == 3);
+    }
+
+    #[test]
+    fn test_hvac_power_to_electrical_conversion() {
+        let coupler = ThermalElectricalCoupler::new(3.0);
+        let mock_model = MockThermalModelForTest::new(1, 3000.0);
+        let thermal_model = Arc::new(mock_model);
+        let bridge = ThermalModelTraitBridge::new(coupler, thermal_model);
+
+        let electrical_power = bridge.hvac_power_to_electrical(0, 10.0);
+
+        assert!((electrical_power - 1000.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_hvac_power_to_electrical_with_different_cop() {
+        let coupler = ThermalElectricalCoupler::new(4.0);
+        let mock_model = MockThermalModelForTest::new(1, 4000.0);
+        let thermal_model = Arc::new(mock_model);
+        let bridge = ThermalModelTraitBridge::new(coupler, thermal_model);
+
+        let electrical_power = bridge.hvac_power_to_electrical(0, 10.0);
+
+        assert!((electrical_power - 1000.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_coupler_reference() {
+        let coupler = ThermalElectricalCoupler::new(3.0);
+        let mock_model = MockThermalModelForTest::new(2, 1500.0);
+        let thermal_model = Arc::new(mock_model);
+        let bridge = ThermalModelTraitBridge::new(coupler.clone(), thermal_model);
+
+        assert_eq!(bridge.coupler().cop, 3.0);
+    }
+
+    #[test]
+    fn test_joint_convergence_with_mock_thermal() {
+        let coupler = ThermalElectricalCoupler::new(3.0);
+        let mock_model = MockThermalModelForTest::new(1, 5000.0);
+        let thermal_model = Arc::new(mock_model);
+        let bridge = ThermalModelTraitBridge::new(coupler, thermal_model);
+
+        let electrical = bridge.hvac_power_to_electrical(0, 5.0);
+
+        assert!(electrical > 0.0);
+        assert!((electrical - 5000.0 / 3.0).abs() < 1e-6);
+    }
+}

--- a/fluxion-grid/src/lib.rs
+++ b/fluxion-grid/src/lib.rs
@@ -26,10 +26,10 @@ pub mod heat_pump_voltage_model;
 pub mod thermal_electrical_coupler;
 
 // === Fluxion Integration Bridge ===
-// Only available when the "fluxion" feature flag is enabled.
-#[cfg(feature = "fluxion")]
+// Only available when the "fluxion-integration" feature flag is enabled.
+#[cfg(feature = "fluxion-integration")]
 pub mod fluxion_bridge;
-#[cfg(feature = "fluxion")]
+#[cfg(feature = "fluxion-integration")]
 pub use fluxion_bridge::ThermalModelTraitBridge;
 
 pub use error::{GridModelError, GridSolveError};


### PR DESCRIPTION
Closes #2381

## Summary by Sourcery

Introduce a new loose coupling BES–FFD airflow co-simulation module, complete the optional fluxion-grid integration with Fluxion via a renamed fluxion-integration feature, and add supporting ADR and agent infrastructure documentation plus tests and build feature updates.

New Features:
- Introduce loose coupling coordinator and interfaces for BES–FFD airflow co-simulation, including boundary condition and result structs, solver trait, accumulator, and integration under sim::loose_coupling.
- Add optional fluxion-grid integration with the main fluxion crate behind a new fluxion-integration feature flag while retaining a deprecated fluxion alias.

Enhancements:
- Align fluxion-grid’s bridge module, feature flags, and Cargo dependency comments with the new fluxion-integration naming, and add targeted unit tests for the ThermalModelTraitBridge.
- Document an FFD feasibility study and issue-generation agent skills, including ADR and agent prompt files for structured GitHub issue creation and planning.

Build:
- Update workspace and fluxion-grid Cargo.toml feature definitions to support both fluxion-integration and a stub fluxion feature for workspace-level feature resolution.

Documentation:
- Add an ADR describing the feasibility, phases, risks, and architecture for introducing an FFD airflow solver and its co-simulation with Fluxion BES.
- Introduce internal agent skill documentation for automated GitHub issue generation and parallel gap analysis.

Tests:
- Add unit tests for the fluxion-grid ThermalModelTraitBridge and for the new loose coupling module, covering micro-step accumulation, timestep handling, and solver validity.

Chores:
- Add agent result JSON stubs capturing previously generated issue proposals and parallel gap analyses for Fluxion.