### PR TITLE
fix: resolve #2355 — create verify_issues_closed.sh

### DIFF
--- a/scripts/verify_issues_closed.sh
+++ b/scripts/verify_issues_closed.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# scripts/verify_issues_closed.sh
+#
+# Verify a given issue is closed using the GitHub CLI.
+# Used by wave-orchestrator sub-agents to confirm an issue was closed.
+#
+# Usage:
+#   bash scripts/verify_issues_closed.sh <ISSUE_NUMBER>
+#
+# Exit codes:
+#   0 — issue is closed
+#   1 — issue is not closed (open, or other state)
+#   2 — usage error
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <issue_number>" >&2
+  exit 2
+fi
+
+ISSUE_NUMBER="$1"
+
+STATE=$(gh issue view "$ISSUE_NUMBER" --json state --jq '.state')
+
+case "$STATE" in
+  closed)
+    echo "OK Issue #$ISSUE_NUMBER is closed"
+    exit 0
+    ;;
+  open)
+    echo "FAIL Issue #$ISSUE_NUMBER is still open" >&2
+    exit 1
+    ;;
+  *)
+    echo "FAIL Issue #$ISSUE_NUMBER has unexpected state: $STATE" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
Closes #2355

## Summary by Sourcery

Build:
- Introduce verify_issues_closed.sh script for checking GitHub issue state by number.