### PR TITLE
feat(twin): wire fluxion-twin UKF digital twin to thermal model trait — resolve #2370

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1174,6 +1174,7 @@ dependencies = [
  "fluxion-core",
  "fluxion-fluid",
  "fluxion-toon",
+ "fluxion-twin",
  "futures",
  "futures-util",
  "http-body-util",
@@ -1250,6 +1251,24 @@ dependencies = [
  "tracing",
  "uom",
  "uuid",
+]
+
+[[package]]
+name = "fluxion-cfd"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "approx",
+ "criterion",
+ "env_logger",
+ "faer",
+ "fluxion-core",
+ "log",
+ "nalgebra 0.34.2",
+ "ndarray 0.16.1",
+ "num-complex",
+ "rayon",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,7 @@ unexpected_cfgs = { level = "allow", check-cfg = ["cfg(docsrs,test)", "cfg(gil_r
 [dependencies]
 # Workspace sibling crate (#1255): leaf modules built once & cached by cargo-mutants.
 fluxion-core = { path = "fluxion-core", version = "1.0.0" }
+fluxion-twin = { path = "crates/fluxion-twin", version = "0.1.0" }
 
 # Optional acausal HVAC / fluid network crate (Issue #1980 / ADR-005).
 # Compile with --features fluid to enable fluid port types and network topology.

--- a/crates/fluxion-twin/src/lib.rs
+++ b/crates/fluxion-twin/src/lib.rs
@@ -17,9 +17,7 @@
 //!
 //! - Wan, E.A. & van der Merwe, R. (2000). The Unscented Kalman Filter for Nonlinear Estimation.
 
-use nalgebra::DMatrix;
-#[cfg(test)]
-use nalgebra::DVector;
+use nalgebra::{DMatrix, DVector};
 use std::vec::Vec;
 
 pub mod error;
@@ -29,6 +27,175 @@ pub use telemetry::{
     MqttTelemetryConsumer, MqttTelemetryError, MqttTelemetryMessage, Sender, TelemetryConsumer,
     TelemetryError, TelemetryMsg,
 };
+
+/// Correction produced by the digital twin UKF — applied to zone temperatures.
+///
+/// Contains per-zone temperature corrections (in °C) that adjust the physics
+/// model's predicted temperatures towards the UKF's estimated (corrected) state.
+#[derive(Clone, Debug, Default)]
+pub struct TwinCorrection {
+    /// Per-zone temperature corrections in Celsius.
+    pub zone_temperatures: Vec<f64>,
+    /// Estimated covariance diagonal (for diagnostics / trust weighting).
+    pub covariance_diagonal: Vec<f64>,
+}
+
+impl TwinCorrection {
+    /// Create a new correction for a single-zone model.
+    pub fn single_zone(correction: f64, covariance: f64) -> Self {
+        Self {
+            zone_temperatures: vec![correction],
+            covariance_diagonal: vec![covariance],
+        }
+    }
+
+    /// Create a new correction for a multi-zone model.
+    pub fn multi_zone(corrections: Vec<f64>, covariances: Vec<f64>) -> Self {
+        Self {
+            zone_temperatures: corrections,
+            covariance_diagonal: covariances,
+        }
+    }
+
+    /// Number of zones this correction covers.
+    pub fn num_zones(&self) -> usize {
+        self.zone_temperatures.len()
+    }
+}
+
+/// Trait for digital twin state estimators that produce [`TwinCorrection`] values.
+///
+/// Implementors wrap a specific state estimation algorithm (UKF, EKF, particle filter, etc.)
+/// and expose a unified interface for correcting thermal model state.
+pub trait TwinStateEstimator: Send + Sync {
+    /// Advance the estimator by one timestep (predict step).
+    fn predict(&mut self, u: &[f64]) -> Result<(), KalmanError>;
+
+    /// Inject a measurement and produce a corrected state estimate.
+    fn correct(&mut self, measurement: &[f64]) -> Result<TwinCorrection, KalmanError>;
+
+    /// Current estimated state vector.
+    fn current_state(&self) -> Vec<f64>;
+
+    /// Number of state dimensions.
+    fn state_dim(&self) -> usize;
+
+    /// Number of measurement dimensions.
+    fn measurement_dim(&self) -> usize;
+}
+
+/// Adapter that wraps an [`UnscentedKalmanFilter`] into a [`TwinStateEstimator`].
+///
+/// # Type Parameters
+///
+/// - `S`: State vector type (must implement [`StateVector`])
+/// - `M`: Measurement vector type (must implement [`MeasurementVector`])
+pub struct UkfTwinAdapter<S, M>
+where
+    S: StateVector + Send + Sync,
+    M: MeasurementVector + Send + Sync,
+{
+    ukf: UnscentedKalmanFilter<S, M>,
+}
+
+impl<S, M> UkfTwinAdapter<S, M>
+where
+    S: StateVector + Send + Sync,
+    M: MeasurementVector + Send + Sync,
+{
+    /// Construct a new adapter from an existing UKF instance.
+    pub fn new(ukf: UnscentedKalmanFilter<S, M>) -> Self {
+        Self { ukf }
+    }
+
+    /// Construct a new adapter with thermal-domain defaults for a single zone.
+    ///
+    /// State: `[zone_temp]` — single zone temperature in °C.
+    /// Measurement: `[zone_temp]` — observed zone temperature in °C.
+    ///
+    /// # Arguments
+    ///
+    /// * `initial_temp` — initial zone temperature in °C
+    /// * `process_noise_std` — process noise std dev (°C/sqrt(h), typical: 0.1–0.5)
+    /// * `measurement_noise_std` — measurement noise std dev (°C, typical: 0.1–1.0)
+    pub fn single_zone(
+        initial_temp: f64,
+        process_noise_std: f64,
+        measurement_noise_std: f64,
+    ) -> Self {
+        let initial_state = S::from_slice(&[initial_temp]);
+        let _n = 1;
+        let p0 = DMatrix::from_diagonal(&DVector::from_vec(vec![1.0]));
+        let q = DMatrix::from_diagonal(&DVector::from_vec(vec![process_noise_std.powi(2)]));
+        let r = DMatrix::from_diagonal(&DVector::from_vec(vec![measurement_noise_std.powi(2)]));
+        let ukf = UnscentedKalmanFilter::new(
+            initial_state,
+            p0,
+            q,
+            r,
+            |x: &S, _u: &[f64]| {
+                let x_vec = x.as_slice();
+                S::from_slice(&[x_vec[0]])
+            },
+            |x: &S| {
+                let x_vec = x.as_slice();
+                M::from_slice(&[x_vec[0]])
+            },
+        );
+        Self { ukf }
+    }
+}
+
+impl<S, M> TwinStateEstimator for UkfTwinAdapter<S, M>
+where
+    S: StateVector + Send + Sync,
+    M: MeasurementVector + Send + Sync,
+{
+    fn predict(&mut self, u: &[f64]) -> Result<(), KalmanError> {
+        self.ukf.predict(u)
+    }
+
+    fn correct(&mut self, measurement: &[f64]) -> Result<TwinCorrection, KalmanError> {
+        let m_vec = M::from_slice(measurement);
+        let num_zones = measurement.len();
+
+        let state_before = self.ukf.state.as_slice().to_vec();
+        self.ukf.update(&m_vec)?;
+
+        let state_after = self.ukf.state.as_slice();
+        let corrections: Vec<f64> = state_after
+            .iter()
+            .zip(state_before.iter())
+            .map(|(&est, &pred)| est - pred)
+            .collect();
+
+        let cov_diag: Vec<f64> = (0..self.ukf.p_covariance.nrows())
+            .map(|i| self.ukf.p_covariance[(i, i)])
+            .collect();
+
+        let result = TwinCorrection::multi_zone(corrections, cov_diag);
+        if num_zones == 1 && result.zone_temperatures.len() == 1 {
+            return Ok(TwinCorrection::single_zone(
+                result.zone_temperatures[0],
+                result.covariance_diagonal[0],
+            ));
+        }
+
+        Ok(result)
+    }
+
+    fn current_state(&self) -> Vec<f64> {
+        self.ukf.state.as_slice().to_vec()
+    }
+
+    fn state_dim(&self) -> usize {
+        self.ukf.state_dim()
+    }
+
+    fn measurement_dim(&self) -> usize {
+        self.ukf.measurement_dim()
+    }
+}
 
 pub trait StateVector: Clone {
     fn zeros() -> Self;

--- a/src/sim/thermal_model.rs
+++ b/src/sim/thermal_model.rs
@@ -54,6 +54,7 @@
 use crate::ai::surrogate::SurrogateManager;
 use crate::physics::cta::{ContinuousTensor, VectorField};
 use crate::sim::thermal_model_core::get_daily_cycle;
+use fluxion_twin::TwinCorrection;
 use std::error::Error;
 use tracing::info;
 
@@ -193,6 +194,16 @@ pub trait ThermalModelTrait: Send + Sync {
     /// Uses default assumptions: met=1.0, clo=0.5, rh=0.5, vel=0.1 m/s.
     /// Adaptive comfort uses running mean computed from zone temperatures.
     fn get_comfort_metrics(&self) -> Vec<ZoneComfortMetrics>;
+
+    /// Apply a twin correction to zone temperatures.
+    ///
+    /// The digital twin UKF produces a [`TwinCorrection`] that adjusts the
+    /// physics-model predicted temperatures toward the sensor-corrected estimates.
+    /// This method applies those corrections in-place.
+    ///
+    /// # Arguments
+    /// * `correction` — per-zone temperature corrections from the UKF
+    fn set_twin_correction(&mut self, correction: &TwinCorrection);
 }
 
 /// Physics-based thermal model implementation.
@@ -311,6 +322,16 @@ impl ThermalModelTrait for PhysicsThermalModel {
             .iter()
             .map(|&t| compute_pmv_ppd_and_adaptive(t, 0.5, 0.1, 1.0, 0.5))
             .collect()
+    }
+
+    fn set_twin_correction(&mut self, correction: &TwinCorrection) {
+        let mut temps = self.inner.temperatures.as_ref().to_vec();
+        for (i, corr) in correction.zone_temperatures.iter().enumerate() {
+            if i < temps.len() {
+                temps[i] += corr;
+            }
+        }
+        self.inner.temperatures = VectorField::new(temps);
     }
 }
 
@@ -541,6 +562,16 @@ impl ThermalModelTrait for SurrogateThermalModel {
             .iter()
             .map(|&t| compute_pmv_ppd_and_adaptive(t, 0.5, 0.1, 1.0, 0.5))
             .collect()
+    }
+
+    fn set_twin_correction(&mut self, correction: &TwinCorrection) {
+        let mut temps = self.inner.temperatures.as_ref().to_vec();
+        for (i, corr) in correction.zone_temperatures.iter().enumerate() {
+            if i < temps.len() {
+                temps[i] += corr;
+            }
+        }
+        self.inner.temperatures = VectorField::new(temps);
     }
 }
 
@@ -1062,6 +1093,16 @@ impl ThermalModelTrait for HybridThermalModel {
             .map(|&t| compute_pmv_ppd_and_adaptive(t, 0.5, 0.1, 1.0, 0.5))
             .collect()
     }
+
+    fn set_twin_correction(&mut self, correction: &TwinCorrection) {
+        let mut temps = self.inner.temperatures.as_ref().to_vec();
+        for (i, corr) in correction.zone_temperatures.iter().enumerate() {
+            if i < temps.len() {
+                temps[i] += corr;
+            }
+        }
+        self.inner.temperatures = crate::physics::cta::VectorField::new(temps);
+    }
 }
 
 /// Unified thermal model that can switch between physics and surrogate modes at runtime.
@@ -1202,6 +1243,16 @@ impl ThermalModelTrait for UnifiedThermalModel {
             .iter()
             .map(|&t| compute_pmv_ppd_and_adaptive(t, 0.5, 0.1, 1.0, 0.5))
             .collect()
+    }
+
+    fn set_twin_correction(&mut self, correction: &TwinCorrection) {
+        let mut temps = self.inner.temperatures.as_ref().to_vec();
+        for (i, corr) in correction.zone_temperatures.iter().enumerate() {
+            if i < temps.len() {
+                temps[i] += corr;
+            }
+        }
+        self.inner.temperatures = VectorField::new(temps);
     }
 }
 
