### PR TITLE
feat: resolve #2463 — physics-sim cycle regression guard (mirrors #1441)

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -398,6 +398,64 @@ jobs:
       - name: Run cycle check
         run: python3 scripts/check_ashrae_cases_cycle.py
 
+  # -- Physics <-> Sim Cycle Check (Issue #2463) -----------------------------
+  # Mirrors the `Ashrae Cases Cycle Check` job above (Issue #1441) but for
+  # the `physics <-> sim` cycle documented in ARCHITECTURE.md §"Remaining
+  # cycles" and docs/mutation_testing_crate_split.md §"Phase 2". The
+  # companion cycle-break issue drives the reported edge count from 5
+  # (current baseline) down to 0; this guard prevents silent regressions
+  # in the meantime.
+  #
+  # Canonical listener job name: `Physics-Sim-Cycle-Check`. The "(GH)"
+  # and "(Hetzner Overflow)" suffixes match the issue #1441 pattern; the
+  # canonical name (sans suffix) is what AGENTS.md §CI Gates and
+  # release_gates.yaml::ci.required_checks reference. Adding the new gate
+  # to release_gates.yaml::ci.required_checks is deferred to the merge PR
+  # that closes both this issue and the companion cycle-break issue
+  # (see issue body §"Notes" for the rationale).
+
+  physics-sim-cycle-gh-probe:
+    name: "PSC Probe"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    steps:
+      - run: echo "GH runner acquired"
+
+  physics-sim-cycle-gh:
+    name: "Physics-Sim-Cycle-Check (GH)"
+    needs: physics-sim-cycle-gh-probe
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+      - uses: ./.github/actions/setup-rust-python-env
+        with:
+          python-version: '3.10'
+      - name: Run physics-sim cycle check
+        run: python3 scripts/check_physics_sim_cycle.py
+
+  physics-sim-cycle-hz:
+    name: "Physics-Sim-Cycle-Check (Hetzner Overflow)"
+    needs: physics-sim-cycle-gh-probe
+    runs-on: [self-hosted,fluxion-overflow]
+    if: |
+      (github.event_name == 'pull_request' ||
+       (github.event_name == 'push' && github.ref == 'refs/heads/main'))
+      && (needs.physics-sim-cycle-gh-probe.result == 'failure'
+          || needs.physics-sim-cycle-gh-probe.result == 'cancelled')
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+      - uses: ./.github/actions/setup-rust-python-env
+        with:
+          python-version: '3.10'
+      - name: Run physics-sim cycle check
+        run: python3 scripts/check_physics_sim_cycle.py
+
   # -- Issue #1603: GPU smoke test for InferenceBackend::CUDA -------------
   # Runs on every PR and main push. On CPU-only runners the test skips
   # gracefully (cuda_ep_available() returns false at runtime). On GPU runners

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ cargo test --test ashrae_140_blind_validation -- --nocapture         # blind-mod
 python scripts/release_gate_checker.py                                # release-gate evaluation
 python3 scripts/check_architecture_drift.py                            # ARCHITECTURE.md vs code drift
 python3 scripts/check_ashrae_cases_cycle.py                            # sim↔validation cycle regression
+python3 scripts/check_physics_sim_cycle.py                              # physics↔sim cycle regression (Issue #2463)
 
 # Code quality (REQUIRED order)
 cargo fmt -- --check                       # CI gate — omit --check to auto-fix
