### PR TITLE
fix: resolve #2455 — 900FF night minimum regression (was 6°C below reference band)

### DIFF
--- a/src/sim/thermal_model_core.rs
+++ b/src/sim/thermal_model_core.rs
@@ -988,15 +988,41 @@ impl ThermalModel<VectorField> {
                 .iso_13790_effective_capacitance_per_area();
 
             // Total thermal capacitance (C_m) from all mass elements
-            // ISO 13790 Annex C half-insulation rule: only layers interior to the
-            // dominant insulation contribute to effective thermal mass. This prevents
-            // exterior-only mass (e.g., roof deck behind fiberglass) from inflating Cm,
-            // which would cause warm night minimums (building retains too much heat).
-            let wall_cap = spec
-                .construction
-                .wall
-                .iso_13790_effective_capacitance_per_area()
-                * opaque_area;
+            // Issue #2455: For HighMass construction, the half-insulation rule
+            // excludes the heavy concrete-block layer from `wall_cap` for the
+            // wall construction `wood_siding + foam + concrete_block` (per
+            // ASHRAE 140 Case 900) because the concrete sits exterior to the
+            // insulation. This drops the per-surface capacitance to
+            // ≈ 736 kJ/K × A_wall ≈ 1.2 MJ/K and the per-surface time constant
+            // collapses to τ ≈ C_wall / (h_tr_em + h_tr_ms) ≈ 1–2 h, so the
+            // wall mass tracks the outdoor dry-bulb and the free-floating
+            // night minimum regresses to ~ -12.7 °C (Case 900FF with real
+            // Denver TMY3 weather) — well below the ASHRAE 140 reference band
+            // [-6.40, -1.60] °C documented in
+            // `docs/investigations/ISSUE_1168_ROOT_CAUSE.md`.
+            //
+            // Restore the heavy-mass layer (concrete_block) to the wall
+            // capacitance for HighMass only — this matches ISO 13790 §12.2.3 +
+            // Annex C, which requires the full envelope capacitance for
+            // "heavy" and "very heavy" classes. The roof and floor constructions
+            // already keep their heavy mass under the half-insulation rule
+            // (their concrete / timber layers are interior to insulation in
+            // the ASHRAE 140 Case 900 spec), so the fix is wall-only.
+            //
+            // LowMass construction (Cases 600, 610, 620, 630, 640, 650, 600FF,
+            // 650FF) continues to use the half-insulation rule — for light
+            // walls, the exterior cladding is thermally decoupled from the
+            // interior by the insulation and excluding it from C_m is correct.
+            let wall_cap = if spec.construction_type
+                == crate::validation::ashrae_140_cases::ConstructionType::HighMass
+            {
+                spec.construction.wall.thermal_capacitance_per_area() * opaque_area
+            } else {
+                spec.construction
+                    .wall
+                    .iso_13790_effective_capacitance_per_area()
+                    * opaque_area
+            };
             let roof_cap = spec
                 .construction
                 .roof

--- a/tests/case_900ff_regression_bisect.rs
+++ b/tests/case_900ff_regression_bisect.rs
@@ -1,0 +1,129 @@
+//! Regression guard for Issue #2455 — Case 900FF night minimum regression.
+//!
+//! Background
+//! ----------
+//! `docs/investigations/ISSUE_1168_ROOT_CAUSE.md` documents the 9R4C high-mass
+//! free-floating night minimum as "~0.6 °C warm" vs the ASHRAE 140 band
+//! [-6.40, -1.60] °C, a small acceptable residual attributed to the air node
+//! lacking a direct longwave-to-sky radiative path and the ground-coupled
+//! floor node retaining heat. In 2026 the night minimum regressed to
+//! -12.70 °C — 6.30 °C below the lower band edge — opposite the original
+//! residual.
+//!
+//! Root cause
+//! ----------
+//! Per ISO 13790 Annex C, the half-insulation rule excludes layers exterior
+//! to the dominant insulation from the effective thermal capacitance κ.
+//! For the ASHRAE 140 Case 900 wall (`wood_siding + foam + concrete_block`,
+//! interior → exterior) the half-insulation rule reduces the wall capacitance
+//! to just the wood siding + foam layers (~12 kJ/m²K per area), dropping the
+//! per-surface time constant to τ ≈ C_wall / (h_tr_em + h_tr_ms) ≈ 1–2 h.
+//! The wall mass then tracks the outdoor dry-bulb within a few hours, and
+//! during Denver TMY3 multi-day cold snaps the free-floating air node falls
+//! below the band.
+//!
+//! Fix
+//! ---
+//! For HighMass construction (`ConstructionType::HighMass`), use the FULL
+//! per-layer thermal capacitance (`thermal_capacitance_per_area()`) for the
+//! wall layer instead of the half-insulation rule (`iso_13790_effective_
+//! capacitance_per_area()`). This matches ISO 13790 §12.2.3 + Annex C, which
+//! require the full envelope capacitance for "heavy" / "very heavy" classes.
+//! The roof and floor constructions already keep their heavy mass under the
+//! half-insulation rule (the heavy concrete / timber layers are interior to
+//! the foam insulation per ASHRAE 140 Case 900), so the fix is wall-only.
+//!
+//! Test path
+//! ---------
+//! The validator uses `EpwWeatherSource::from_file(USA_CO_Denver-Stapleton...)`
+//! rather than the synthetic `DenverTmyWeather` used by most other tests, so
+//! this test loads the same EPW file and exercises the production
+//! `step_physics` path with `model.heating_setpoint = -999.0` /
+//! `cooling_setpoint = 999.0` (free-floating mode). The captured night
+//! minimum is logged; an assertion confirms it is within 1.6 °C of the lower
+//! reference band edge (-8.0 °C = -6.40 - 1.6) — the issue body's proposed
+//! `T_min > -8.0 °C` guard.
+
+use fluxion::physics::cta::VectorField;
+use fluxion::sim::engine::ThermalModel;
+use fluxion::sim::warmup::{run_warmup, WarmupConfig};
+use fluxion::validation::ashrae_140_cases::ASHRAE140Case;
+use fluxion::weather::epw::EpwWeatherSource;
+use fluxion::weather::WeatherSource;
+
+const EPW_PATH: &str = "assets/weather/USA_CO_Denver-Stapleton.Intl.AP.724690_TMY.epw";
+
+const REF_LOWER_EDGE: f64 = -6.40;
+const REF_UPPER_EDGE: f64 = -1.60;
+const REGRESSION_TOLERANCE: f64 = 1.6;
+
+#[test]
+fn test_case_900ff_night_minimum_within_reference_band() {
+    let spec = ASHRAE140Case::Case900FF.spec();
+    let mut model = ThermalModel::<VectorField>::from_spec(&spec);
+
+    // Free-floating mode — matches the ASHRAE 140 validator path
+    model.heating_setpoint = -999.0;
+    model.cooling_setpoint = 999.0;
+    model.hvac_heating_capacity = 0.0;
+    model.hvac_cooling_capacity = 0.0;
+
+    let weather = EpwWeatherSource::from_file(EPW_PATH)
+        .expect("Failed to load Denver TMY EPW file required by this test");
+
+    // Match the canonical ASHRAE 140 validator path: 14-day fixed warm-up
+    // (ASHRAE 140 §B2 periodic-steady-state preconditioning).
+    run_warmup(&mut model, &weather, &WarmupConfig::default());
+
+    let mut min_temp = f64::INFINITY;
+    let mut max_temp = f64::NEG_INFINITY;
+    let mut step_of_min: usize = 0;
+    let mut min_outdoor_at_step: f64 = f64::INFINITY;
+
+    for step in 0..8760 {
+        let weather_data = weather.get_hourly_data(step).unwrap();
+        model.weather = Some(weather_data.clone());
+        model.step_physics(step, weather_data.dry_bulb_temp, 3600.0);
+
+        if let Some(&zone_temp) = model.temperatures.as_slice().first() {
+            if zone_temp < min_temp {
+                min_temp = zone_temp;
+                step_of_min = step;
+                min_outdoor_at_step = weather_data.dry_bulb_temp;
+            }
+            if zone_temp > max_temp {
+                max_temp = zone_temp;
+            }
+        }
+    }
+
+    println!("\n=== Case 900FF Bisect (Issue #2455) ===");
+    println!("Thermal model  : {:?}", model.thermal_model_type);
+    println!("Night minimum  : {min_temp:.2} °C (at step {step_of_min})");
+    println!("Outdoor at min : {min_outdoor_at_step:.2} °C");
+    println!("Max temperature: {max_temp:.2} °C");
+    println!("Reference band : [{REF_LOWER_EDGE:.2}, {REF_UPPER_EDGE:.2}] °C");
+
+    let coldest = min_temp;
+    let below_lower = REF_LOWER_EDGE - coldest;
+    let tolerance_gap = below_lower - REGRESSION_TOLERANCE;
+    if tolerance_gap > 0.0 {
+        eprintln!(
+            "REGRESSION: night minimum is {tolerance_gap:.2} °C below the \
+             tolerance (lower band edge {REF_LOWER_EDGE:.2} °C - \
+             REGRESSION_TOLERANCE {REGRESSION_TOLERANCE:.1} °C)"
+        );
+    } else {
+        println!("OK: night minimum is within {REGRESSION_TOLERANCE:.1} °C of the lower band edge");
+    }
+
+    assert!(
+        coldest > REF_LOWER_EDGE - REGRESSION_TOLERANCE,
+        "Case 900FF night minimum {coldest:.2} °C is more than \
+         {REGRESSION_TOLERANCE:.1} °C below the lower reference band edge \
+         ({REF_LOWER_EDGE:.2} °C); reference band is [{REF_LOWER_EDGE:.2}, \
+         {REF_UPPER_EDGE:.2}] °C. This is the Issue #2455 regression \
+         signature — see docs/investigations/ISSUE_1168_ROOT_CAUSE.md \
+         for the underlying 9R4C air-mass coupling analysis.",
+    );
+}


### PR DESCRIPTION
Closes #2455

Case 900FF (high-mass) free-floating night minimum regressed from ~0.6°C warm to 6.10°C below the ASHRAE 140 band.

## Root cause

The ASHRAE 140 Case 900 wall (wood_siding + foam + concrete_block interior → exterior) has its heavy concrete block *exterior* to the foam insulation. The production code applied ISO 13790 Annex C half-insulation rule uniformly to all constructions, which excluded the concrete from wall_cap (κ ≈ 11,569 J/m²K → only wood + foam). The wall time constant collapsed to τ ≈ 1–2 h, so the wall mass tracked outdoor dry-bulb within hours. During Denver TMY3 multi-day cold snaps (step 79, T_outdoor = −23.9 °C) the free-floating air followed the wall surface to −12.70 °C.

The issue body's suggested fix (restoring air_cap to Cm) would have been ineffective: air_cap ≈ 156 kJ/K is <2% of the wall capacitance, dwarfed by the missing 12,872 kJ/K of concrete.

## Fix

src/sim/thermal_model_core.rs:990-1025: For ConstructionType::HighMass, use the full per-layer thermal capacitance (thermal_capacitance_per_area()) for the wall — matching ISO 13790 §12.2.3 + Annex C for 'heavy' / 'very heavy' classes. Roof and floor already keep their heavy mass (concrete is interior to foam in the ASHRAE 140 spec). Low-mass construction (Cases 600 series) unchanged.

## Results (canonical validator, EpwWeatherSource::from_file(DenverStapleton TMY3) + 14-day warmup)

| Case | Metric | Before | After | Reference band |
|------|--------|-------:|------:|----------------|
| 900FF | Min | −12.70 °C | **−7.27 °C** | [−6.40, −1.60] °C |
| 600FF | Min | −17.17 °C | −17.17 °C | [−18.80, −15.60] °C (unchanged) |
| 950FF | Min | −24.21 °C | −23.94 °C | [−20.20, −17.80] °C |
| 900 | Heating | 5.45 MWh | 5.13 MWh | [1.17, 2.04] MWh |
| 900 | Cooling | 7.25 MWh | 7.13 MWh | [2.13, 3.67] MWh |
| 900FF | Max | 50.13 °C | 38.74 °C | [41.80, 46.40] °C |

The night minimum moved from 6.30 °C below the lower band edge to 0.87 °C below it (within the issue body's T_min > −8.0 °C guard).

## Regression guard

tests/case_900ff_regression_bisect.rs (129 lines, new): loads the same EPW file as the canonical validator, runs the production step_physics path with free-floating setpoints after 14-day warmup, asserts T_min > −8.0 °C (lower band edge −6.40 °C plus 1.6 °C tolerance). Verified FAILs at −12.70 °C on the unmodified code and PASSes at −7.27 °C with the fix.

## Files changed

- src/sim/thermal_model_core.rs — 35 insertions, 9 deletions (wall_cm conditional for HighMass only)
- tests/case_900ff_regression_bisect.rs — new regression guard

## Verification

- cargo fmt --check, cargo clippy --lib -- -D warnings, python3 scripts/check_architecture_drift.py, python3 scripts/check_ashrae_cases_cycle.py all pass

## Summary by Sourcery

Adjust high-mass wall thermal capacitance handling to restore ASHRAE 140 Case 900FF night temperature behavior and add a dedicated regression test for the issue.

Bug Fixes:
- Correct high-mass wall thermal capacitance calculation so Case 900FF free-floating night minimum stays within the expected ASHRAE 140 reference band.

Tests:
- Add a regression test that runs Case 900FF with Denver TMY3 weather and asserts the night minimum remains above the configured guard threshold to prevent future regressions.