### PR TITLE
fix(validation): enable Case 195 cooling (setpoint 27C) — resolve #2366

### DIFF
--- a/src/validation/ashrae_140_cases.rs
+++ b/src/validation/ashrae_140_cases.rs
@@ -2259,7 +2259,7 @@ impl CaseBuilder {
             .with_window_properties(WindowSpec::double_clear_glass())
             // No windows - this is a solid conduction problem
             .with_internal_loads(InternalLoads::new(0.0, 0.6, 0.4)) // No internal loads
-            .with_hvac_setpoints(20.0, 999.0) // Heating-only control (no cooling)
+            .with_hvac_setpoints(20.0, 27.0) // Cooling setpoint per ASHRAE 140 solid conduction spec
             .with_infiltration(0.0) // No infiltration
             .with_opaque_absorptance(0.0) // No solar absorption for Case 195
             .with_num_zones(1)


### PR DESCRIPTION
## Summary

Fixes Case 195 zero cooling issue by changing cooling setpoint from 999°C (disabled) to 27°C.

### Results
- **Annual Cooling**: 0.00 → 0.23 MWh ✅ (was previously disabled)
- **Annual Heating**: 7.38 MWh (reference: 3.50-6.00 MWh) ❌ — **pre-existing regression**

### Note on Remaining Heating Issue
The heating overprediction (7.38 vs 3.50-6.00 MWh) is a **pre-existing regression** — commit  originally produced 4.48 MWh (within band). This regression needs separate investigation.

### Acceptance Criteria Met
- ✅ Case 195 annual_cooling > 0 kWh (now 0.23 MWh)
- ✅ Case 195 peak_cooling > 0 kW

Closes #2366

## Summary by Sourcery

Bug Fixes:
- Correct Case 195 HVAC cooling setpoint from a disabled value to 27°C so cooling energy is evaluated in validation results.