@@ -172,6 +173,7 @@ ML-surrogate swap-point traits:
 - `Clippy` — `cargo clippy --lib -- -D warnings`
 - `Known Issues Stale Check` (Issue #1723)
 - `Ashrae Cases Cycle Check` (Issue #1441) — runs `scripts/check_ashrae_cases_cycle.py`
+- `Physics-Sim-Cycle-Check` (Issue #2463) — runs `scripts/check_physics_sim_cycle.py` (deferred to release_gates.yaml `required_checks` until the companion cycle-break PR lands)
 - `CUDA Smoke Test` (Issue #1603) — `cargo build --features cuda` + `cargo test --test surrogate_cuda_smoke --features cuda`
 - `ASHRAE 140 Strict Energy Gate (Issue #1333)` (4 tests, named explicitly in workflow)
 - `Fluxion Determinism Gate (Issue #1351)` — listener on Cross-Platform Determinism CI workflow
@@ -257,6 +259,7 @@ Heavy Linux jobs honour `vars.FLUXION_LINUX_RUNNER` (self-hosted Hetzner fallbac
 | `release_gates.yaml` | Required branch-protection checks + thresholds |
 | `scripts/check_architecture_drift.py` | ARCHITECTURE.md vs source-code drift |
 | `scripts/check_ashrae_cases_cycle.py` | `sim ↔ validation` cycle regression guard |
+| `scripts/check_physics_sim_cycle.py` | `physics ↔ sim` cycle regression guard (Issue #2463) |
 | `scripts/check_root_md_policy.py` | Root `.md` allow-list gate (issue #2466) |
 | `scripts/check_docs_summaries.py` | `docs/**/*.md` 7-line summary coverage gate (issue #2466) |
 | `scripts/generate_doc_inventory.py` | Regenerate `docs/doc-inventory.md` auto-table (issue #2466) |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -120,6 +120,18 @@ invariants and is wired into CI (run from repo root):
   `fluxion::physics::{ctf_coefficients, fd_discretization, ctf_solver}` — moving
   these to `fluxion-core` requires moving the whole `physics` tree.
 
+**Regression guard (Issue #2463)**: `scripts/check_physics_sim_cycle.py`
+mirrors the `check_ashrae_cases_cycle.py` pattern above and reports the
+`physics ↔ sim` cycle edge count by file:line. The script's two phases
+forbid (a) any `use crate::sim::*` import under `src/physics/**` and
+(b) any `use crate::physics::*` import in the two protected `sim` files
+(`src/sim/construction.rs` and `src/sim/per_surface_conduction.rs`).
+The guard ships with a baseline of 5+2 documented edges; the companion
+cycle-break work drives the count to 0. Wired into CI as the
+`Physics-Sim-Cycle-Check` job in `.github/workflows/rust-tests.yml`;
+promotion to `release_gates.yaml::ci.required_checks` is deferred to
+the merge PR that closes both this issue and the cycle-break issue.
+
 These will be addressed in subsequent phases. The current change lets
 `cargo-mutants -p fluxion` skip the bulk of the assembly / multi-node /
 ashrae-cases type machinery by mutating only `fluxion`.

--- a/scripts/check_physics_sim_cycle.py
+++ b/scripts/check_physics_sim_cycle.py
@@ -4,8 +4,9 @@ Cycle Regression Guard for the `physics <-> sim` cycle (Issue #2463).
 
 Mirrors `scripts/check_ashrae_cases_cycle.py` (Issue #1441) and verifies
 the `physics <-> sim` cycle documented in `ARCHITECTURE.md` §"Remaining
-cycles" stays in its current target state (5 known physics->sim edges;
-the companion cycle-break issue is the work that drives the count to 0):
+cycles" stays in its current target state (5 known physics->sim edges
++ 2 known sim->physics edges; the companion cycle-break issue is the
+work that drives the count to 0):
 
 1. `src/physics/**` must NOT import from `src/sim/**` (no `use crate::sim::`
    upward deps). The 5 currently-known offenders are:
@@ -28,15 +29,19 @@ Usage:
   python3 scripts/check_physics_sim_cycle.py
 
 Exit codes:
-  0 — no cycle regression (or only the documented baseline edges remain)
-  1 — cycle regression detected (a NEW edge appeared, beyond the baseline)
+  0 — no cycle regression (offender count is at or below the documented
+      baseline, or the companion work has driven it down further)
+  1 — cycle regression detected (a NEW edge appeared, exceeding the
+      documented baseline)
   2 — script error
 
-The script deliberately reports the current 5+ baseline edges as failures
-so that any future PR that adds a *new* `use crate::sim::` import under
-`src/physics/**` (or `use crate::physics::` under the two protected
-`src/sim/**` files) is flagged immediately. The companion cycle-break
-issue is the work that drives the count to 0.
+The script reports the current `BASELINE_PHYSICS_TO_SIM = 5` and
+`BASELINE_SIM_TO_PHYSICS = 2` documented edges as the *current state*,
+not as failures. A future PR that adds a *new* `use crate::sim::` import
+under `src/physics/**` (or `use crate::physics::` under the two protected
+`src/sim/**` files) — pushing the count *above* the baseline — is flagged
+immediately as a regression. The companion cycle-break issue is the
+work that drives the count down to 0.
 
 See ARCHITECTURE.md §"Remaining cycles (deferred to follow-up issues)"
 and docs/mutation_testing_crate_split.md §"Phase 2 — break the physics
@@ -61,6 +66,13 @@ PROTECTED_SIM_FILES = (
     FLUXION_SRC / "sim" / "construction.rs",
     FLUXION_SRC / "sim" / "per_surface_conduction.rs",
 )
+
+# Documented baseline edge counts. The companion cycle-break work is the
+# only thing authorised to drive these down; any PR that pushes them *up*
+# is a regression and is flagged by this guard. See ARCHITECTURE.md
+# §"Regression guard (Issue #2463)" for the source-of-truth numbers.
+BASELINE_PHYSICS_TO_SIM = 5
+BASELINE_SIM_TO_PHYSICS = 2
 
 # Regex for Phase 2: match `use` or `pub use` against `crate::physics::`.
 # Mirrors `scan_sim_for_orientation_cycle` in check_ashrae_cases_cycle.py
@@ -129,29 +141,48 @@ def main() -> int:
 
     print("[1/3] src/physics/** must not `use crate::sim::` ...")
     physics_to_sim = scan_physics_for_sim_deps()
-    if physics_to_sim:
-        failures.append(f"src/physics has {len(physics_to_sim)} upward dep(s) to src/sim:")
+    if len(physics_to_sim) > BASELINE_PHYSICS_TO_SIM:
+        new_edges = len(physics_to_sim) - BASELINE_PHYSICS_TO_SIM
+        failures.append(
+            f"src/physics has {len(physics_to_sim)} upward dep(s) to src/sim "
+            f"(baseline: {BASELINE_PHYSICS_TO_SIM}; {new_edges} NEW edge(s) above baseline):"
+        )
         failures.extend(f"    {o}" for o in physics_to_sim)
-        print(f"    FAIL: {len(physics_to_sim)} offender(s)")
+        print(f"    FAIL: {len(physics_to_sim)} offender(s) "
+              f"({new_edges} above baseline {BASELINE_PHYSICS_TO_SIM})")
     else:
-        print("    OK: 0 upward deps")
+        if physics_to_sim:
+            print(f"    OK: {len(physics_to_sim)} offender(s) "
+                  f"(at baseline {BASELINE_PHYSICS_TO_SIM})")
+        else:
+            print(f"    OK: 0 upward deps (below baseline {BASELINE_PHYSICS_TO_SIM})")
 
     print("[2/3] src/sim/construction.rs + src/sim/per_surface_conduction.rs "
           "must not `use crate::physics::` ...")
     sim_to_physics = scan_protected_sim_files_for_physics_deps()
-    if sim_to_physics:
+    if len(sim_to_physics) > BASELINE_SIM_TO_PHYSICS:
+        new_edges = len(sim_to_physics) - BASELINE_SIM_TO_PHYSICS
         failures.append(
-            f"protected sim files have {len(sim_to_physics)} upward dep(s) to src/physics:"
+            f"protected sim files have {len(sim_to_physics)} upward dep(s) to src/physics "
+            f"(baseline: {BASELINE_SIM_TO_PHYSICS}; {new_edges} NEW edge(s) above baseline):"
         )
         failures.extend(f"    {o}" for o in sim_to_physics)
-        print(f"    FAIL: {len(sim_to_physics)} offender(s)")
+        print(f"    FAIL: {len(sim_to_physics)} offender(s) "
+              f"({new_edges} above baseline {BASELINE_SIM_TO_PHYSICS})")
     else:
-        print("    OK: no cycle markers")
+        if sim_to_physics:
+            print(f"    OK: {len(sim_to_physics)} offender(s) "
+                  f"(at baseline {BASELINE_SIM_TO_PHYSICS})")
+        else:
+            print(f"    OK: no cycle markers (below baseline {BASELINE_SIM_TO_PHYSICS})")
 
     print("[3/3] summary ...")
     total = len(physics_to_sim) + len(sim_to_physics)
+    baseline_total = BASELINE_PHYSICS_TO_SIM + BASELINE_SIM_TO_PHYSICS
     print(f"    Total cycle edges: {total}")
-    print(f"    (Baseline: 5 physics->sim edges from the [Architecture] issue;")
+    print(f"    (Documented baseline: {baseline_total} "
+          f"({BASELINE_PHYSICS_TO_SIM} physics->sim + "
+          f"{BASELINE_SIM_TO_PHYSICS} sim->physics);")
     print(f"     companion cycle-break work drives this to 0.)")
 
     print()
@@ -160,11 +191,14 @@ def main() -> int:
         for f in failures:
             print(f"  {f}")
         print()
-        print("These cycle markers were already documented in issue #2463. The")
-        print("guard script enforces the *target* invariant (zero cycle edges);")
-        print("the companion cycle-break issue is the work that closes the gap.")
+        print(f"A new `use crate::sim::*` import under `src/physics/**` (or a")
+        print(f"`use crate::physics::*` import under the two protected sim files)")
+        print(f"has appeared that exceeds the documented baseline of "
+              f"{baseline_total} edges. The companion cycle-break issue is the")
+        print(f"work authorised to reduce the count; this guard rejects growth.")
         return 1
-    print("No cycle regression. Issue #2463 cycle stays at 0 edges.")
+    print(f"No cycle regression. Issue #2463 cycle stays at {total} edge(s) "
+          f"(at or below documented baseline of {baseline_total}).")
     return 0
 
 

--- a/scripts/check_physics_sim_cycle.py
+++ b/scripts/check_physics_sim_cycle.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""
+Cycle Regression Guard for the `physics <-> sim` cycle (Issue #2463).
+
+Mirrors `scripts/check_ashrae_cases_cycle.py` (Issue #1441) and verifies
+the `physics <-> sim` cycle documented in `ARCHITECTURE.md` §"Remaining
+cycles" stays in its current target state (5 known physics->sim edges;
+the companion cycle-break issue is the work that drives the count to 0):
+
+1. `src/physics/**` must NOT import from `src/sim/**` (no `use crate::sim::`
+   upward deps). The 5 currently-known offenders are:
+
+   - `src/physics/thermal_mass/construction.rs -> sim::construction::ConstructionLayer`
+   - `src/physics/thermal_mass/diagnostics.rs   -> sim::construction::ConstructionLayer`
+   - `src/physics/multi_node_solver.rs          -> sim::per_surface_conduction::{...}`
+   - `src/physics/multi_node_solver.rs          -> sim::sky_radiation::STEFAN_BOLTZMANN`
+   - `src/physics/multi_node_solver.rs          -> sim::sky_radiation::SkyRadiationExchange`
+
+2. `src/sim/construction.rs` and `src/sim/per_surface_conduction.rs`
+   (the two `sim` files that host shared domain types) must NOT import
+   from `src/physics/**` (no `use crate::physics::` upward deps). Currently
+   `sim::construction` re-exports a few leaf constants from
+   `physics::constants`; the companion cycle-break work moves them.
+3. Summary: report the total cycle-edge count so branch protection can
+   track the cycle-break PR's progress to 0.
+
+Usage:
+  python3 scripts/check_physics_sim_cycle.py
+
+Exit codes:
+  0 — no cycle regression (or only the documented baseline edges remain)
+  1 — cycle regression detected (a NEW edge appeared, beyond the baseline)
+  2 — script error
+
+The script deliberately reports the current 5+ baseline edges as failures
+so that any future PR that adds a *new* `use crate::sim::` import under
+`src/physics/**` (or `use crate::physics::` under the two protected
+`src/sim/**` files) is flagged immediately. The companion cycle-break
+issue is the work that drives the count to 0.
+
+See ARCHITECTURE.md §"Remaining cycles (deferred to follow-up issues)"
+and docs/mutation_testing_crate_split.md §"Phase 2 — break the physics
+<-> sim cycle (extract shared domain types)" for context.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FLUXION_SRC = REPO_ROOT / "src"
+PHYSICS_DIR = FLUXION_SRC / "physics"
+
+# `sim` files that host shared domain types and must not import physics internals.
+# Per ARCHITECTURE.md §"Remaining cycles" and the companion cycle-break plan,
+# these are the two sides of the `physics <-> sim` seam. They currently carry
+# leaf re-exports from `physics::constants`; the cycle-break work moves those.
+PROTECTED_SIM_FILES = (
+    FLUXION_SRC / "sim" / "construction.rs",
+    FLUXION_SRC / "sim" / "per_surface_conduction.rs",
+)
+
+# Regex for Phase 2: match `use` or `pub use` against `crate::physics::`.
+# Mirrors `scan_sim_for_orientation_cycle` in check_ashrae_cases_cycle.py
+# which uses `(pub\s+)?use\s+crate::validation::...::Orientation\b`.
+_PHYSICS_IMPORT_RE = re.compile(
+    r"^\s*(pub\s+)?use\s+crate::physics::"
+)
+
+
+def scan_physics_for_sim_deps() -> list[str]:
+    r"""Walk src/physics/** and forbid any `use crate::sim::` upward dep.
+
+    Mirrors `scan_fluxion_core_for_upward_deps` in check_ashrae_cases_cycle.py
+    but scoped to `src/physics/**`. We use the same `prefix in stripped` scan
+    technique (without the `pub use / use` anchor) so we catch every form
+    of import that would create the upward edge — `use`, `pub use`,
+    `use crate::sim::foo::*`, fully-qualified `crate::sim::foo::bar()` paths,
+    etc.
+    """
+    offenders: list[str] = []
+    sim_prefix = "crate::sim::"
+    if not PHYSICS_DIR.exists():
+        return offenders
+    for rs_file in PHYSICS_DIR.rglob("*.rs"):
+        rel = rs_file.relative_to(REPO_ROOT)
+        for lineno, line in enumerate(
+            rs_file.read_text(encoding="utf-8", errors="replace").splitlines(),
+            start=1,
+        ):
+            stripped = line.strip()
+            if stripped.startswith("//") or stripped.startswith("*"):
+                continue
+            if sim_prefix in stripped:
+                offenders.append(f"{rel}:{lineno}: {stripped}")
+    return offenders
+
+
+def scan_protected_sim_files_for_physics_deps() -> list[str]:
+    """Walk the two protected `sim` files and forbid `use crate::physics::`.
+
+    Mirrors `scan_sim_for_orientation_cycle` in check_ashrae_cases_cycle.py:
+    anchors on `(pub\\s+)?use\\s+crate::physics::` and reports every match
+    (file:line + the offending line) so the cycle-break PR can verify
+    progress.
+    """
+    offenders: list[str] = []
+    for rs_file in PROTECTED_SIM_FILES:
+        if not rs_file.exists():
+            offenders.append(f"{rs_file.relative_to(REPO_ROOT)}: file missing")
+            continue
+        rel = rs_file.relative_to(REPO_ROOT)
+        for lineno, line in enumerate(
+            rs_file.read_text(encoding="utf-8", errors="replace").splitlines(),
+            start=1,
+        ):
+            if _PHYSICS_IMPORT_RE.match(line):
+                offenders.append(f"{rel}:{lineno}: {line.strip()}")
+    return offenders
+
+
+def main() -> int:
+    print(f"Checking physics<->sim cycle guards for issue #2463 (repo: {REPO_ROOT})")
+    print()
+
+    failures: list[str] = []
+
+    print("[1/3] src/physics/** must not `use crate::sim::` ...")
+    physics_to_sim = scan_physics_for_sim_deps()
+    if physics_to_sim:
+        failures.append(f"src/physics has {len(physics_to_sim)} upward dep(s) to src/sim:")
+        failures.extend(f"    {o}" for o in physics_to_sim)
+        print(f"    FAIL: {len(physics_to_sim)} offender(s)")
+    else:
+        print("    OK: 0 upward deps")
+
+    print("[2/3] src/sim/construction.rs + src/sim/per_surface_conduction.rs "
+          "must not `use crate::physics::` ...")
+    sim_to_physics = scan_protected_sim_files_for_physics_deps()
+    if sim_to_physics:
+        failures.append(
+            f"protected sim files have {len(sim_to_physics)} upward dep(s) to src/physics:"
+        )
+        failures.extend(f"    {o}" for o in sim_to_physics)
+        print(f"    FAIL: {len(sim_to_physics)} offender(s)")
+    else:
+        print("    OK: no cycle markers")
+
+    print("[3/3] summary ...")
+    total = len(physics_to_sim) + len(sim_to_physics)
+    print(f"    Total cycle edges: {total}")
+    print(f"    (Baseline: 5 physics->sim edges from the [Architecture] issue;")
+    print(f"     companion cycle-break work drives this to 0.)")
+
+    print()
+    if failures:
+        print("CYCLE REGRESSION DETECTED:")
+        for f in failures:
+            print(f"  {f}")
+        print()
+        print("These cycle markers were already documented in issue #2463. The")
+        print("guard script enforces the *target* invariant (zero cycle edges);")
+        print("the companion cycle-break issue is the work that closes the gap.")
+        return 1
+    print("No cycle regression. Issue #2463 cycle stays at 0 edges.")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(2)

--- a/scripts/ci/test_check_physics_sim_cycle.py
+++ b/scripts/ci/test_check_physics_sim_cycle.py
@@ -370,15 +370,68 @@ def test_main_returns_zero_when_clean(checker, tmp_path, monkeypatch, capsys):
     assert "No cycle regression" in out
 
 
-def test_main_returns_one_when_physics_offender_present(checker, tmp_path, monkeypatch, capsys):
-    """A single new `use crate::sim::` import in src/physics/** must trip main()."""
+def test_main_returns_zero_at_documented_baseline(checker, tmp_path, monkeypatch, capsys):
+    """5 physics->sim + 2 sim->physics offenders (the documented baseline) must pass.
+
+    Mirrors the current real-repo state per issue #2463: the companion
+    cycle-break work is the only thing authorised to drive the count
+    down. The script must NOT fail on the documented baseline; it only
+    fails if a *new* edge appears that pushes the count above baseline.
+    """
     _redirect_to_fixture(
         checker,
         tmp_path,
         monkeypatch,
         physics_files={
-            "sneaky.rs": "use crate::sim::construction::ConstructionLayer;\n",
+            f"offender{i}.rs": "use crate::sim::construction::ConstructionLayer;\n"
+            for i in range(checker.BASELINE_PHYSICS_TO_SIM)
         },
+        sim_files={
+            "construction.rs": "fn f() {}\n",
+            "per_surface_conduction.rs": "fn f() {}\n",
+        },
+    )
+    # Replace construction.rs with the right number of physics imports
+    # (one per line) to mirror the real baseline of 2 sim->physics edges.
+    (tmp_path / "src" / "sim" / "construction.rs").write_text(
+        "".join(
+            f"use crate::physics::constants::SOMETHING_{i};\n"
+            for i in range(checker.BASELINE_SIM_TO_PHYSICS)
+        ),
+        encoding="utf-8",
+    )
+
+    rc = checker.main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "OK:" in out
+    assert "at baseline" in out
+    assert "No cycle regression" in out
+    baseline_total = checker.BASELINE_PHYSICS_TO_SIM + checker.BASELINE_SIM_TO_PHYSICS
+    assert f"Total cycle edges: {baseline_total}" in out
+
+
+def test_main_returns_one_when_physics_offender_exceeds_baseline(
+    checker, tmp_path, monkeypatch, capsys
+):
+    """6+ `use crate::sim::` imports in src/physics/** (1 above baseline 5) must trip main().
+
+    The guard's contract is *regression-only*: a NEW edge that pushes the
+    count above the documented baseline is a failure. A single offender
+    is fine if the baseline allows it; the test therefore seeds
+    `BASELINE_PHYSICS_TO_SIM` legitimate edges + 1 extra, and asserts
+    that the *extra* is what trips the guard.
+    """
+    physics_files = {
+        f"baseline{i}.rs": "use crate::sim::construction::ConstructionLayer;\n"
+        for i in range(checker.BASELINE_PHYSICS_TO_SIM)
+    }
+    physics_files["sneaky.rs"] = "use crate::sim::sky_radiation::STEFAN_BOLTZMANN;\n"
+    _redirect_to_fixture(
+        checker,
+        tmp_path,
+        monkeypatch,
+        physics_files=physics_files,
         sim_files={
             "construction.rs": "fn f() {}\n",
             "per_surface_conduction.rs": "fn f() {}\n",
@@ -388,46 +441,28 @@ def test_main_returns_one_when_physics_offender_present(checker, tmp_path, monke
     out = capsys.readouterr().out
     assert rc == 1
     assert "[1/3]" in out
-    assert "FAIL: 1 offender(s)" in out
+    assert f"({1} above baseline {checker.BASELINE_PHYSICS_TO_SIM})" in out
     assert "src/physics/sneaky.rs" in out
     assert "CYCLE REGRESSION DETECTED" in out
 
 
-def test_main_returns_one_when_sim_offender_present(checker, tmp_path, monkeypatch, capsys):
-    """A `use crate::physics::` import in a protected sim file must trip main()."""
+def test_main_returns_one_when_sim_offender_exceeds_baseline(
+    checker, tmp_path, monkeypatch, capsys
+):
+    """A `use crate::physics::` import in a protected sim file above the baseline of 2 must trip main()."""
+    sim_baseline_lines = "".join(
+        f"use crate::physics::constants::SOMETHING_{i};\n"
+        for i in range(checker.BASELINE_SIM_TO_PHYSICS)
+    )
     _redirect_to_fixture(
         checker,
         tmp_path,
         monkeypatch,
         physics_files={"ok.rs": "fn f() {}\n"},
         sim_files={
-            "construction.rs": "use crate::physics::wall_properties::WallProperties;\n",
-            "per_surface_conduction.rs": "fn f() {}\n",
-        },
-    )
-    rc = checker.main()
-    out = capsys.readouterr().out
-    assert rc == 1
-    assert "[2/3]" in out
-    assert "FAIL: 1 offender(s)" in out
-    assert "src/sim/construction.rs" in out
-    assert "CYCLE REGRESSION DETECTED" in out
-
-
-def test_main_aggregates_offenders_from_both_phases(checker, tmp_path, monkeypatch, capsys):
-    """Both phases contribute offenders to the summary."""
-    _redirect_to_fixture(
-        checker,
-        tmp_path,
-        monkeypatch,
-        physics_files={
-            "sneaky1.rs": "use crate::sim::construction::ConstructionLayer;\n",
-            "sneaky2.rs": "use crate::sim::sky_radiation::STEFAN_BOLTZMANN;\n",
-        },
-        sim_files={
             "construction.rs": (
-                "use crate::physics::constants::thermal::ashrae_140::EXTERIOR_FILM_COEFF;\n"
-                "use crate::physics::constants::AIR_DENSITY_SEA_LEVEL;\n"
+                sim_baseline_lines
+                + "use crate::physics::wall_properties::WallProperties;\n"
             ),
             "per_surface_conduction.rs": "fn f() {}\n",
         },
@@ -435,9 +470,52 @@ def test_main_aggregates_offenders_from_both_phases(checker, tmp_path, monkeypat
     rc = checker.main()
     out = capsys.readouterr().out
     assert rc == 1
-    assert "FAIL: 2 offender(s)" in out  # Phase 1
-    assert "FAIL: 2 offender(s)" in out  # Phase 2
-    assert "Total cycle edges: 4" in out
+    assert "[2/3]" in out
+    assert f"({1} above baseline {checker.BASELINE_SIM_TO_PHYSICS})" in out
+    assert "src/sim/construction.rs" in out
+    assert "CYCLE REGRESSION DETECTED" in out
+
+
+def test_main_aggregates_offenders_from_both_phases(checker, tmp_path, monkeypatch, capsys):
+    """Both phases contribute offenders to the summary when each exceeds baseline."""
+    physics_files = {
+        f"baseline{i}.rs": "use crate::sim::construction::ConstructionLayer;\n"
+        for i in range(checker.BASELINE_PHYSICS_TO_SIM)
+    }
+    # 2 above the Phase 1 baseline.
+    physics_files["sneaky1.rs"] = "use crate::sim::construction::ConstructionLayer;\n"
+    physics_files["sneaky2.rs"] = "use crate::sim::sky_radiation::STEFAN_BOLTZMANN;\n"
+    sim_baseline_lines = "".join(
+        f"use crate::physics::constants::SOMETHING_{i};\n"
+        for i in range(checker.BASELINE_SIM_TO_PHYSICS)
+    )
+    # 2 above the Phase 2 baseline.
+    _redirect_to_fixture(
+        checker,
+        tmp_path,
+        monkeypatch,
+        physics_files=physics_files,
+        sim_files={
+            "construction.rs": (
+                sim_baseline_lines
+                + "use crate::physics::constants::thermal::ashrae_140::EXTERIOR_FILM_COEFF;\n"
+                + "use crate::physics::constants::AIR_DENSITY_SEA_LEVEL;\n"
+            ),
+            "per_surface_conduction.rs": "fn f() {}\n",
+        },
+    )
+    rc = checker.main()
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert f"({2} above baseline {checker.BASELINE_PHYSICS_TO_SIM})" in out  # Phase 1
+    assert f"({2} above baseline {checker.BASELINE_SIM_TO_PHYSICS})" in out  # Phase 2
+    expected_total = (
+        checker.BASELINE_PHYSICS_TO_SIM
+        + 2
+        + checker.BASELINE_SIM_TO_PHYSICS
+        + 2
+    )
+    assert f"Total cycle edges: {expected_total}" in out
     assert "src/physics/sneaky1.rs" in out
     assert "src/physics/sneaky2.rs" in out
     assert "src/sim/construction.rs" in out

--- a/scripts/ci/test_check_physics_sim_cycle.py
+++ b/scripts/ci/test_check_physics_sim_cycle.py
@@ -1,0 +1,541 @@
+"""
+Tests for ``scripts/check_physics_sim_cycle.py`` — Issue #2463.
+
+Regression guard for the ``physics <-> sim`` cycle. Mirrors the test
+pattern in ``scripts/ci/test_check_osimflow_coverage.py``:
+import the script as a module, monkey-patch the repo-rooted path
+constants to point at a ``tmp_path`` fixture, then drive each phase
+and the ``main()`` orchestration through both clean and offender
+scenarios.
+
+The 5 physics->sim edges documented in the issue body are the
+baseline; once the companion cycle-break work lands, the script
+must report 0 edges. These tests pin the scanning primitives so a
+silent regex regression cannot re-introduce a cycle.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2] / "scripts" / "check_physics_sim_cycle.py"
+)
+
+
+def _load_checker():
+    """Load scripts/check_physics_sim_cycle.py as a module.
+
+    The script uses module-level ``REPO_ROOT`` / ``PHYSICS_DIR`` /
+    ``PROTECTED_SIM_FILES`` constants rooted at the real repo, so we
+    reload it fresh for each test that wants to monkey-patch those
+    paths. Returns the imported module object.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "check_physics_sim_cycle", SCRIPT_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def checker():
+    """Return a freshly-loaded copy of the cycle-check script.
+
+    Use ``monkeypatch.setattr(checker, "REPO_ROOT", tmp_path)`` (and the
+    other path constants) to redirect the scan to a synthetic fixture
+    tree. ``REPO_ROOT`` is resolved at import time from the script's
+    location, so a fresh module each test gives a clean slate.
+    """
+    return _load_checker()
+
+
+def _write(p: Path, text: str) -> Path:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(dedent(text), encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# scan_physics_for_sim_deps  (Phase 1)
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_flags_use_crate_sim_in_physics(checker, tmp_path, monkeypatch):
+    monkeypatch.setattr(checker, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(checker, "PHYSICS_DIR", tmp_path / "src" / "physics")
+    _write(
+        tmp_path / "src" / "physics" / "thermal_mass" / "construction.rs",
+        """
+        use crate::sim::construction::ConstructionLayer;
+        fn f(_: ConstructionLayer) {}
+        """,
+    )
+    offenders = checker.scan_physics_for_sim_deps()
+    assert len(offenders) == 1
+    assert "src/physics/thermal_mass/construction.rs" in offenders[0]
+    assert "use crate::sim::construction::ConstructionLayer" in offenders[0]
+
+
+def test_phase1_flags_pub_use_crate_sim(checker, tmp_path, monkeypatch):
+    """pub use crate::sim::* must also trip the guard (it's still an upward edge)."""
+    monkeypatch.setattr(checker, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(checker, "PHYSICS_DIR", tmp_path / "src" / "physics")
+    _write(
+        tmp_path / "src" / "physics" / "re_export.rs",
+        """
+        pub use crate::sim::construction::ConstructionLayer;
+        """,
+    )
+    offenders = checker.scan_physics_for_sim_deps()
+    assert len(offenders) == 1
+    assert "src/physics/re_export.rs" in offenders[0]
+
+
+def test_phase1_flags_fully_qualified_path_in_function_body(checker, tmp_path, monkeypatch):
+    """A `crate::sim::foo::bar()` call (not a use-stmt) is still an upward dep."""
+    monkeypatch.setattr(checker, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(checker, "PHYSICS_DIR", tmp_path / "src" / "physics")
+    _write(
+        tmp_path / "src" / "physics" / "weird_path.rs",
+        """
+        fn f() {
+            let x = crate::sim::construction::ConstructionLayer::default();
+        }
+        """,
+    )
+    offenders = checker.scan_physics_for_sim_deps()
+    assert len(offenders) == 1
+    assert "src/physics/weird_path.rs" in offenders[0]
+
+
+def test_phase1_ignores_use_crate_sim_inside_line_comments(checker, tmp_path, monkeypatch):
+    """Comment-only mentions of `crate::sim::` must not trip the guard.
+
+    The script mirrors ``check_ashrae_cases_cycle.py`` which strips
+    line comments via ``stripped.startswith("//")`` and continuation
+    lines via ``stripped.startswith("*")`` — a faithful mirror of the
+    established pattern. Block comments (single-line ``/* ... */``)
+    are not detected by either guard, so they are NOT exercised here.
+    """
+    monkeypatch.setattr(checker, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(checker, "PHYSICS_DIR", tmp_path / "src" / "physics")
+    _write(
+        tmp_path / "src" / "physics" / "commented.rs",
+        """
+        // use crate::sim::construction::ConstructionLayer; -- was here, now removed
+        fn clean() -> i32 { 0 }
+        """,
+    )
+    assert checker.scan_physics_for_sim_deps() == []
+
+
+def test_phase1_ignores_non_sim_upward_paths(checker, tmp_path, monkeypatch):
+    """`crate::physics::...` self-imports in src/physics/** must not trip the guard."""
+    monkeypatch.setattr(checker, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(checker, "PHYSICS_DIR", tmp_path / "src" / "physics")
+    _write(
+        tmp_path / "src" / "physics" / "ok.rs",
+        """
+        use crate::physics::constants::thermal::ashrae_140::EXTERIOR_FILM_COEFF;
+        use crate::physics::solver_trait::HeatConductionSolver;
+        use crate::physics::units::Celsius;
+        fn f() {}
+        """,
+    )
+    assert checker.scan_physics_for_sim_deps() == []
+
+
+def test_phase1_returns_empty_when_physics_dir_missing(checker, tmp_path, monkeypatch):
+    """If `src/physics/` does not exist, the guard must not crash."""
+    monkeypatch.setattr(checker, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(checker, "PHYSICS_DIR", tmp_path / "no" / "such" / "path")
+    assert checker.scan_physics_for_sim_deps() == []
+
+
+def test_phase1_matches_real_offender_baseline(checker, tmp_path, monkeypatch):
+    """The 5 documented offenders must all be detected under the right paths."""
+    monkeypatch.setattr(checker, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(checker, "PHYSICS_DIR", tmp_path / "src" / "physics")
+    _write(
+        tmp_path / "src" / "physics" / "thermal_mass" / "construction.rs",
+        "use crate::sim::construction::ConstructionLayer;\n",
+    )
+    _write(
+        tmp_path / "src" / "physics" / "thermal_mass" / "diagnostics.rs",
+        "use crate::sim::construction::ConstructionLayer;\n",
+    )
+    _write(
+        tmp_path / "src" / "physics" / "multi_node_solver.rs",
+        (
+            "use crate::sim::per_surface_conduction::{PerSurfaceConductionSolver, SurfaceKind};\n"
+            "use crate::sim::sky_radiation::STEFAN_BOLTZMANN;\n"
+        ),
+    )
+    _write(
+        tmp_path / "src" / "physics" / "deep_nest.rs",
+        (
+            "fn deep() {\n"
+            "    use crate::sim::sky_radiation::SkyRadiationExchange;\n"
+            "}\n"
+        ),
+    )
+    offenders = checker.scan_physics_for_sim_deps()
+    assert len(offenders) == 5
+    paths = {o.split(":", 1)[0] for o in offenders}
+    assert paths == {
+        "src/physics/thermal_mass/construction.rs",
+        "src/physics/thermal_mass/diagnostics.rs",
+        "src/physics/multi_node_solver.rs",
+        "src/physics/deep_nest.rs",
+    }
+
+
+# ---------------------------------------------------------------------------
+# scan_protected_sim_files_for_physics_deps  (Phase 2)
+# ---------------------------------------------------------------------------
+
+
+def test_phase2_flags_use_crate_physics_in_construction(checker, tmp_path, monkeypatch):
+    monkeypatch.setattr(checker, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(
+        checker,
+        "PROTECTED_SIM_FILES",
+        (
+            tmp_path / "src" / "sim" / "construction.rs",
+            tmp_path / "src" / "sim" / "per_surface_conduction.rs",
+        ),
+    )
+    _write(
+        tmp_path / "src" / "sim" / "construction.rs",
+        "use crate::physics::constants::SOMETHING;\n",
+    )
+    _write(
+        tmp_path / "src" / "sim" / "per_surface_conduction.rs",
+        "fn clean() -> i32 { 0 }\n",
+    )
+    offenders = checker.scan_protected_sim_files_for_physics_deps()
+    assert len(offenders) == 1
+    assert "src/sim/construction.rs" in offenders[0]
+
+
+def test_phase2_flags_pub_use_crate_physics(checker, tmp_path, monkeypatch):
+    """pub use crate::physics:: must also trip Phase 2 (it is still an upward dep)."""
+    monkeypatch.setattr(checker, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(
+        checker,
+        "PROTECTED_SIM_FILES",
+        (tmp_path / "src" / "sim" / "construction.rs",),
+    )
+    _write(
+        tmp_path / "src" / "sim" / "construction.rs",
+        """
+        pub use crate::physics::constants::thermal::ashrae_140::EXTERIOR_FILM_COEFF;
+        pub use crate::physics::constants::AIR_DENSITY_SEA_LEVEL;
+        """,
+    )
+    offenders = checker.scan_protected_sim_files_for_physics_deps()
+    assert len(offenders) == 2
+    assert all("src/sim/construction.rs" in o for o in offenders)
+
+
+def test_phase2_flags_crate_physics_in_per_surface_conduction(checker, tmp_path, monkeypatch):
+    monkeypatch.setattr(checker, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(
+        checker,
+        "PROTECTED_SIM_FILES",
+        (
+            tmp_path / "src" / "sim" / "construction.rs",
+            tmp_path / "src" / "sim" / "per_surface_conduction.rs",
+        ),
+    )
+    _write(tmp_path / "src" / "sim" / "construction.rs", "fn clean() -> i32 { 0 }\n")
+    _write(
+        tmp_path / "src" / "sim" / "per_surface_conduction.rs",
+        "use crate::physics::wall_properties::WallProperties;\n",
+    )
+    offenders = checker.scan_protected_sim_files_for_physics_deps()
+    assert len(offenders) == 1
+    assert "src/sim/per_surface_conduction.rs" in offenders[0]
+
+
+def test_phase2_ignores_comments_and_unrelated_paths(checker, tmp_path, monkeypatch):
+    """Comments mentioning crate::physics:: and unrelated use statements must not trip.
+
+    Mirrors the line-comment behaviour from Phase 1 / check_ashrae_cases_cycle.py:
+    only ``// ...`` line comments are skipped — the regex pattern anchors on
+    ``(pub\\s+)?use\\s+crate::physics::`` so other use statements and
+    block-comment contents are not relevant.
+    """
+    monkeypatch.setattr(checker, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(
+        checker,
+        "PROTECTED_SIM_FILES",
+        (tmp_path / "src" / "sim" / "construction.rs",),
+    )
+    _write(
+        tmp_path / "src" / "sim" / "construction.rs",
+        """
+        // use crate::physics::constants::SOMETHING;
+        use crate::sim::construction::ConstructionLayer;
+        use crate::sim::per_surface_conduction::PerSurfaceConductionSolver;
+        fn clean() -> i32 { 0 }
+        """,
+    )
+    assert checker.scan_protected_sim_files_for_physics_deps() == []
+
+
+def test_phase2_reports_missing_protected_file(checker, tmp_path, monkeypatch):
+    """A missing protected file must be reported as an offender (loud failure)."""
+    monkeypatch.setattr(checker, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(
+        checker,
+        "PROTECTED_SIM_FILES",
+        (tmp_path / "src" / "sim" / "construction.rs",),
+    )
+    offenders = checker.scan_protected_sim_files_for_physics_deps()
+    assert len(offenders) == 1
+    assert "file missing" in offenders[0]
+    assert "src/sim/construction.rs" in offenders[0]
+
+
+# ---------------------------------------------------------------------------
+# main() — end-to-end orchestration
+# ---------------------------------------------------------------------------
+
+
+def _redirect_to_fixture(
+    checker, tmp_path, monkeypatch, physics_files=None, sim_files=None
+):
+    """Point the module's path constants at a synthetic fixture tree.
+
+    ``physics_files`` is a dict of {relpath: content} written under
+    ``tmp_path/src/physics/``. ``sim_files`` is the same for
+    ``tmp_path/src/sim/`` — the two protected files must be present for
+    Phase 2 to do anything meaningful, but missing files are tolerated
+    and reported by the scan.
+    """
+    physics_files = physics_files or {}
+    sim_files = sim_files or {}
+    physics_root = tmp_path / "src" / "physics"
+    sim_root = tmp_path / "src" / "sim"
+    for rel, content in physics_files.items():
+        _write(physics_root / rel, content)
+    for rel, content in sim_files.items():
+        _write(sim_root / rel, content)
+    monkeypatch.setattr(checker, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(checker, "PHYSICS_DIR", physics_root)
+    monkeypatch.setattr(
+        checker,
+        "PROTECTED_SIM_FILES",
+        (sim_root / "construction.rs", sim_root / "per_surface_conduction.rs"),
+    )
+
+
+def test_main_returns_zero_when_clean(checker, tmp_path, monkeypatch, capsys):
+    _redirect_to_fixture(
+        checker,
+        tmp_path,
+        monkeypatch,
+        physics_files={
+            "solver.rs": (
+                "use crate::physics::constants::thermal::ashrae_140::EXTERIOR_FILM_COEFF;\n"
+                "fn f() {}\n"
+            ),
+        },
+        sim_files={
+            "construction.rs": (
+                "use crate::sim::construction::ConstructionLayer;\n"
+                "fn f() {}\n"
+            ),
+            "per_surface_conduction.rs": (
+                "use crate::sim::per_surface_conduction::PerSurfaceConductionSolver;\n"
+                "fn f() {}\n"
+            ),
+        },
+    )
+    rc = checker.main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "OK: 0 upward deps" in out
+    assert "OK: no cycle markers" in out
+    assert "Total cycle edges: 0" in out
+    assert "No cycle regression" in out
+
+
+def test_main_returns_one_when_physics_offender_present(checker, tmp_path, monkeypatch, capsys):
+    """A single new `use crate::sim::` import in src/physics/** must trip main()."""
+    _redirect_to_fixture(
+        checker,
+        tmp_path,
+        monkeypatch,
+        physics_files={
+            "sneaky.rs": "use crate::sim::construction::ConstructionLayer;\n",
+        },
+        sim_files={
+            "construction.rs": "fn f() {}\n",
+            "per_surface_conduction.rs": "fn f() {}\n",
+        },
+    )
+    rc = checker.main()
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "[1/3]" in out
+    assert "FAIL: 1 offender(s)" in out
+    assert "src/physics/sneaky.rs" in out
+    assert "CYCLE REGRESSION DETECTED" in out
+
+
+def test_main_returns_one_when_sim_offender_present(checker, tmp_path, monkeypatch, capsys):
+    """A `use crate::physics::` import in a protected sim file must trip main()."""
+    _redirect_to_fixture(
+        checker,
+        tmp_path,
+        monkeypatch,
+        physics_files={"ok.rs": "fn f() {}\n"},
+        sim_files={
+            "construction.rs": "use crate::physics::wall_properties::WallProperties;\n",
+            "per_surface_conduction.rs": "fn f() {}\n",
+        },
+    )
+    rc = checker.main()
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "[2/3]" in out
+    assert "FAIL: 1 offender(s)" in out
+    assert "src/sim/construction.rs" in out
+    assert "CYCLE REGRESSION DETECTED" in out
+
+
+def test_main_aggregates_offenders_from_both_phases(checker, tmp_path, monkeypatch, capsys):
+    """Both phases contribute offenders to the summary."""
+    _redirect_to_fixture(
+        checker,
+        tmp_path,
+        monkeypatch,
+        physics_files={
+            "sneaky1.rs": "use crate::sim::construction::ConstructionLayer;\n",
+            "sneaky2.rs": "use crate::sim::sky_radiation::STEFAN_BOLTZMANN;\n",
+        },
+        sim_files={
+            "construction.rs": (
+                "use crate::physics::constants::thermal::ashrae_140::EXTERIOR_FILM_COEFF;\n"
+                "use crate::physics::constants::AIR_DENSITY_SEA_LEVEL;\n"
+            ),
+            "per_surface_conduction.rs": "fn f() {}\n",
+        },
+    )
+    rc = checker.main()
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "FAIL: 2 offender(s)" in out  # Phase 1
+    assert "FAIL: 2 offender(s)" in out  # Phase 2
+    assert "Total cycle edges: 4" in out
+    assert "src/physics/sneaky1.rs" in out
+    assert "src/physics/sneaky2.rs" in out
+    assert "src/sim/construction.rs" in out
+
+
+def test_main_returns_two_on_unhandled_exception(checker, tmp_path, monkeypatch, capsys):
+    """The ``__main__`` wrapper must translate unhandled exceptions to exit 2.
+
+    Mirrors ``check_ashrae_cases_cycle.py`` — its ``if __name__ == '__main__'``
+    block wraps ``sys.exit(main())`` in ``try/except`` and emits
+    ``ERROR: <msg>`` on stderr. We drive the same code path with a
+    tiny subprocess invocation of ``python3`` against a copy of the
+    script whose ``scan_physics_for_sim_deps`` is patched at runtime.
+    The patch uses a wrapper script that imports the cycle-check module,
+    swaps in a raising function, and calls ``main()`` via the same
+    wrapper logic.
+    """
+    # Build a synthetic clean fixture under tmp_path so the real repo's
+    # current 7 offenders do not contaminate the test.
+    physics_root = tmp_path / "src" / "physics"
+    sim_root = tmp_path / "src" / "sim"
+    _write(physics_root / "ok.rs", "fn f() {}\n")
+    _write(sim_root / "construction.rs", "fn f() {}\n")
+    _write(sim_root / "per_surface_conduction.rs", "fn f() {}\n")
+
+    # Write a small driver that imports the cycle-check script, redirects
+    # its REPO_ROOT / PHYSICS_DIR / PROTECTED_SIM_FILES to the fixture,
+    # patches scan_physics_for_sim_deps to raise, then mirrors the
+    # script's own __main__ wrapper so the exception is translated to
+    # exit 2.
+    driver = tmp_path / "driver.py"
+    driver.write_text(
+        dedent(
+            f"""\
+            import importlib.util
+            import sys
+            from pathlib import Path
+
+            spec = importlib.util.spec_from_file_location(
+                "checker", {str(SCRIPT_PATH)!r}
+            )
+            checker = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(checker)
+
+            checker.REPO_ROOT = {str(tmp_path)!r}
+            checker.PHYSICS_DIR = {str(physics_root)!r}
+            checker.PROTECTED_SIM_FILES = (
+                {str(sim_root / "construction.rs")!r},
+                {str(sim_root / "per_surface_conduction.rs")!r},
+            )
+
+            def boom():
+                raise RuntimeError("boom from test")
+
+            checker.scan_physics_for_sim_deps = boom
+
+            try:
+                rc = checker.main()
+            except Exception as e:
+                print(f"ERROR: {{e}}", file=sys.stderr)
+                sys.exit(2)
+            sys.exit(rc)
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    import subprocess
+
+    result = subprocess.run(
+        [sys.executable, str(driver)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 2
+    assert "ERROR: boom from test" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# import-path safety
+# ---------------------------------------------------------------------------
+
+
+def test_main_orchestration_is_a_thin_shell():
+    """The ``if __name__ == '__main__'`` wrapper must route main() to sys.exit().
+
+    Read the script tail directly and assert the wrapper delegates
+    correctly. This pins the public contract that ``python3 script.py``
+    exits with the same code as ``checker.main()`` returns, and that
+    unhandled exceptions become exit 2.
+    """
+    script_src = SCRIPT_PATH.read_text(encoding="utf-8")
+    assert 'if __name__ == "__main__":' in script_src
+    assert "sys.exit(main())" in script_src
+    assert "sys.exit(2)" in script_src
+    # The wrapper must include a try/except around sys.exit(main()).
+    wrapper_block = script_src.split('if __name__ == "__main__":', 1)[1]
+    assert "try:" in wrapper_block
+    assert "except Exception" in wrapper_block


### PR DESCRIPTION
Closes #2463

Adds scripts/check_physics_sim_cycle.py mirroring the existing
scripts/check_ashrae_cases_cycle.py pattern from issue #1441.

## New files

- **scripts/check_physics_sim_cycle.py** (176 lines) — 3-phase cycle guard:
  - Phase 1: walk src/physics/**, forbid `use crate::sim::*` upward deps → 5 baseline edges
  - Phase 2: walk src/sim/construction.rs + src/sim/per_surface_conduction.rs, forbid `use crate::physics::*` → 2 baseline edges
  - Phase 3: print cycle-edge summary
- **scripts/ci/test_check_physics_sim_cycle.py** (541 lines, 18 tests) — covers Phase 1 (positive/negative, comments, non-sim paths, missing dir, baseline match), Phase 2, main() orchestration, __main__ wrapper
- **.github/workflows/rust-tests.yml** — adds physics-sim-cycle-{gh-probe,gh,hz} jobs (canonical listener name Physics-Sim-Cycle-Check), mirroring the ashrae-cases-cycle-* block

## Modified files

- **AGENTS.md** — adds the new gate to §CI Gates, Key Files table, and python3 scripts/... reference list
- **ARCHITECTURE.md** — adds 'Regression guard (Issue #2463)' paragraph under §'Remaining cycles'

## Deferred

`release_gates.yaml::ci.required_checks` was intentionally NOT updated — adding it now would fail `develop` because the 5 baseline edges still exist. The wiring into release_gates.yaml is deferred to the merge PR that closes both #2463 and the companion cycle-break issue (issue #2462), so the required_checks ↔ workflows invariant stays intact.

## Summary by Sourcery

Add a CI regression guard and tests to monitor and prevent growth of the physics↔sim dependency cycle, and document the new guard in architecture and agent docs.

New Features:
- Introduce scripts/check_physics_sim_cycle.py to track and enforce baseline limits on physics↔sim cycle edges.
- Add scripts/ci/test_check_physics_sim_cycle.py with comprehensive tests covering both scan phases and main orchestration for the new guard.

CI:
- Extend .github/workflows/rust-tests.yml with Physics-Sim-Cycle-Check jobs on GitHub and Hetzner runners, mirroring the existing ASHRAE cycle check.

Documentation:
- Update ARCHITECTURE.md and AGENTS.md to describe the new Physics-Sim-Cycle-Check guard, its baseline counts, and how it integrates into CI.