@@ -2017,6 +2068,63 @@ mod tests {
         let eui = model.solve_timesteps(24, &surrogates, true);
         assert!(eui.is_finite());
         assert_eq!(surrogates.inference_metrics().num_inferences, 24);
+    }
+
+    #[test]
+    fn test_set_twin_correction_single_zone() {
+        use fluxion_twin::TwinCorrection;
+
+        let mut model = PhysicsThermalModel::new(1);
+        model.set_temperatures(&[20.0]);
+
+        let correction = TwinCorrection::single_zone(0.5, 0.1);
+        model.set_twin_correction(&correction);
+
+        let temps = model.get_temperatures();
+        assert!((temps[0] - 20.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_set_twin_correction_multi_zone() {
+        use fluxion_twin::TwinCorrection;
+
+        let mut model = PhysicsThermalModel::new(3);
+        model.set_temperatures(&[18.0, 20.0, 22.0]);
+
+        let correction = TwinCorrection::multi_zone(vec![-0.5, 1.0, 0.3], vec![0.1, 0.1, 0.1]);
+        model.set_twin_correction(&correction);
+
+        let temps = model.get_temperatures();
+        assert!((temps[0] - 17.5).abs() < 1e-9);
+        assert!((temps[1] - 21.0).abs() < 1e-9);
+        assert!((temps[2] - 22.3).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_set_twin_correction_all_model_types() {
+        use fluxion_twin::TwinCorrection;
+
+        let correction = TwinCorrection::single_zone(1.0, 0.05);
+
+        let mut physics = PhysicsThermalModel::new(1);
+        physics.set_temperatures(&[20.0]);
+        physics.set_twin_correction(&correction);
+        assert!((physics.get_temperatures()[0] - 21.0).abs() < 1e-9);
+
+        let mut surrogate = SurrogateThermalModel::new(1);
+        surrogate.set_temperatures(&[20.0]);
+        surrogate.set_twin_correction(&correction);
+        assert!((surrogate.get_temperatures()[0] - 21.0).abs() < 1e-9);
+
+        let mut hybrid = HybridThermalModel::new(1, HybridRouting::default());
+        hybrid.set_temperatures(&[20.0]);
+        hybrid.set_twin_correction(&correction);
+        assert!((hybrid.get_temperatures()[0] - 21.0).abs() < 1e-9);
+
+        let mut unified = UnifiedThermalModel::new(1);
+        unified.set_temperatures(&[20.0]);
+        unified.set_twin_correction(&correction);
+        assert!((unified.get_temperatures()[0] - 21.0).abs() < 1e-9);
     }
 }
 

--- a/src/sim/thermal_model_mock.rs
+++ b/src/sim/thermal_model_mock.rs
@@ -17,6 +17,7 @@ use crate::ai::surrogate::SurrogateManager;
 use crate::sim::thermal_model::{
     compute_pmv_ppd_and_adaptive, ThermalModelMode, ThermalModelTrait, ZoneComfortMetrics,
 };
+use fluxion_twin::TwinCorrection;
 
 /// A mock thermal model for testing that returns configurable fixed values.
 ///
@@ -196,6 +197,14 @@ impl ThermalModelTrait for MockThermalModel {
             .iter()
             .map(|&t| compute_pmv_ppd_and_adaptive(t, 0.5, 0.1, 1.0, 0.5))
             .collect()
+    }
+
+    fn set_twin_correction(&mut self, correction: &TwinCorrection) {
+        for (i, corr) in correction.zone_temperatures.iter().enumerate() {
+            if i < self.temperatures.len() {
+                self.temperatures[i] += corr;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Closes #2370

## Summary by Sourcery

Integrate a UKF-based digital twin correction pipeline with the thermal model and introduce a loose-coupling framework for BES–FFD co-simulation, along with supporting documentation and agent issue-generation skills.

New Features:
- Add TwinCorrection abstraction and TwinStateEstimator trait with a UKF adapter for applying digital twin corrections to thermal models.
- Extend all thermal model implementations and mocks with a set_twin_correction API to adjust zone temperatures from UKF outputs.
- Introduce a loose_coupling module providing BES-to-FFD boundary contracts, FFD solver traits, accumulation, and a LooseCoupling coordinator for macro/micro timestep integration.
- Add an ADR documenting the feasibility study and phased plan for a GPU-accelerated FFD airflow solver and its integration.
- Add AI agent skills and result artifacts for structured GitHub issue generation within the repository.

Build:
- Wire the fluxion-twin crate into the main Cargo manifest as a dependency.

Documentation:
- Document the FFD feasibility study and phased integration plan in a new ADR.

Tests:
- Add unit tests validating twin correction application across single and multi-zone thermal models and all model types.
- Add unit tests for the loose coupling coordinator, FFD accumulator, and mock FFD solver behavior.